### PR TITLE
ADM-375 fix: jira board backend mock server config

### DIFF
--- a/backend/src/main/java/heartbeat/component/E2EUrlGenerator.java
+++ b/backend/src/main/java/heartbeat/component/E2EUrlGenerator.java
@@ -17,7 +17,7 @@ public class E2EUrlGenerator implements UrlGenerator {
 
 	@Override
 	public URI getUri(String site) {
-		return URI.create(url);
+		return URI.create("http://" + url);
 	}
 
 }

--- a/backend/src/main/resources/application-e2e.yml
+++ b/backend/src/main/resources/application-e2e.yml
@@ -7,8 +7,8 @@ logging:
     root: INFO
 
 githubFeignClient:
-  url: ${MOCK_SERVER_URL:http//localhost:4323}
+  url: ${MOCK_SERVER_URL:localhost:4323}
 
 jira:
-  url: ${MOCK_SERVER_URL:http//localhost:4323}
+  url: ${MOCK_SERVER_URL:localhost:4323}
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -17,4 +17,4 @@ jira:
   url: https://demo.atlassian.net
 
 buildKite:
-  url: ${MOCK_SERVER_URL:http//localhost:4323}
+  url: ${MOCK_SERVER_URL:localhost:4323}

--- a/backend/src/test/java/heartbeat/component/E2EUrlGeneratorTest.java
+++ b/backend/src/test/java/heartbeat/component/E2EUrlGeneratorTest.java
@@ -14,7 +14,7 @@ class E2EUrlGeneratorTest {
 	public void testGetUri() {
 		e2EUrlGenerator.setUrl("mockTest");
 		URI uri = e2EUrlGenerator.getUri("test");
-		assertEquals("mockTest", uri.toString());
+		assertEquals("http://mockTest", uri.toString());
 	}
 
 }


### PR DESCRIPTION
## Summary
- refactor: delete setter annotation in E2EUrlGenerator
- fix jira board mock server config
...

## Before

_Description_

![Before](Image_path.png)
use @Setter to set url in e2EUrlGenerator
## After

_Description_
use ReflectionTestUtils to set url
![After](Image_path.png)

## Note

_Null_
