### PR TITLE
ADM-348 T5C - [frontend] [Config] - Source control section

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/PipelineTool.test.tsx
@@ -9,7 +9,7 @@ import {
   PIPELINE_TOOL_VERIFY_ERROR_MESSAGE,
   VERIFY,
   RESET,
-  mockInfo,
+  MOCK_INFO,
   TOKEN_ERROR_MESSAGE,
 } from '../../../fixtures'
 import { Provider } from 'react-redux'
@@ -114,7 +114,7 @@ describe('PipelineTool', () => {
     await fillPipelineToolFieldsInformation()
     const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement
 
-    await userEvent.type(tokenInput, mockInfo)
+    await userEvent.type(tokenInput, MOCK_INFO)
     await userEvent.clear(tokenInput)
 
     expect(getByText(TOKEN_ERROR_MESSAGE[1])).toBeVisible()
@@ -125,9 +125,9 @@ describe('PipelineTool', () => {
     const { getByText } = setup()
     const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement
 
-    await userEvent.type(tokenInput, mockInfo)
+    await userEvent.type(tokenInput, MOCK_INFO)
 
-    expect(tokenInput.value).toEqual(mockInfo)
+    expect(tokenInput.value).toEqual(MOCK_INFO)
 
     expect(getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument()
     expect(getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR)

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/PipelineTool.test.tsx
@@ -9,6 +9,8 @@ import {
   PIPELINE_TOOL_VERIFY_ERROR_MESSAGE,
   VERIFY,
   RESET,
+  mockInfo,
+  TOKEN_ERROR_MESSAGE,
 } from '../../../fixtures'
 import { Provider } from 'react-redux'
 import { setupStore } from '../../../utils/setupStoreUtil'
@@ -109,30 +111,26 @@ describe('PipelineTool', () => {
 
   it('should show error message and error style when token is empty', async () => {
     const { getByText } = setup()
-    const TOKEN_ERROR_MESSAGE = 'Token is required'
-    const mockInfo = 'mockToken'
     await fillPipelineToolFieldsInformation()
     const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement
 
     await userEvent.type(tokenInput, mockInfo)
     await userEvent.clear(tokenInput)
 
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toBeVisible()
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toHaveStyle(ERROR_MESSAGE_COLOR)
+    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toBeVisible()
+    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR)
   })
 
   it('should show error message and error style when token is invalid', async () => {
     const { getByText } = setup()
-    const TOKEN_ERROR_MESSAGE = 'Invalid token'
-    const mockInfo = 'mockToken'
     const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement
 
     await userEvent.type(tokenInput, mockInfo)
 
     expect(tokenInput.value).toEqual(mockInfo)
 
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toBeInTheDocument()
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toHaveStyle(ERROR_MESSAGE_COLOR)
+    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument()
+    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR)
   })
 
   it('should show reset button when verify succeed ', async () => {

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
@@ -7,7 +7,7 @@ import {
   ERROR_MESSAGE_COLOR,
   GITHUB_VERIFY_ERROR_MESSAGE,
   MOCK_SOURCE_CONTROL_URL,
-  mockInfo,
+  MOCK_INFO,
   RESET,
   SOURCE_CONTROL_FIELDS,
   SOURCE_CONTROL_TYPES,
@@ -122,9 +122,9 @@ describe('SourceControl', () => {
     const { getByText } = setup()
     const tokenInput = screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement
 
-    fireEvent.change(tokenInput, { target: { value: mockInfo } })
+    fireEvent.change(tokenInput, { target: { value: MOCK_INFO } })
 
-    expect(tokenInput.value).toEqual(mockInfo)
+    expect(tokenInput.value).toEqual(MOCK_INFO)
     expect(getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument()
     expect(getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR)
   })

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
@@ -7,9 +7,11 @@ import {
   ERROR_MESSAGE_COLOR,
   GITHUB_VERIFY_ERROR_MESSAGE,
   MOCK_SOURCE_CONTROL_URL,
+  mockInfo,
   RESET,
   SOURCE_CONTROL_FIELDS,
   SOURCE_CONTROL_TYPES,
+  TOKEN_ERROR_MESSAGE,
   VERIFIED,
   VERIFY,
 } from '../../../fixtures'
@@ -105,7 +107,6 @@ describe('SourceControl', () => {
 
   it('should show error message and error style when token is empty', () => {
     const { getByText } = setup()
-    const TOKEN_ERROR_MESSAGE = 'Token is required'
 
     fillSourceControlFieldsInformation()
 
@@ -113,22 +114,19 @@ describe('SourceControl', () => {
 
     fireEvent.change(tokenInput, { target: { value: '' } })
 
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toBeInTheDocument()
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toHaveStyle(ERROR_MESSAGE_COLOR)
+    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument()
+    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR)
   })
 
   it('should show error message and error style when token is invalid', () => {
     const { getByText } = setup()
-    const TOKEN_ERROR_MESSAGE = 'Invalid token'
-    const mockInfo = 'mockToken'
     const tokenInput = screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement
 
     fireEvent.change(tokenInput, { target: { value: mockInfo } })
 
     expect(tokenInput.value).toEqual(mockInfo)
-
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toBeInTheDocument()
-    expect(getByText(TOKEN_ERROR_MESSAGE)).toHaveStyle(ERROR_MESSAGE_COLOR)
+    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument()
+    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR)
   })
 
   it('should show error notification when sourceControl verify response status is 401', async () => {

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -18,6 +18,10 @@ export const RESET = 'Reset'
 
 export const VERIFIED = 'Verified'
 
+export const mockInfo = 'mockToken'
+
+export const TOKEN_ERROR_MESSAGE = ['Token is invalid', 'Token is required']
+
 export const PROJECT_NAME_LABEL = 'Project Name'
 
 export const EXPORT_BOARD_DATA = 'Export board data'

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -18,7 +18,7 @@ export const RESET = 'Reset'
 
 export const VERIFIED = 'Verified'
 
-export const mockInfo = 'mockToken'
+export const MOCK_INFO = 'mockToken'
 
 export const TOKEN_ERROR_MESSAGE = ['Token is invalid', 'Token is required']
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -89,7 +89,7 @@ export const ERROR_MESSAGE_TIME_DURATION = 2000
 
 export const TOKEN_HELPER_TEXT = {
   RequiredTokenText: 'Token is required',
-  InvalidTokenText: 'Invalid token',
+  InvalidTokenText: 'Token is invalid',
 }
 
 export const DONE = 'Done'


### PR DESCRIPTION
1. change error message of SouceControl and PipelineTool components when token is invalid
2. fix unit tests