### PR TITLE
ADM-380 T0A [Backend] Replace jira backend with mock sever

### DIFF
--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -1,7 +1,7 @@
 server:
-  port: 4324
+  port: 4322
   servlet:
-    context-path: /api/v2
+    context-path: /api/v1
 logging:
   level:
     root: INFO

--- a/frontend/cypress/pages/metrics.ts
+++ b/frontend/cypress/pages/metrics.ts
@@ -49,10 +49,9 @@ class Metrics {
     cy.intercept(Cypress.env('url') + '/api/v1/source-control*', (req) => {
       req.url = req.url.replace('/v1/', '/v2/')
     })
-    cy.get('[data-test-id="sourceControlVerifyButton"]').should('be.disabled')
 
     cy.contains("[data-testid='sourceControlTextField']", 'Token').type(token)
-    cy.get('[data-test-id="sourceControlVerifyButton"]').should('be.enabled').click()
+    cy.get('[data-test-id="sourceControlVerifyButton"]').click()
   }
 
   goMetricsStep() {

--- a/frontend/cypress/pages/metrics.ts
+++ b/frontend/cypress/pages/metrics.ts
@@ -46,10 +46,6 @@ class Metrics {
   }
 
   fillSourceControlFieldsInfo(token: string) {
-    cy.intercept(Cypress.env('url') + '/api/v1/source-control*', (req) => {
-      req.url = req.url.replace('/v1/', '/v2/')
-    })
-
     cy.contains("[data-testid='sourceControlTextField']", 'Token').type(token)
     cy.get('[data-test-id="sourceControlVerifyButton"]').click()
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,6 @@ export default defineConfig({
     port: 4321,
     proxy: {
       '/api/v1': 'http://localhost:4322',
-      '/api/v2': 'http://localhost:4324',
     },
   },
   plugins: [react()],


### PR DESCRIPTION
## Summary

ADM-380 T0A [Backend] Replace jira backend with mock sever

## Before

In order to improve the process of development and speed up development, we decide to setup the E2E environment. And E2E test will be conducted on E2E environment as below.
