### PR TITLE
[ADM-299] Shorten time for getting board reports

### DIFF
--- a/backend/src/services/kanban/Jira/Jira.ts
+++ b/backend/src/services/kanban/Jira/Jira.ts
@@ -53,7 +53,7 @@ export class Jira implements Kanban {
     });
     console.log(
       `Successfully queried configuration_data:${JSON.stringify(
-        configurationResponse
+        configurationResponse.data
       )}`
     );
 
@@ -96,7 +96,7 @@ export class Jira implements Kanban {
     http.defaults.headers.common["Authorization"] = token;
     const result = await http.get(url);
     console.log(
-      `Successfully queried card status_data:${JSON.stringify(result)}`
+      `Successfully queried card status_data:${JSON.stringify(result.data)}`
     );
     return result.data;
   }

--- a/backend/src/services/kanban/Jira/Jira.ts
+++ b/backend/src/services/kanban/Jira/Jira.ts
@@ -20,6 +20,7 @@ import { Cards } from "../../../models/kanban/RequestKanbanResults";
 import {
   CardCustomFieldKey,
   FixVersion,
+  Status,
 } from "../../../models/kanban/JiraCard";
 import { CardFieldsEnum } from "../../../models/kanban/CardFieldsEnum";
 import { CardStepsEnum } from "../../../models/kanban/CardStepsEnum";
@@ -58,26 +59,30 @@ export class Jira implements Kanban {
 
     const columns = configuration.columnConfig.columns;
 
-    for (const column of columns) {
-      if (column.statuses.length == 0) {
-        continue;
+    await columns.map(async (column: any) => {
+      if (column.statuses.length != 0) {
+        const columnValue: ColumnValue = new ColumnValue();
+        columnValue.name = column.name;
+        const jiraColumnResponse = new ColumnResponse();
+
+        await Promise.all(
+          column.statuses.map((status: { self: string }) =>
+            Jira.queryStatus(status.self, model.token)
+          )
+        ).then((responses) => {
+          responses.map((response) => {
+            jiraColumnResponse.key = (
+              response as StatusSelf
+            ).statusCategory.key;
+            columnValue.statuses.push(
+              (response as StatusSelf).untranslatedName.toUpperCase()
+            );
+          });
+          jiraColumnResponse.value = columnValue;
+          jiraColumnNames.push(jiraColumnResponse);
+        });
       }
-
-      const columnValue: ColumnValue = new ColumnValue();
-      columnValue.name = column.name;
-
-      const jiraColumnResponse = new ColumnResponse();
-      for (const status of column.statuses) {
-        const statusSelf = await Jira.queryStatus(status.self, model.token);
-        jiraColumnResponse.key = statusSelf.statusCategory.key;
-
-        columnValue.statuses.push(statusSelf.untranslatedName.toUpperCase());
-      }
-
-      jiraColumnResponse.value = columnValue;
-      jiraColumnNames.push(jiraColumnResponse);
-    }
-
+    });
     return jiraColumnNames;
   }
 
@@ -207,7 +212,11 @@ export class Jira implements Kanban {
     if (model.status.length > 0) {
       switch (model.type.toLowerCase()) {
         case KanbanEnum.JIRA:
-          jql = `status in ('${model.status.join("','")}')`;
+          jql = `status in ('${model.status.join(
+            "','"
+          )}') AND statusCategoryChangedDate >= ${
+            model.startTime
+          } AND statusCategoryChangedDate <= ${model.endTime}`;
           break;
         case KanbanEnum.CLASSIC_JIRA: {
           let subJql = "";
@@ -236,18 +245,6 @@ export class Jira implements Kanban {
         allDoneCards,
         model.boardId
       );
-    }
-
-    if (model.type.toLowerCase() == KanbanEnum.JIRA) {
-      const allDoneCardsResult = allDoneCards.filter(
-        (DoneCard: { fields: { statuscategorychangedate: string } }) =>
-          Jira.matchTime(
-            DoneCard.fields.statuscategorychangedate,
-            model.startTime,
-            model.endTime
-          )
-      );
-      return allDoneCardsResult;
     }
     return allDoneCards;
   }
@@ -432,14 +429,6 @@ export class Jira implements Kanban {
       assigneeSet: new Set<string>(assigneeList),
       originCycleTimeInfos,
     };
-  }
-
-  private static matchTime(
-    cardTime: string,
-    startTime: number,
-    endTime: number
-  ): boolean {
-    return startTime <= Date.parse(cardTime) && Date.parse(cardTime) <= endTime;
   }
 
   private static putStatusChangeEventsIntoAnArray(

--- a/backend/src/services/kanban/Jira/JiraVerifyToken.ts
+++ b/backend/src/services/kanban/Jira/JiraVerifyToken.ts
@@ -43,7 +43,7 @@ export class JiraVerifyToken implements KanbanVerifyToken {
 
     console.log(
       `Successfully get configuration_data: ${JSON.stringify(
-        configurationResponse
+        configurationResponse.data
       )}`
     );
 
@@ -135,7 +135,9 @@ export class JiraVerifyToken implements KanbanVerifyToken {
     const http = axios.create();
     http.defaults.headers.common["Authorization"] = token;
     const result = await http.get(url);
-    console.log(`Successfully queried status_data:${JSON.stringify(result)}`);
+    console.log(
+      `Successfully queried status_data:${JSON.stringify(result.data)}`
+    );
     return result.data;
   }
 

--- a/backend/tests/services/kanban/Jira/Jira.test.ts
+++ b/backend/tests/services/kanban/Jira/Jira.test.ts
@@ -44,7 +44,11 @@ describe("get story points and cycle times of done cards during period", () => {
           storyPointsAndCycleTimeRequest.site
         }.atlassian.net/rest/agile/1.0/board/2/issue?maxResults=100&jql=status in ('${storyPointsAndCycleTimeRequest.status.join(
           "','"
-        )}')`
+        )}') AND statusCategoryChangedDate >= ${
+          storyPointsAndCycleTimeRequest.startTime
+        } AND statusCategoryChangedDate <= ${
+          storyPointsAndCycleTimeRequest.endTime
+        }`
       )
       .reply(200, JiraCards);
 

--- a/frontend/src/app/dora/models/boardParams.ts
+++ b/frontend/src/app/dora/models/boardParams.ts
@@ -37,8 +37,8 @@ export class BoardParams {
     email: string;
     boardId: string;
   }) {
-    this.type = type;
-    this.token = type === BOARD_TYPE.JIRA ? this.generateBasicToken(token, email) : token;
+    this.type = type.toLocaleLowerCase();
+    this.token = type.toLocaleLowerCase() === BOARD_TYPE.JIRA ? this.generateBasicToken(token, email) : token;
     this.site = site;
     this.projectKey = projectKey;
     this.teamName = teamName;


### PR DESCRIPTION
## Before

Use loop to send many requests, and logic and name hard to understand.

![Before](Image_path.png)

## After

Use promise to concurrently send requests, extract and rename variables and simplify the logic.

![After](Image_path.png)

## Note

Fix a letter case match error and logging error