### PR TITLE
ADM-438.1 [stub][Report][frontend] Report response data mapping

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -49,6 +49,8 @@ describe('Report Step', () => {
     await waitFor(() => {
       expect(getByText('30.26(days/card)')).toBeInTheDocument()
       expect(getByText('21.18(days/SP)')).toBeInTheDocument()
+      expect(getByText('0.57')).toBeInTheDocument()
+      expect(getByText('12.13(days/SP)')).toBeInTheDocument()
     })
   })
 })

--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -38,8 +38,8 @@ describe('Report Step', () => {
     const { getByText } = setup()
 
     await waitFor(() => {
-      expect(getByText('20')).toBeInTheDocument()
-      expect(getByText('14')).toBeInTheDocument()
+      expect(getByText(20)).toBeInTheDocument()
+      expect(getByText(14)).toBeInTheDocument()
     })
   })
 

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -396,7 +396,7 @@ export const EXPECTED_REPORT_VALUES = {
       valuesList: [
         {
           name: 'Deployment frequency(deployments/day)',
-          value: 0.3,
+          value: '30.00%',
         },
       ],
     },
@@ -406,7 +406,7 @@ export const EXPECTED_REPORT_VALUES = {
       valuesList: [
         {
           name: 'Deployment frequency(deployments/day)',
-          value: 0.4,
+          value: '40.00%',
         },
       ],
     },
@@ -416,105 +416,18 @@ export const EXPECTED_REPORT_VALUES = {
       id: 0,
       name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
       valuesList: [
-        { name: 'mergeDelayTime', value: 2702.53 },
-        { name: 'pipelineDelayTime', value: 2587.42 },
-        { name: 'totalDelayTime', value: 5289.95 },
+        { name: 'mergeDelayTime', value: '1day 21hours 2minutes' },
+        { name: 'pipelineDelayTime', value: '1day 19hours 7minutes' },
+        { name: 'totalDelayTime', value: '3day 16hours 9minutes' },
       ],
     },
     {
       id: 1,
       name: 'Average/',
       valuesList: [
-        { name: 'mergeDelayTime', value: 3647.51 },
-        { name: 'pipelineDelayTime', value: 2341.72 },
-        { name: 'totalDelayTime', value: 5989.22 },
-      ],
-    },
-  ],
-  changeFailureRateList: [
-    {
-      id: 0,
-      name: 'fs-platform-onboarding/ :shipit: deploy to PROD',
-      valuesList: [
-        {
-          name: 'Failure rate',
-          value: '0.00% (0/3)',
-        },
-      ],
-    },
-    {
-      id: 1,
-      name: 'Average/',
-      valuesList: [
-        {
-          name: 'Failure rate',
-          value: '0.00% (0/12)',
-        },
-      ],
-    },
-  ],
-}
-export const EXPECTED_REPORT_VALUES_FOR_COMP = {
-  velocityList: [
-    { id: 0, name: 'Velocity(Story Point)', valueList: [{ value: 20 }] },
-    { id: 1, name: 'Throughput(Cards Count)', valueList: [{ value: 14 }] },
-  ],
-  cycleTimeList: [
-    {
-      id: 0,
-      name: 'Average cycle time',
-      valueList: [
-        { value: 21.18, unit: '(days/SP)' },
-        { value: 30.26, unit: '(days/card)' },
-      ],
-    },
-  ],
-  classificationList: [
-    {
-      id: 0,
-      name: 'FS Work Type',
-      valuesList: [{ name: 'Feature Work - Planned', value: '57.14%' }],
-    },
-  ],
-  deploymentFrequencyList: [
-    {
-      id: 0,
-      name: 'fs-platform-onboarding/ :shipit: deploy to PROD',
-      valuesList: [
-        {
-          name: 'Deployment frequency(deployments/day)',
-          value: 0.3,
-        },
-      ],
-    },
-    {
-      id: 1,
-      name: 'Average/',
-      valuesList: [
-        {
-          name: 'Deployment frequency(deployments/day)',
-          value: 0.4,
-        },
-      ],
-    },
-  ],
-  leadTimeForChangesList: [
-    {
-      id: 0,
-      name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
-      valuesList: [
-        { name: 'mergeDelayTime', value: 2702.53 },
-        { name: 'pipelineDelayTime', value: 2587.42 },
-        { name: 'totalDelayTime', value: 5289.95 },
-      ],
-    },
-    {
-      id: 1,
-      name: 'Average/',
-      valuesList: [
-        { name: 'mergeDelayTime', value: 3647.51 },
-        { name: 'pipelineDelayTime', value: 2341.72 },
-        { name: 'totalDelayTime', value: 5989.22 },
+        { name: 'mergeDelayTime', value: '2day 12hours 47minutes' },
+        { name: 'pipelineDelayTime', value: '1day 15hours 1minutes' },
+        { name: 'totalDelayTime', value: '4day 3hours 49minutes' },
       ],
     },
   ],

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -285,6 +285,12 @@ export const MOCK_REPORT_RESPONSE = {
         averageTimeForCards: 11.95,
         totalTime: 167.27,
       },
+      {
+        optionalItemName: 'In Dev',
+        averageTimeForSP: 12.13,
+        averageTimeForCards: 17.32,
+        totalTime: 242.51,
+      },
     ],
   },
   deploymentFrequency: {
@@ -360,6 +366,19 @@ export const EXPECTED_REPORT_VALUES = {
       valueList: [
         { value: 21.18, unit: '(days/SP)' },
         { value: 30.26, unit: '(days/card)' },
+      ],
+    },
+    {
+      id: 1,
+      name: 'Total development time / Total cycle time',
+      valueList: [{ value: 0.57 }],
+    },
+    {
+      id: 2,
+      name: 'Average development time',
+      valueList: [
+        { value: 12.13, unit: '(days/SP)' },
+        { value: 17.32, unit: '(days/card)' },
       ],
     },
   ],

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -350,21 +350,105 @@ export const MOCK_REPORT_RESPONSE = {
 }
 export const EXPECTED_REPORT_VALUES = {
   velocityList: [
-    { id: 0, name: 'Velocity(Story Point)', valueList: [20] },
-    { id: 1, name: 'Throughput(Cards Count)', valueList: [14] },
+    { id: 0, name: 'Velocity(Story Point)', valueList: [{ value: 20 }] },
+    { id: 1, name: 'Throughput(Cards Count)', valueList: [{ value: 14 }] },
   ],
   cycleTimeList: [
-    { id: 0, name: 'Average cycle time', valueList: ['21.18(days/SP)', '30.26(days/card)'] },
-    { id: 1, name: 'Total development time / Total cycle time', valueList: [] },
-    { id: 2, name: 'Total waiting for testing time / Total cycle time', valueList: [] },
-    { id: 3, name: 'Total block time / Total cycle time', valueList: [] },
-    { id: 4, name: 'Total review time / Total cycle time', valueList: [] },
-    { id: 5, name: 'Total testing time / Total cycle time', valueList: [] },
-    { id: 6, name: 'Average development time', valueList: [] },
-    { id: 7, name: 'Average waiting for testing time', valueList: [] },
-    { id: 8, name: 'Average block time', valueList: [] },
-    { id: 9, name: 'Average review time', valueList: [] },
-    { id: 10, name: 'Average testing time', valueList: [] },
+    {
+      id: 0,
+      name: 'Average cycle time',
+      valueList: [
+        { value: 21.18, unit: '(days/SP)' },
+        { value: 30.26, unit: '(days/card)' },
+      ],
+    },
+  ],
+  classificationList: [
+    {
+      id: 0,
+      name: 'FS Work Type',
+      valuesList: [{ name: 'Feature Work - Planned', value: '57.14%' }],
+    },
+  ],
+  deploymentFrequencyList: [
+    {
+      id: 0,
+      name: 'fs-platform-onboarding/ :shipit: deploy to PROD',
+      valuesList: [
+        {
+          name: 'Deployment frequency(deployments/day)',
+          value: 0.3,
+        },
+      ],
+    },
+    {
+      id: 1,
+      name: 'Average/',
+      valuesList: [
+        {
+          name: 'Deployment frequency(deployments/day)',
+          value: 0.4,
+        },
+      ],
+    },
+  ],
+  leadTimeForChangesList: [
+    {
+      id: 0,
+      name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
+      valuesList: [
+        { name: 'mergeDelayTime', value: 2702.53 },
+        { name: 'pipelineDelayTime', value: 2587.42 },
+        { name: 'totalDelayTime', value: 5289.95 },
+      ],
+    },
+    {
+      id: 1,
+      name: 'Average/',
+      valuesList: [
+        { name: 'mergeDelayTime', value: 3647.51 },
+        { name: 'pipelineDelayTime', value: 2341.72 },
+        { name: 'totalDelayTime', value: 5989.22 },
+      ],
+    },
+  ],
+  changeFailureRateList: [
+    {
+      id: 0,
+      name: 'fs-platform-onboarding/ :shipit: deploy to PROD',
+      valuesList: [
+        {
+          name: 'Failure rate',
+          value: '0.00% (0/3)',
+        },
+      ],
+    },
+    {
+      id: 1,
+      name: 'Average/',
+      valuesList: [
+        {
+          name: 'Failure rate',
+          value: '0.00% (0/12)',
+        },
+      ],
+    },
+  ],
+}
+export const EXPECTED_REPORT_VALUES_FOR_COMP = {
+  velocityList: [
+    { id: 0, name: 'Velocity(Story Point)', valueList: [{ value: 20 }] },
+    { id: 1, name: 'Throughput(Cards Count)', valueList: [{ value: 14 }] },
+  ],
+  cycleTimeList: [
+    {
+      id: 0,
+      name: 'Average cycle time',
+      valueList: [
+        { value: 21.18, unit: '(days/SP)' },
+        { value: 30.26, unit: '(days/card)' },
+      ],
+    },
   ],
   classificationList: [
     {

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -271,32 +271,32 @@ export const MOCK_GET_STEPS_PARAMS = {
 }
 export const MOCK_REPORT_RESPONSE = {
   velocity: {
-    velocityForSP: '20',
-    velocityForCards: '14',
+    velocityForSP: 20,
+    velocityForCards: 14,
   },
   cycleTime: {
-    averageCircleTimePerCard: '30.26',
-    averageCycleTimePerSP: '21.18',
+    averageCycleTimePerCard: 30.26,
+    averageCycleTimePerSP: 21.18,
     totalTimeForCards: 423.59,
     swimlaneList: [
       {
         optionalItemName: 'Analysis',
-        averageTimeForSP: '8.36',
-        averageTimeForCards: '11.95',
-        totalTime: '167.27',
+        averageTimeForSP: 8.36,
+        averageTimeForCards: 11.95,
+        totalTime: 167.27,
       },
     ],
   },
   deploymentFrequency: {
     avgDeploymentFrequency: {
       name: 'Average',
-      deploymentFrequency: '0.40',
+      deploymentFrequency: 0.4,
     },
     deploymentFrequencyOfPipelines: [
       {
         name: 'fs-platform-onboarding',
         step: ' :shipit: deploy to PROD',
-        deploymentFrequency: '0.30',
+        deploymentFrequency: 0.3,
         items: [
           {
             date: '9/9/2022',
@@ -350,8 +350,8 @@ export const MOCK_REPORT_RESPONSE = {
 }
 export const EXPECTED_REPORT_VALUES = {
   velocityList: [
-    { id: 0, name: 'Velocity(Story Point)', valueList: ['20'] },
-    { id: 1, name: 'Throughput(Cards Count)', valueList: ['14'] },
+    { id: 0, name: 'Velocity(Story Point)', valueList: [20] },
+    { id: 1, name: 'Throughput(Cards Count)', valueList: [14] },
   ],
   cycleTimeList: [
     { id: 0, name: 'Average cycle time', valueList: ['21.18(days/SP)', '30.26(days/card)'] },
@@ -380,7 +380,7 @@ export const EXPECTED_REPORT_VALUES = {
       valuesList: [
         {
           name: 'Deployment frequency(deployments/day)',
-          value: '0.30',
+          value: 0.3,
         },
       ],
     },
@@ -390,7 +390,7 @@ export const EXPECTED_REPORT_VALUES = {
       valuesList: [
         {
           name: 'Deployment frequency(deployments/day)',
-          value: '0.40',
+          value: 0.4,
         },
       ],
     },
@@ -400,18 +400,18 @@ export const EXPECTED_REPORT_VALUES = {
       id: 0,
       name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
       valuesList: [
-        { name: 'mergeDelayTime', value: '2702.53' },
-        { name: 'pipelineDelayTime', value: '2587.42' },
-        { name: 'totalDelayTime', value: '5289.95' },
+        { name: 'mergeDelayTime', value: 2702.53 },
+        { name: 'pipelineDelayTime', value: 2587.42 },
+        { name: 'totalDelayTime', value: 5289.95 },
       ],
     },
     {
       id: 1,
       name: 'Average/',
       valuesList: [
-        { name: 'mergeDelayTime', value: '3647.51' },
-        { name: 'pipelineDelayTime', value: '2341.72' },
-        { name: 'totalDelayTime', value: '5989.22' },
+        { name: 'mergeDelayTime', value: 3647.51 },
+        { name: 'pipelineDelayTime', value: 2341.72 },
+        { name: 'totalDelayTime', value: 5989.22 },
       ],
     },
   ],

--- a/frontend/__tests__/src/hooks/reportMapper/cycleTime.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/cycleTime.test.tsx
@@ -22,17 +22,32 @@ describe('cycleTime data mapper', () => {
   }
   it('maps response cycleTime values to ui display value', () => {
     const expectedCycleValues = [
-      { id: 0, name: 'Average cycle time', valueList: ['21.18(days/SP)', '30.26(days/card)'] },
-      { id: 1, name: 'Total development time / Total cycle time', valueList: [0.57] },
-      { id: 2, name: 'Total waiting for testing time / Total cycle time', valueList: [0.01] },
-      { id: 3, name: 'Total block time / Total cycle time', valueList: [] },
-      { id: 4, name: 'Total review time / Total cycle time', valueList: [] },
-      { id: 5, name: 'Total testing time / Total cycle time', valueList: [] },
-      { id: 6, name: 'Average development time', valueList: ['12.13(days/SP)', '17.32(days/card)'] },
-      { id: 7, name: 'Average waiting for testing time', valueList: ['0.16(days/SP)', '0.23(days/card)'] },
-      { id: 8, name: 'Average block time', valueList: [] },
-      { id: 9, name: 'Average review time', valueList: [] },
-      { id: 10, name: 'Average testing time', valueList: [] },
+      {
+        id: 0,
+        name: 'Average cycle time',
+        valueList: [
+          { value: 21.18, unit: '(days/SP)' },
+          { value: 30.26, unit: '(days/card)' },
+        ],
+      },
+      { id: 1, name: 'Total development time / Total cycle time', valueList: [{ value: 0.57 }] },
+      { id: 2, name: 'Total waiting for testing time / Total cycle time', valueList: [{ value: 0.01 }] },
+      {
+        id: 3,
+        name: 'Average development time',
+        valueList: [
+          { value: 12.13, unit: '(days/SP)' },
+          { value: 17.32, unit: '(days/card)' },
+        ],
+      },
+      {
+        id: 4,
+        name: 'Average waiting for testing time',
+        valueList: [
+          { value: 0.16, unit: '(days/SP)' },
+          { value: 0.23, unit: '(days/card)' },
+        ],
+      },
     ]
     const mappedCycleValues = cycleTimeMapper(mockCycleTimeRes)
 

--- a/frontend/__tests__/src/hooks/reportMapper/cycleTime.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/cycleTime.test.tsx
@@ -3,28 +3,28 @@ import { cycleTimeMapper } from '@src/hooks/reportMapper/cycleTime'
 describe('cycleTime data mapper', () => {
   const mockCycleTimeRes = {
     totalTimeForCards: 423.59,
-    averageCycleTimePerSP: '21.18',
-    averageCircleTimePerCard: '30.26',
+    averageCycleTimePerSP: 21.18,
+    averageCycleTimePerCard: 30.26,
     swimlaneList: [
       {
         optionalItemName: 'In Dev',
-        averageTimeForSP: '12.13',
-        averageTimeForCards: '17.32',
-        totalTime: '242.51',
+        averageTimeForSP: 12.13,
+        averageTimeForCards: 17.32,
+        totalTime: 242.51,
       },
       {
         optionalItemName: 'Waiting for testing',
-        averageTimeForSP: '0.16',
-        averageTimeForCards: '0.23',
-        totalTime: '3.21',
+        averageTimeForSP: 0.16,
+        averageTimeForCards: 0.23,
+        totalTime: 3.21,
       },
     ],
   }
   it('maps response cycleTime values to ui display value', () => {
     const expectedCycleValues = [
       { id: 0, name: 'Average cycle time', valueList: ['21.18(days/SP)', '30.26(days/card)'] },
-      { id: 1, name: 'Total development time / Total cycle time', valueList: ['0.57'] },
-      { id: 2, name: 'Total waiting for testing time / Total cycle time', valueList: ['0.01'] },
+      { id: 1, name: 'Total development time / Total cycle time', valueList: [0.57] },
+      { id: 2, name: 'Total waiting for testing time / Total cycle time', valueList: [0.01] },
       { id: 3, name: 'Total block time / Total cycle time', valueList: [] },
       { id: 4, name: 'Total review time / Total cycle time', valueList: [] },
       { id: 5, name: 'Total testing time / Total cycle time', valueList: [] },

--- a/frontend/__tests__/src/hooks/reportMapper/deploymentFrequency.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/deploymentFrequency.test.tsx
@@ -4,13 +4,13 @@ describe('deployment frequency data mapper', () => {
   const mockDeploymentFrequencyRes = {
     avgDeploymentFrequency: {
       name: 'Average',
-      deploymentFrequency: '0.40',
+      deploymentFrequency: 0.4,
     },
     deploymentFrequencyOfPipelines: [
       {
         name: 'fs-platform-onboarding',
         step: ' :shipit: deploy to PROD',
-        deploymentFrequency: '0.30',
+        deploymentFrequency: 0.3,
         items: [
           {
             date: '9/9/2022',
@@ -36,7 +36,7 @@ describe('deployment frequency data mapper', () => {
         valuesList: [
           {
             name: 'Deployment frequency(deployments/day)',
-            value: '0.30',
+            value: 0.3,
           },
         ],
       },
@@ -46,7 +46,7 @@ describe('deployment frequency data mapper', () => {
         valuesList: [
           {
             name: 'Deployment frequency(deployments/day)',
-            value: '0.40',
+            value: 0.4,
           },
         ],
       },

--- a/frontend/__tests__/src/hooks/reportMapper/deploymentFrequency.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/deploymentFrequency.test.tsx
@@ -36,7 +36,7 @@ describe('deployment frequency data mapper', () => {
         valuesList: [
           {
             name: 'Deployment frequency(deployments/day)',
-            value: 0.3,
+            value: '30.00%',
           },
         ],
       },
@@ -46,7 +46,7 @@ describe('deployment frequency data mapper', () => {
         valuesList: [
           {
             name: 'Deployment frequency(deployments/day)',
-            value: 0.4,
+            value: '40.00%',
           },
         ],
       },

--- a/frontend/__tests__/src/hooks/reportMapper/leadTimeForChanges.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/leadTimeForChanges.test.tsx
@@ -24,18 +24,18 @@ describe('lead time for changes data mapper', () => {
         id: 0,
         name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
         valuesList: [
-          { name: 'mergeDelayTime', value: 2702.53 },
-          { name: 'pipelineDelayTime', value: 2587.42 },
-          { name: 'totalDelayTime', value: 5289.95 },
+          { name: 'mergeDelayTime', value: '1day 21hours 2minutes' },
+          { name: 'pipelineDelayTime', value: '1day 19hours 7minutes' },
+          { name: 'totalDelayTime', value: '3day 16hours 9minutes' },
         ],
       },
       {
         id: 1,
         name: 'Average/',
         valuesList: [
-          { name: 'mergeDelayTime', value: 3647.51 },
-          { name: 'pipelineDelayTime', value: 2341.72 },
-          { name: 'totalDelayTime', value: 5989.22 },
+          { name: 'mergeDelayTime', value: '2day 12hours 47minutes' },
+          { name: 'pipelineDelayTime', value: '1day 15hours 1minutes' },
+          { name: 'totalDelayTime', value: '4day 3hours 49minutes' },
         ],
       },
     ]

--- a/frontend/__tests__/src/hooks/reportMapper/leadTimeForChanges.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/leadTimeForChanges.test.tsx
@@ -24,18 +24,18 @@ describe('lead time for changes data mapper', () => {
         id: 0,
         name: 'fs-platform-payment-selector/RECORD RELEASE TO PROD',
         valuesList: [
-          { name: 'mergeDelayTime', value: '2702.53' },
-          { name: 'pipelineDelayTime', value: '2587.42' },
-          { name: 'totalDelayTime', value: '5289.95' },
+          { name: 'mergeDelayTime', value: 2702.53 },
+          { name: 'pipelineDelayTime', value: 2587.42 },
+          { name: 'totalDelayTime', value: 5289.95 },
         ],
       },
       {
         id: 1,
         name: 'Average/',
         valuesList: [
-          { name: 'mergeDelayTime', value: '3647.51' },
-          { name: 'pipelineDelayTime', value: '2341.72' },
-          { name: 'totalDelayTime', value: '5989.22' },
+          { name: 'mergeDelayTime', value: 3647.51 },
+          { name: 'pipelineDelayTime', value: 2341.72 },
+          { name: 'totalDelayTime', value: 5989.22 },
         ],
       },
     ]

--- a/frontend/__tests__/src/hooks/reportMapper/velocity.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/velocity.test.tsx
@@ -3,12 +3,12 @@ import { velocityMapper } from '@src/hooks/reportMapper/velocity'
 describe('velocity data mapper', () => {
   it('maps response velocity values to ui display value', () => {
     const mockVelocityRes = {
-      velocityForSP: '20',
-      velocityForCards: '15',
+      velocityForSP: 20,
+      velocityForCards: 15,
     }
     const expectedVelocityValues = [
-      { id: 0, name: 'Velocity(Story Point)', valueList: ['20'] },
-      { id: 1, name: 'Throughput(Cards Count)', valueList: ['15'] },
+      { id: 0, name: 'Velocity(Story Point)', valueList: [20] },
+      { id: 1, name: 'Throughput(Cards Count)', valueList: [15] },
     ]
 
     const mappedVelocityValues = velocityMapper(mockVelocityRes)

--- a/frontend/__tests__/src/hooks/reportMapper/velocity.test.tsx
+++ b/frontend/__tests__/src/hooks/reportMapper/velocity.test.tsx
@@ -7,8 +7,8 @@ describe('velocity data mapper', () => {
       velocityForCards: 15,
     }
     const expectedVelocityValues = [
-      { id: 0, name: 'Velocity(Story Point)', valueList: [20] },
-      { id: 1, name: 'Throughput(Cards Count)', valueList: [15] },
+      { id: 0, name: 'Velocity(Story Point)', valueList: [{ value: 20 }] },
+      { id: 1, name: 'Throughput(Cards Count)', valueList: [{ value: 15 }] },
     ]
 
     const mappedVelocityValues = velocityMapper(mockVelocityRes)

--- a/frontend/src/clients/report/ReportClient.ts
+++ b/frontend/src/clients/report/ReportClient.ts
@@ -4,19 +4,19 @@ import { ReportRequestDTO } from '@src/clients/report/dto/request'
 export class ReportClient extends HttpClient {
   reportResponse = {
     velocity: {
-      velocityForSP: '',
-      velocityForCards: '',
+      velocityForSP: 0,
+      velocityForCards: 0,
     },
     cycleTime: {
-      averageCircleTimePerCard: '',
-      averageCycleTimePerSP: '',
+      averageCycleTimePerCard: 0,
+      averageCycleTimePerSP: 0,
       totalTimeForCards: 0,
       swimlaneList: [
         {
           optionalItemName: '',
-          averageTimeForSP: '',
-          averageTimeForCards: '',
-          totalTime: '',
+          averageTimeForSP: 0,
+          averageTimeForCards: 0,
+          totalTime: 0,
         },
       ],
     },
@@ -29,7 +29,7 @@ export class ReportClient extends HttpClient {
     deploymentFrequency: {
       avgDeploymentFrequency: {
         name: '',
-        deploymentFrequency: '',
+        deploymentFrequency: 0,
       },
       deploymentFrequencyOfPipelines: [],
     },

--- a/frontend/src/clients/report/dto/response.ts
+++ b/frontend/src/clients/report/dto/response.ts
@@ -14,8 +14,8 @@ export interface VelocityResponse {
 
 export interface CycleTimeResponse {
   totalTimeForCards: number
-  averageCircleTimePerCard: string
-  averageCycleTimePerSP: string
+  averageCycleTimePerCard: number
+  averageCycleTimePerSP: number
   swimlaneList: Array<Swimlane>
 }
 
@@ -41,9 +41,9 @@ export interface ChangeFailureRateResponse {
 
 export interface Swimlane {
   optionalItemName: string
-  averageTimeForSP: string
-  averageTimeForCards: string
-  totalTime: string
+  averageTimeForSP: number
+  averageTimeForCards: number
+  totalTime: number
 }
 
 export interface AVGDeploymentFrequency {

--- a/frontend/src/clients/report/dto/response.ts
+++ b/frontend/src/clients/report/dto/response.ts
@@ -8,8 +8,8 @@ export interface ReportResponseDTO {
 }
 
 export interface VelocityResponse {
-  velocityForSP: string
-  velocityForCards: string
+  velocityForSP: number
+  velocityForCards: number
 }
 
 export interface CycleTimeResponse {

--- a/frontend/src/clients/report/dto/response.ts
+++ b/frontend/src/clients/report/dto/response.ts
@@ -49,7 +49,7 @@ export interface Swimlane {
 export interface AVGDeploymentFrequency {
   name: string
   step?: string
-  deploymentFrequency: string
+  deploymentFrequency: number
 }
 
 export interface DeploymentDateCount {
@@ -60,7 +60,7 @@ export interface DeploymentDateCount {
 export interface DeploymentFrequencyOfPipeline {
   name: string
   step: string
-  deploymentFrequency: string
+  deploymentFrequency: number
   items: DeploymentDateCount[]
 }
 

--- a/frontend/src/components/Common/ReportForTwoColumns/index.tsx
+++ b/frontend/src/components/Common/ReportForTwoColumns/index.tsx
@@ -16,12 +16,12 @@ export const ReportForTwoColumns = ({ title, data }: ReportForTwoColumnsProps) =
         <Row>
           <TableCell rowSpan={row.valueList.length}>{row.name}</TableCell>
           <TableCell>
-            {row.valueList[0].unit ? `${row.valueList[0].value}${row.valueList[0].unit}` : row.valueList[0].value}
+            {row.valueList[0]?.unit ? `${row.valueList[0].value}${row.valueList[0].unit}` : row.valueList[0].value}
           </TableCell>
         </Row>
         {row.valueList.slice(1).map((data) => (
           <Row key={row.id}>
-            <TableCell>{data.unit ? `${data.value}${data.unit}` : data.value}</TableCell>
+            <TableCell>{`${data.value}${data.unit}`}</TableCell>
           </Row>
         ))}
       </Fragment>

--- a/frontend/src/components/Common/ReportForTwoColumns/index.tsx
+++ b/frontend/src/components/Common/ReportForTwoColumns/index.tsx
@@ -15,11 +15,13 @@ export const ReportForTwoColumns = ({ title, data }: ReportForTwoColumnsProps) =
       <Fragment key={row.id}>
         <Row>
           <TableCell rowSpan={row.valueList.length}>{row.name}</TableCell>
-          <TableCell>{row.valueList[0]}</TableCell>
+          <TableCell>
+            {row.valueList[0].unit ? `${row.valueList[0].value}${row.valueList[0].unit}` : row.valueList[0].value}
+          </TableCell>
         </Row>
-        {row.valueList.slice(1).map((value) => (
+        {row.valueList.slice(1).map((data) => (
           <Row key={row.id}>
-            <TableCell>{value}</TableCell>
+            <TableCell>{data.unit ? `${data.value}${data.unit}` : data.value}</TableCell>
           </Row>
         ))}
       </Fragment>

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -6,6 +6,7 @@ import { selectConfig } from '@src/context/config/configSlice'
 import {
   INIT_REPORT_DATA_WITH_THREE_COLUMNS,
   INIT_REPORT_DATA_WITH_TWO_COLUMNS,
+  INIT_REPORT_DATA_WITH_TWO_COLUMNS_CYCLE,
   NAME,
   PIPELINE_STEP,
 } from '@src/constants'
@@ -15,7 +16,7 @@ import ReportForThreeColumns from '@src/components/Common/ReportForThreeColumns'
 export const ReportStep = () => {
   const { generateReport, isLoading } = useGenerateReportEffect()
   const [velocityData, setVelocityData] = useState(INIT_REPORT_DATA_WITH_TWO_COLUMNS)
-  const [cycleTimeData, setCycleTimeData] = useState(INIT_REPORT_DATA_WITH_TWO_COLUMNS)
+  const [cycleTimeData, setCycleTimeData] = useState(INIT_REPORT_DATA_WITH_TWO_COLUMNS_CYCLE)
   const [classificationData, setClassificationData] = useState(INIT_REPORT_DATA_WITH_THREE_COLUMNS)
   const [deploymentFrequencyData, setDeploymentFrequencyData] = useState(INIT_REPORT_DATA_WITH_THREE_COLUMNS)
   const [leadTimeForChangesData, setLeadTimeForChangesData] = useState(INIT_REPORT_DATA_WITH_THREE_COLUMNS)

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -147,7 +147,7 @@ export const INIT_REPORT_DATA_WITH_TWO_COLUMNS: ReportDataWithTwoColumns[] = [
   {
     id: 1,
     name: '',
-    valueList: [],
+    valueList: [{ value: 0, unit: '' }],
   },
 ]
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -147,6 +147,13 @@ export const INIT_REPORT_DATA_WITH_TWO_COLUMNS: ReportDataWithTwoColumns[] = [
   {
     id: 1,
     name: '',
+    valueList: [{ value: 0 }],
+  },
+]
+export const INIT_REPORT_DATA_WITH_TWO_COLUMNS_CYCLE: ReportDataWithTwoColumns[] = [
+  {
+    id: 1,
+    name: '',
     valueList: [{ value: 0, unit: '' }],
   },
 ]

--- a/frontend/src/hooks/reportMapper/cycleTime.ts
+++ b/frontend/src/hooks/reportMapper/cycleTime.ts
@@ -1,5 +1,5 @@
 import { CYCLE_TIME_METRICS_NAME, METRICS_CONSTANTS, Unit } from '@src/constants'
-import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
+import { ReportDataWithTwoColumns, ValueWithUnits } from '@src/hooks/reportMapper/reportUIDataStructure'
 import { CycleTimeResponse, Swimlane } from '@src/clients/report/dto/response'
 
 export const cycleTimeMapper = ({
@@ -13,19 +13,31 @@ export const cycleTimeMapper = ({
   const getSwimlaneByItemName = (itemName: string) => {
     return swimlaneList.find((item: Swimlane) => item.optionalItemName === itemName)
   }
-  const calPerColumnTotalTimeDivTotalTime = (itemName: string): number[] | string[] => {
+  const calPerColumnTotalTimeDivTotalTime = (itemName: string): ValueWithUnits[] => {
     const swimlane = getSwimlaneByItemName(itemName)
-    return swimlane ? [parseFloat((swimlane.totalTime / totalTimeForCards).toFixed(2))] : []
+    return swimlane ? [{ value: parseFloat((swimlane.totalTime / totalTimeForCards).toFixed(2)) }] : []
   }
   const getAverageTimeForPerColumn = (itemName: string) => {
     const swimlane = getSwimlaneByItemName(itemName)
     return swimlane
-      ? [`${swimlane.averageTimeForSP}${Unit.PER_SP}`, `${swimlane.averageTimeForCards}${Unit.PER_CARD}`]
+      ? [
+          { value: swimlane.averageTimeForSP, unit: Unit.PER_SP },
+          {
+            value: swimlane.averageTimeForCards,
+            unit: Unit.PER_CARD,
+          },
+        ]
       : []
   }
 
-  const cycleTimeValue: { [key: string]: string[] | number[] } = {
-    AVERAGE_CYCLE_TIME: [`${averageCycleTimePerSP}${Unit.PER_SP}`, `${averageCycleTimePerCard}${Unit.PER_CARD}`],
+  const cycleTimeValue: { [key: string]: ValueWithUnits[] } = {
+    AVERAGE_CYCLE_TIME: [
+      { value: averageCycleTimePerSP, unit: Unit.PER_SP },
+      {
+        value: averageCycleTimePerCard,
+        unit: Unit.PER_CARD,
+      },
+    ],
     DEVELOPMENT_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.inDevValue),
     WAITING_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.waitingValue),
     BLOCK_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.blockValue),

--- a/frontend/src/hooks/reportMapper/cycleTime.ts
+++ b/frontend/src/hooks/reportMapper/cycleTime.ts
@@ -50,8 +50,10 @@ export const cycleTimeMapper = ({
     AVERAGE_TESTING_TIME: getAverageTimeForPerColumn(METRICS_CONSTANTS.testingValue),
   }
 
-  Object.entries(CYCLE_TIME_METRICS_NAME).map(([key, cycleName], index) => {
-    mappedCycleTimeValue.push({ id: index, name: cycleName, valueList: cycleTimeValue[key] })
+  Object.entries(CYCLE_TIME_METRICS_NAME).map(([key, cycleName]) => {
+    if (cycleTimeValue[key].length > 0) {
+      mappedCycleTimeValue.push({ id: mappedCycleTimeValue.length, name: cycleName, valueList: cycleTimeValue[key] })
+    }
   })
 
   return mappedCycleTimeValue

--- a/frontend/src/hooks/reportMapper/cycleTime.ts
+++ b/frontend/src/hooks/reportMapper/cycleTime.ts
@@ -6,16 +6,16 @@ export const cycleTimeMapper = ({
   swimlaneList,
   totalTimeForCards,
   averageCycleTimePerSP,
-  averageCircleTimePerCard,
+  averageCycleTimePerCard,
 }: CycleTimeResponse) => {
   const mappedCycleTimeValue: ReportDataWithTwoColumns[] = []
 
   const getSwimlaneByItemName = (itemName: string) => {
     return swimlaneList.find((item: Swimlane) => item.optionalItemName === itemName)
   }
-  const calPerColumnTotalTimeDivTotalTime = (itemName: string) => {
+  const calPerColumnTotalTimeDivTotalTime = (itemName: string): number[] | string[] => {
     const swimlane = getSwimlaneByItemName(itemName)
-    return swimlane ? [(parseFloat(swimlane.totalTime) / totalTimeForCards).toFixed(2)] : []
+    return swimlane ? [parseFloat((swimlane.totalTime / totalTimeForCards).toFixed(2))] : []
   }
   const getAverageTimeForPerColumn = (itemName: string) => {
     const swimlane = getSwimlaneByItemName(itemName)
@@ -24,8 +24,8 @@ export const cycleTimeMapper = ({
       : []
   }
 
-  const cycleTimeValue: { [key: string]: string[] } = {
-    AVERAGE_CYCLE_TIME: [`${averageCycleTimePerSP}${Unit.PER_SP}`, `${averageCircleTimePerCard}${Unit.PER_CARD}`],
+  const cycleTimeValue: { [key: string]: string[] | number[] } = {
+    AVERAGE_CYCLE_TIME: [`${averageCycleTimePerSP}${Unit.PER_SP}`, `${averageCycleTimePerCard}${Unit.PER_CARD}`],
     DEVELOPMENT_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.inDevValue),
     WAITING_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.waitingValue),
     BLOCK_PROPORTION: calPerColumnTotalTimeDivTotalTime(METRICS_CONSTANTS.blockValue),

--- a/frontend/src/hooks/reportMapper/deploymentFrequency.ts
+++ b/frontend/src/hooks/reportMapper/deploymentFrequency.ts
@@ -12,15 +12,20 @@ export const deploymentFrequencyMapper = ({
     const deploymentFrequencyValue: ReportDataWithThreeColumns = {
       id: index,
       name: `${item.name}/${item.step}`,
-      valuesList: [{ name: DEPLOYMENT_FREQUENCY_NAME, value: item.deploymentFrequency }],
+      valuesList: [{ name: DEPLOYMENT_FREQUENCY_NAME, value: `${(item.deploymentFrequency * 100).toFixed(2)}%` }],
     }
     mappedDeploymentFrequencyValue.push(deploymentFrequencyValue)
   })
   mappedDeploymentFrequencyValue.push({
     id: mappedDeploymentFrequencyValue.length,
     name: `${avgDeploymentFrequency.name}/`,
-    valuesList: [{ name: DEPLOYMENT_FREQUENCY_NAME, value: avgDeploymentFrequency.deploymentFrequency }],
+    valuesList: [
+      {
+        name: DEPLOYMENT_FREQUENCY_NAME,
+        value: `${(avgDeploymentFrequency.deploymentFrequency * 100).toFixed(2)}%`,
+      },
+    ],
   })
-
+  console.log(mappedDeploymentFrequencyValue)
   return mappedDeploymentFrequencyValue
 }

--- a/frontend/src/hooks/reportMapper/leadTimeForChanges.ts
+++ b/frontend/src/hooks/reportMapper/leadTimeForChanges.ts
@@ -7,6 +7,24 @@ export const leadTimeForChangesMapper = ({
 }: LeadTimeForChangesResponse) => {
   const mappedLeadTimeForChangesValue: ReportDataWithThreeColumns[] = []
 
+  const formatDuration = (duration: number) => {
+    const minutesPerDay = 1440
+    const minutesPerHour = 60
+    const days = Math.floor(duration / minutesPerDay)
+    const hours = Math.floor((duration % minutesPerDay) / minutesPerHour)
+    const minutes = Math.floor(duration % minutesPerHour)
+    let result = ''
+    if (days > 0) {
+      result += days + 'day '
+    }
+    if (hours > 0) {
+      result += hours + 'hours '
+    }
+    if (minutes > 0) {
+      result += minutes + 'minutes'
+    }
+    return result.trim()
+  }
   leadTimeForChangesOfPipelines.map((item, index) => {
     const deploymentFrequencyValue: ReportDataWithThreeColumns = {
       id: index,
@@ -15,7 +33,7 @@ export const leadTimeForChangesMapper = ({
         .slice(-3)
         .map(([name, value]) => ({
           name: name,
-          value: value,
+          value: formatDuration(value),
         })),
     }
     mappedLeadTimeForChangesValue.push(deploymentFrequencyValue)
@@ -27,7 +45,7 @@ export const leadTimeForChangesMapper = ({
       .slice(-3)
       .map(([name, value]) => ({
         name: name,
-        value: value,
+        value: formatDuration(value),
       })),
   })
 

--- a/frontend/src/hooks/reportMapper/leadTimeForChanges.ts
+++ b/frontend/src/hooks/reportMapper/leadTimeForChanges.ts
@@ -15,7 +15,7 @@ export const leadTimeForChangesMapper = ({
         .slice(-3)
         .map(([name, value]) => ({
           name: name,
-          value: value.toString(),
+          value: value,
         })),
     }
     mappedLeadTimeForChangesValue.push(deploymentFrequencyValue)
@@ -27,7 +27,7 @@ export const leadTimeForChangesMapper = ({
       .slice(-3)
       .map(([name, value]) => ({
         name: name,
-        value: value.toString(),
+        value: value,
       })),
   })
 

--- a/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
+++ b/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
@@ -1,7 +1,12 @@
 export interface ReportDataWithTwoColumns {
   id: number
   name: string
-  valueList: string[] | number[]
+  valueList: ValueWithUnits[]
+}
+
+export interface ValueWithUnits {
+  value: number
+  unit?: string
 }
 
 export interface ReportDataWithThreeColumns {

--- a/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
+++ b/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
@@ -14,6 +14,6 @@ export interface ReportDataWithThreeColumns {
   name: string
   valuesList: {
     name: string
-    value: string | number
+    value: string
   }[]
 }

--- a/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
+++ b/frontend/src/hooks/reportMapper/reportUIDataStructure.ts
@@ -1,7 +1,7 @@
 export interface ReportDataWithTwoColumns {
   id: number
   name: string
-  valueList: string[]
+  valueList: string[] | number[]
 }
 
 export interface ReportDataWithThreeColumns {
@@ -9,6 +9,6 @@ export interface ReportDataWithThreeColumns {
   name: string
   valuesList: {
     name: string
-    value: string
+    value: string | number
   }[]
 }

--- a/frontend/src/hooks/reportMapper/velocity.ts
+++ b/frontend/src/hooks/reportMapper/velocity.ts
@@ -5,7 +5,7 @@ import { VelocityResponse } from '@src/clients/report/dto/response'
 export const velocityMapper = ({ velocityForSP, velocityForCards }: VelocityResponse) => {
   const mappedVelocityValue: ReportDataWithTwoColumns[] = []
 
-  const velocityValue: { [key: string]: string } = {
+  const velocityValue: { [key: string]: number } = {
     VELOCITY_SP: velocityForSP,
     THROUGHPUT_CARDS_COUNT: velocityForCards,
   }

--- a/frontend/src/hooks/reportMapper/velocity.ts
+++ b/frontend/src/hooks/reportMapper/velocity.ts
@@ -14,7 +14,7 @@ export const velocityMapper = ({ velocityForSP, velocityForCards }: VelocityResp
     mappedVelocityValue.push({
       id: index,
       name: velocityName,
-      valueList: [velocityValue[key]],
+      valueList: [{ value: velocityValue[key] }],
     })
   })
 

--- a/stubs/frontend/exportPage/jsons/exportData.json
+++ b/stubs/frontend/exportPage/jsons/exportData.json
@@ -1,67 +1,67 @@
 {
   "velocity": {
-    "velocityForSP": "20",
-    "velocityForCards": "14"
+    "velocityForSP": 20,
+    "velocityForCards": 14
   },
   "cycleTime": {
-    "averageCircleTimePerCard": "30.26",
-    "averageCycleTimePerSP": "21.18",
+    "averageCycleTimePerCard": 30.26,
+    "averageCycleTimePerSP": 21.18,
     "totalTimeForCards": 423.59,
     "swimlaneList": [
       {
         "optionalItemName": "Analysis",
-        "averageTimeForSP": "8.36",
-        "averageTimeForCards": "11.95",
-        "totalTime": "167.27"
+        "averageTimeForSP": 8.36,
+        "averageTimeForCards": 11.95,
+        "totalTime": 167.27
       },
       {
         "optionalItemName": "In Dev",
-        "averageTimeForSP": "12.13",
-        "averageTimeForCards": "17.32",
-        "totalTime": "242.51"
+        "averageTimeForSP": 12.13,
+        "averageTimeForCards": 17.32,
+        "totalTime": 242.51
       },
       {
         "optionalItemName": "Waiting for testing",
-        "averageTimeForSP": "0.16",
-        "averageTimeForCards": "0.23",
-        "totalTime": "3.21"
+        "averageTimeForSP": 0.16,
+        "averageTimeForCards": 0.23,
+        "totalTime": 3.21
       },
       {
         "optionalItemName": "Done",
-        "averageTimeForSP": "86.20",
-        "averageTimeForCards": "123.14",
-        "totalTime": "1723.99"
+        "averageTimeForSP": 86.2,
+        "averageTimeForCards": 123.14,
+        "totalTime": 1723.99
       },
       {
         "optionalItemName": "Block",
-        "averageTimeForSP": "8.54",
-        "averageTimeForCards": "12.20",
-        "totalTime": "170.80"
+        "averageTimeForSP": 8.54,
+        "averageTimeForCards": 12.2,
+        "totalTime": 170.8
       },
       {
         "optionalItemName": "Review",
-        "averageTimeForSP": "0.26",
-        "averageTimeForCards": "0.36",
-        "totalTime": "5.10"
+        "averageTimeForSP": 0.26,
+        "averageTimeForCards": 0.36,
+        "totalTime": 5.1
       },
       {
         "optionalItemName": "Testing",
-        "averageTimeForSP": "0.10",
-        "averageTimeForCards": "0.14",
-        "totalTime": "1.97"
+        "averageTimeForSP": 0.1,
+        "averageTimeForCards": 0.14,
+        "totalTime": 1.97
       }
     ]
   },
   "deploymentFrequency": {
     "avgDeploymentFrequency": {
       "name": "Average",
-      "deploymentFrequency": "0.40"
+      "deploymentFrequency": 0.4
     },
     "deploymentFrequencyOfPipelines": [
       {
         "name": "fs-platform-onboarding",
         "step": " :shipit: deploy to PROD",
-        "deploymentFrequency": "0.30",
+        "deploymentFrequency": 0.3,
         "items": [
           {
             "date": "9/9/2022",
@@ -80,7 +80,7 @@
       {
         "name": "fs-platform-environment-devops",
         "step": "RECORD RELEASE TO PROD",
-        "deploymentFrequency": "0.50",
+        "deploymentFrequency": 0.5,
         "items": [
           {
             "date": "9/9/2022",
@@ -103,7 +103,7 @@
       {
         "name": "fs-platform-payment-selector",
         "step": "RECORD RELEASE TO PROD",
-        "deploymentFrequency": "0.40",
+        "deploymentFrequency": 0.4,
         "items": [
           {
             "date": "9/6/2022",


### PR DESCRIPTION
## Summary

Change report data type from `string` to `number`
- Frontend mockServer of report response data type
- Report page UI model data type

## Screenshots

### Before

<img width="360" alt="Screen Shot 2023-04-14 at 2 53 43 PM" src="https://user-images.githubusercontent.com/110439025/231966650-5a75505c-9670-419a-9008-1fe41c681ff3.png">

### After
<img width="370" alt="Screen Shot 2023-04-14 at 2 55 06 PM" src="https://user-images.githubusercontent.com/110439025/231966952-06867be8-784f-42ac-b339-b9952ba7b544.png">

<img width="747" alt="Screen Shot 2023-04-14 at 2 57 17 PM" src="https://user-images.githubusercontent.com/110439025/231967481-ade1a9f6-b66e-4060-834b-387cc250e005.png">


