### PR TITLE
ADM-380 T0A [Backend] Replace jira backend with mock sever

### DIFF
--- a/stubs/backend/jira/jira-stubs.yaml
+++ b/stubs/backend/jira/jira-stubs.yaml
@@ -7,7 +7,7 @@
     headers:
       content-type: application/json
     status: 200
-    file: ./jira/jsons/jira.board.1963.configuration.json
+    file: ./backend/jira/jsons/jira.board.1963.configuration.json
 
 # Status
 - request:


### PR DESCRIPTION
## Summary

ADM-380 [stubs] fix: add path for board-configuration api

## Before

_Description_

![Before](Image_path.png)

## After

_Description_

![After](Image_path.png)

## Note

_Null_
