### PR TITLE
ADM-468 timestamp cover mocksever

### DIFF
--- a/frontend/__tests__/src/context/pipelineToolSlice.test.ts
+++ b/frontend/__tests__/src/context/pipelineToolSlice.test.ts
@@ -204,7 +204,7 @@ describe('pipelineTool reducer', () => {
         buildId: 'mockId',
         organizationId: 'mockOrgId',
         params: {
-          endTime: 1681747200000,
+          endTime: 1681833599999,
           orgName: 'mockOrgName',
           pipelineName: 'mockName',
           repository: 'mockRepository',
@@ -220,7 +220,7 @@ describe('pipelineTool reducer', () => {
         buildId: '',
         organizationId: '',
         params: {
-          endTime: 1681747200000,
+          endTime: 1681833599999,
           orgName: '',
           pipelineName: '',
           repository: '',

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -199,7 +199,7 @@ export const selectStepsParams = (state: RootState, organizationName: string, pi
       repository: pipeline?.repository ?? '',
       orgName: pipeline?.orgName ?? '',
       startTime: dayjs(startDate).startOf('date').valueOf(),
-      endTime: dayjs(endDate).startOf('date').valueOf(),
+      endTime: dayjs(endDate).endOf('date').valueOf(),
     },
     buildId: pipeline?.id ?? '',
     organizationId: pipeline?.orgId ?? '',


### PR DESCRIPTION
## Summary

fix timestamp of params when get steps in metrics page

## Before

![image](https://user-images.githubusercontent.com/110760470/236722586-b0969b76-8ea4-4007-bca2-ed4bdb88b659.png)


## After

<img width="1531" alt="image" src="https://user-images.githubusercontent.com/110760470/236722634-97432753-44cb-46a0-a362-09e0d0f95fda.png">

## Note

_Null_
