### PR TITLE
ADM-468 [stub] [Frontend] timestamp match with mocksever

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -290,8 +290,8 @@ describe('MetricsStepper', () => {
       board: { boardId: '', email: '', projectKey: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',
       dateRange: {
-        endDate: dayjs().endOf('date').add(14, 'day').format(),
-        startDate: dayjs().startOf('date').format(),
+        endDate: dayjs().endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        startDate: dayjs().startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       },
       metrics: ['Velocity', 'Lead time for changes'],
       pipelineTool: { type: 'BuildKite', token: '' },
@@ -319,8 +319,8 @@ describe('MetricsStepper', () => {
       board: { boardId: '', email: '', projectKey: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',
       dateRange: {
-        endDate: dayjs().endOf('date').add(14, 'day').format(),
-        startDate: dayjs().startOf('date').format(),
+        endDate: dayjs().endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        startDate: dayjs().startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       },
       metrics: ['Velocity', 'Lead time for changes'],
       pipelineTool: { type: 'BuildKite', token: '' },

--- a/frontend/cypress/fixtures/ConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/ConfigFileForImporting.json
@@ -2,8 +2,8 @@
   "projectName": "ConfigFileForImporting",
   "metrics": ["Velocity", "Cycle time", "Classification", "Lead time for changes"],
   "dateRange": {
-    "startDate": "2023-03-16T00:00:00+08:00",
-    "endDate": "2023-03-30T23:59:59+08:00"
+    "startDate": "2023-03-16T00:00:00.000+08:00",
+    "endDate": "2023-03-30T23:59:59.999+08:00"
   },
   "calendarType": "Calendar with Chinese Holiday",
   "boardConfig": {

--- a/frontend/src/components/Metrics/ConfigStep/DateRangePicker/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/DateRangePicker/index.tsx
@@ -31,8 +31,8 @@ export const DateRangePicker = () => {
     } else {
       dispatch(
         updateDateRange({
-          startDate: value.startOf('date').format(),
-          endDate: value.endOf('date').add(14, 'day').format(),
+          startDate: value.startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+          endDate: value.endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
         })
       )
     }
@@ -48,7 +48,9 @@ export const DateRangePicker = () => {
         })
       )
     } else {
-      dispatch(updateDateRange({ startDate: startDate, endDate: value.endOf('date').format() }))
+      dispatch(
+        updateDateRange({ startDate: startDate, endDate: value.endOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ') })
+      )
     }
     updateVerifyStates()
   }

--- a/stubs/backend/jira/jira-stubs.yaml
+++ b/stubs/backend/jira/jira-stubs.yaml
@@ -27,7 +27,7 @@
     query:
       maxResults: 100
       startAt: 0
-      jql: status in %28%27DONE%27%2C %27CLOSED%27%29 AND %28status changed to %27DONE%27 during %281678896000000%2C 1680191999000%29 or status changed to %27CLOSED%27 during %281678896000000%2C 1680191999000%29%29
+      jql: status in %28%27DONE%27%2C %27CLOSED%27%29 AND %28status changed to %27DONE%27 during %281678896000000%2C 1680191999999%29 or status changed to %27CLOSED%27 during %281678896000000%2C 1680191999999%29%29
 
   response:
     headers:


### PR DESCRIPTION
## Summary

change timestamp of endDate to 23:59:59, and save millisecond to 999

## Before

_Description_

<img width="669" alt="image" src="https://user-images.githubusercontent.com/110760470/236601421-08ce00cd-bd73-4634-84e9-eabb9391fbe7.png">
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

<img width="658" alt="image" src="https://user-images.githubusercontent.com/110760470/236601434-36a06d09-78e7-48ba-8ca0-f76f494343eb.png">
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
