### PR TITLE
ADM-380 T0A [Backend] Replace jira backend with mock sever

### DIFF
--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -1,5 +1,5 @@
 server:
-  port: 4324
+  port: 4322
   servlet:
     context-path: /api/v1
 logging:

--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -1,0 +1,13 @@
+server:
+  port: 4324
+  servlet:
+    context-path: /api/v1
+logging:
+  level:
+    root: INFO
+
+githubFeignClient:
+  url: 54.223.108.141:4323
+
+jira:
+  url: 54.223.108.141:4323

--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -1,5 +1,5 @@
 server:
-  port: 4322
+  port: 4324
   servlet:
     context-path: /api/v1
 logging:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+spring:
+  profiles:
+    active: default
+# connect to MockServer
+#    active: e2e
+
 server:
   port: 4322
   servlet:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   profiles:
     active: default
-# connect to MockServer
-#    active: e2e
 
 server:
   port: 4322


### PR DESCRIPTION
## Summary

In order to improve the process of development and speed up development, we decide to setup the E2E environment. And E2E test will be conducted on E2E environment as below.

## Before

_Description_

1. Happy path
* E2E testing for Jira verify could be automatically be conducted against Mock server  

