### PR TITLE
ADM-375 Set cypress timezone to prc for e2e

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,8 +13,8 @@
     "fix": "eslint -c .eslintrc.json --fix && npx prettier --write . --ignore-unknown",
     "test": "jest",
     "coverage": "jest --env=jsdom --watchAll=false --coverage",
-    "e2e:open": "cypress open",
-    "e2e": "cypress run --spec cypress/",
+    "e2e:open": "TZ='PRC' cypress open",
+    "e2e": "TZ='PRC' cypress run --spec cypress/",
     "prepare": "cd .. && husky install frontend/.husky",
     "license-compliance": "license-compliance -r detailed --allow='Unlicense;MIT;ISC;0BSD;BSD-2-Clause;BSD-3-Clause;Apache-2.0;Python-2.0;CC-BY-4.0;CC-BY-3.0;WTFPL;CC0-1.0'"
   },


### PR DESCRIPTION
## Summary

Set cypress timezone to prc for e2e
