### PR TITLE
[ADM-412][frontend] [Metrics] Deployment frequency settings part II

### DIFF
--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -7,6 +7,7 @@ import saveMetricsSettingReducer, {
   addADeploymentFrequencySetting,
   deleteADeploymentFrequencySetting,
   selectDeploymentFrequencySettings,
+  initDeploymentFrequencySettings,
 } from '@src/context/Metrics/metricsSlice'
 import { store } from '@src/store'
 
@@ -148,5 +149,22 @@ describe('saveMetricsSetting reducer', () => {
 
   it('should return deploymentFrequencySettings when call selectDeploymentFrequencySettings functions', () => {
     expect(selectDeploymentFrequencySettings(store.getState())).toEqual(initState.deploymentFrequencySettings)
+  })
+
+  it('should init deploymentFrequencySettings when handle initDeploymentFrequencySettings given multiple deploymentFrequencySettings', () => {
+    const multipleDeploymentFrequencySettingsInitState = {
+      ...initState,
+      deploymentFrequencySettings: [
+        { id: 0, organization: 'mockOrgName1', pipelineName: 'mockName1', steps: 'step1' },
+        { id: 1, organization: 'mockOrgName2', pipelineName: 'mockName2', steps: 'step2' },
+      ],
+    }
+
+    const savedMetricsSetting = saveMetricsSettingReducer(
+      multipleDeploymentFrequencySettingsInitState,
+      initDeploymentFrequencySettings()
+    )
+
+    expect(savedMetricsSetting.deploymentFrequencySettings).toEqual(initState.deploymentFrequencySettings)
   })
 })

--- a/frontend/src/components/Metrics/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/PipelineTool/index.tsx
@@ -30,6 +30,7 @@ import { useVerifyPipelineToolEffect } from '@src/hooks/useVerifyPipelineToolEff
 import { ErrorNotification } from '@src/components/ErrorNotification'
 import { Loading } from '@src/components/Loading'
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons'
+import { initDeploymentFrequencySettings } from '@src/context/Metrics/metricsSlice'
 
 export const PipelineTool = () => {
   const dispatch = useAppDispatch()
@@ -129,6 +130,7 @@ export const PipelineTool = () => {
       if (res) {
         dispatch(updatePipelineToolVerifyState(res.isPipelineToolVerified))
         dispatch(updatePipelineToolVerifyResponse(res.response))
+        dispatch(initDeploymentFrequencySettings())
       }
     })
   }

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -78,6 +78,10 @@ export const metricsSlice = createSlice({
       const deleteId = action.payload
       state.deploymentFrequencySettings = [...state.deploymentFrequencySettings.filter(({ id }) => id !== deleteId)]
     },
+
+    initDeploymentFrequencySettings: (state) => {
+      state.deploymentFrequencySettings = initialState.deploymentFrequencySettings
+    },
   },
 })
 
@@ -86,6 +90,7 @@ export const {
   saveDoneColumn,
   saveUsers,
   saveBoardColumns,
+  initDeploymentFrequencySettings,
   addADeploymentFrequencySetting,
   updateDeploymentFrequencySettings,
   deleteADeploymentFrequencySetting,


### PR DESCRIPTION
## Summary
fix failed test
Test2:
Given verified Pipeline Tool
When secondly click next to go to Metrics page
Then just show Organization field selection
## Before
When filled in some pipeline settings in Deployment Frequency Settings part
And back to config page
And verified Pipeline Tool again, Then step into metrics page again
Deployment Frequency Settings part wsn't initilized
**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After
Initialize Deployment Frequency Settings part once verify Pipeline Tool

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
