### PR TITLE
ADM-450 [Metrics] Active 'Next' button in metric page

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -138,7 +138,7 @@ describe('PipelineMetricSelection', () => {
     await waitFor(() => {
       expect(getByText('BuildKite get steps failed: error message')).toBeInTheDocument()
     })
-    expect(mockUpdatePipeline).toHaveBeenCalledTimes(1)
+    expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
     expect(mockClearErrorMessage).toHaveBeenCalledTimes(1)
   })
 
@@ -160,7 +160,7 @@ describe('PipelineMetricSelection', () => {
     const stepsListBox = within(getByRole('listbox'))
     await userEvent.click(stepsListBox.getByText('step2'))
 
-    expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
+    expect(mockUpdatePipeline).toHaveBeenCalledTimes(3)
     expect(mockClearErrorMessage).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection.test.tsx
@@ -68,9 +68,8 @@ describe('SingleSelection', () => {
     await userEvent.click(getByRole('button', { name: mockLabel }))
     await userEvent.click(getByText(mockOptions[1]))
 
-    expect(getByText(mockOptions[1])).toBeInTheDocument()
     expect(mockClearErrorMessage).toHaveBeenCalledTimes(1)
     expect(mockOnGetSteps).toHaveBeenCalledTimes(1)
-    expect(mockUpdatePipeline).toHaveBeenCalledTimes(1)
+    expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -53,6 +53,7 @@ const mockValidationCheckContext = {
   clearErrorMessage: jest.fn(),
   checkDuplicatedPipeline: jest.fn(),
   isPipelineValid: jest.fn().mockReturnValue(true),
+  getDuplicatedPipeLineIds: jest.fn().mockReturnValue([]),
 }
 
 jest.mock('@src/hooks/useMetricsStepValidationCheckContext', () => ({
@@ -103,7 +104,13 @@ const fillMetricsPageDate = async () => {
       store.dispatch(
         updateDeploymentFrequencySettings({ updateId: 0, label: 'organization', value: 'mock new organization' })
       ),
+      store.dispatch(
+        updateDeploymentFrequencySettings({ updateId: 0, label: 'pipelineName', value: 'mock new pipelineName' })
+      ),
+      store.dispatch(updateDeploymentFrequencySettings({ updateId: 0, label: 'step', value: 'mock new step' })),
       store.dispatch(updateLeadTimeForChanges({ updateId: 0, label: 'organization', value: 'mock new organization' })),
+      store.dispatch(updateLeadTimeForChanges({ updateId: 0, label: 'pipelineName', value: 'mock new pipelineName' })),
+      store.dispatch(updateLeadTimeForChanges({ updateId: 0, label: 'step', value: 'mock new step' })),
     ])
   })
 }
@@ -235,6 +242,7 @@ describe('MetricsStepper', () => {
     const { getByText } = setup()
     await fillConfigPageData()
     await userEvent.click(getByText(NEXT))
+    await fillMetricsPageDate()
     await userEvent.click(getByText(NEXT))
 
     expect(getByText(REPORT)).toHaveStyle(`color:${stepperColor}`)
@@ -332,9 +340,13 @@ describe('MetricsStepper', () => {
         jiraColumns: [{ TODO: 'To do' }],
         treatFlagCardAsBlock: false,
       },
-      deployment: [{ id: 0, organization: 'mock new organization', pipelineName: '', step: '' }],
+      deployment: [
+        { id: 0, organization: 'mock new organization', pipelineName: 'mock new pipelineName', step: 'mock new step' },
+      ],
       doneStatus: ['Done', 'Canceled'],
-      leadTime: [{ id: 0, organization: 'mock new organization', pipelineName: '', step: '' }],
+      leadTime: [
+        { id: 0, organization: 'mock new organization', pipelineName: 'mock new pipelineName', step: 'mock new step' },
+      ],
     }
     const { getByText } = setup()
 

--- a/frontend/__tests__/src/hooks/useMetricsStepValidationCheckContext.test.tsx
+++ b/frontend/__tests__/src/hooks/useMetricsStepValidationCheckContext.test.tsx
@@ -147,6 +147,9 @@ describe('useMetricsStepValidationCheckContext', () => {
     ).toBe(null)
     expect(result.current?.isPipelineValid(DEPLOYMENT_FREQUENCY_SETTINGS)).toBe(false)
     expect(result.current?.isPipelineValid(LEAD_TIME_FOR_CHANGES)).toBe(false)
+    expect(result.current?.getDuplicatedPipeLineIds([{ id: 1, organization: '', pipelineName: '', step: '' }])).toEqual(
+      []
+    )
   })
 
   it('should return useMetricsStepValidationCheckContext correctly ', () => {

--- a/frontend/cypress/e2e/createANewProject.cy.ts
+++ b/frontend/cypress/e2e/createANewProject.cy.ts
@@ -40,8 +40,12 @@ describe('Create a new project', () => {
 
     configPage.goMetricsStep()
 
+    nextButton().should('be.disabled')
+
     cy.contains('Crews setting').should('exist')
     cy.contains('Real done').should('exist')
+
+    metricsPage.checkRealDone()
 
     metricsPage.checkClassification()
 

--- a/frontend/cypress/fixtures/ConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/ConfigFileForImporting.json
@@ -1,6 +1,11 @@
 {
   "projectName": "ConfigFileForImporting",
-  "metrics": ["Velocity", "Cycle time", "Classification", "Lead time for changes"],
+  "metrics": [
+    "Velocity",
+    "Cycle time",
+    "Classification",
+    "Lead time for changes"
+  ],
   "dateRange": {
     "startDate": "2023-03-16T00:00:00.000+08:00",
     "endDate": "2023-03-30T23:59:59.999+08:00"
@@ -22,10 +27,17 @@
   },
   "sourceControlConfig": {
     "type": "GitHub",
-    "token": ""
+    "token": "ghp_Abc123Abc123Abc123Abc123Abc123Abc123"
   },
-  "crews": ["lucy", "hi hi", "Yu Zhang"],
-  "classification": ["type", "Parent"],
+  "crews": [
+    "lucy",
+    "hi hi",
+    "Yu Zhang"
+  ],
+  "classification": [
+    "type",
+    "Parent"
+  ],
   "cycleTime": [
     {
       "In Analysis": "To do"

--- a/frontend/cypress/fixtures/ConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/ConfigFileForImporting.json
@@ -1,11 +1,6 @@
 {
   "projectName": "ConfigFileForImporting",
-  "metrics": [
-    "Velocity",
-    "Cycle time",
-    "Classification",
-    "Lead time for changes"
-  ],
+  "metrics": ["Velocity", "Cycle time", "Classification", "Lead time for changes"],
   "dateRange": {
     "startDate": "2023-03-16T00:00:00.000+08:00",
     "endDate": "2023-03-30T23:59:59.999+08:00"
@@ -27,17 +22,10 @@
   },
   "sourceControlConfig": {
     "type": "GitHub",
-    "token": "ghp_Abc123Abc123Abc123Abc123Abc123Abc123"
+    "token": ""
   },
-  "crews": [
-    "lucy",
-    "hi hi",
-    "Yu Zhang"
-  ],
-  "classification": [
-    "type",
-    "Parent"
-  ],
+  "crews": ["lucy", "hi hi", "Yu Zhang"],
+  "classification": ["type", "Parent"],
   "cycleTime": [
     {
       "In Analysis": "To do"

--- a/frontend/cypress/pages/metrics/metrics.ts
+++ b/frontend/cypress/pages/metrics/metrics.ts
@@ -1,4 +1,11 @@
 class Metrics {
+  checkRealDone() {
+    cy.contains('Consider as done').siblings().eq(0).click()
+
+    cy.contains('All').click()
+    cy.get('div.MuiBackdrop-root.MuiBackdrop-invisible.MuiModal-backdrop').click({ force: true })
+  }
+
   checkClassification() {
     cy.contains('Distinguished By').siblings().click()
 

--- a/frontend/cypress/pages/metrics/metrics.ts
+++ b/frontend/cypress/pages/metrics/metrics.ts
@@ -1,6 +1,6 @@
 class Metrics {
   checkRealDone() {
-    cy.contains('Consider as done').siblings().eq(0).click()
+    cy.contains('Consider as Done').siblings().eq(0).click()
 
     cy.contains('All').click()
     cy.get('div.MuiBackdrop-root.MuiBackdrop-invisible.MuiModal-backdrop').click({ force: true })

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
@@ -1,5 +1,5 @@
 import { FormHelperText, InputLabel, ListItemText, MenuItem, Select, SelectChangeEvent } from '@mui/material'
-import React, { useState } from 'react'
+import React from 'react'
 import { FormControlWrapper } from './style'
 import camelCase from 'lodash.camelcase'
 
@@ -24,13 +24,14 @@ export const SingleSelection = ({
   onUpDatePipeline,
   onClearErrorMessage,
 }: Props) => {
-  const [selectedValue, setSelectedValue] = useState(value)
   const labelId = `single-selection-${label.toLowerCase().replace(' ', '-')}`
 
   const handleChange = (event: SelectChangeEvent) => {
     const value = event.target.value
-    if (onGetSteps) onGetSteps(value)
-    setSelectedValue(value)
+    if (onGetSteps) {
+      onGetSteps(value)
+      onUpDatePipeline(id, 'Step', '')
+    }
     onUpDatePipeline(id, label, value)
     !!errorMessage && onClearErrorMessage(id, camelCase(label))
   }
@@ -39,7 +40,7 @@ export const SingleSelection = ({
     <>
       <FormControlWrapper variant='standard' required error={!!errorMessage}>
         <InputLabel id={labelId}>{label}</InputLabel>
-        <Select labelId={labelId} value={options.length > 0 ? selectedValue : ''} onChange={handleChange}>
+        <Select labelId={labelId} value={value} onChange={handleChange}>
           {options.map((data) => (
             <MenuItem key={data} value={data} data-test-id={labelId}>
               <ListItemText primary={data} />

--- a/frontend/src/components/Metrics/MetricsStep/RealDone/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/RealDone/index.tsx
@@ -13,20 +13,16 @@ interface realDoneProps {
   label: string
 }
 
-function getSelectedDoneColumns(selectedBoardColumns: { name: string; value: string }[]) {
-  return selectedBoardColumns.filter(({ value }) => value === METRICS_CONSTANTS.doneValue).map(({ name }) => name)
-}
+const getSelectedDoneColumns = (selectedBoardColumns: { name: string; value: string }[]) =>
+  selectedBoardColumns.filter(({ value }) => value === METRICS_CONSTANTS.doneValue).map(({ name }) => name)
 
-function getFilteredStatuses(
+const getFilteredStatuses = (
   columns: { key: string; value: { name: string; statuses: string[] } }[],
   selectedDoneColumns: string[]
-) {
-  return columns.filter(({ value }) => selectedDoneColumns.includes(value.name)).flatMap(({ value }) => value.statuses)
-}
+) => columns.filter(({ value }) => selectedDoneColumns.includes(value.name)).flatMap(({ value }) => value.statuses)
 
-function getDoneStatuses(columns: { key: string; value: { name: string; statuses: string[] } }[]) {
-  return columns.find((column) => column.key === METRICS_CONSTANTS.doneKeyFromBackend)?.value.statuses ?? []
-}
+const getDoneStatuses = (columns: { key: string; value: { name: string; statuses: string[] } }[]) =>
+  columns.find((column) => column.key === METRICS_CONSTANTS.doneKeyFromBackend)?.value.statuses ?? []
 
 export const RealDone = ({ columns, title, label }: realDoneProps) => {
   const dispatch = useAppDispatch()

--- a/frontend/src/components/Metrics/MetricsStep/RealDone/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/RealDone/index.tsx
@@ -16,37 +16,37 @@ interface realDoneProps {
 const getSelectedDoneColumns = (selectedBoardColumns: { name: string; value: string }[]) =>
   selectedBoardColumns.filter(({ value }) => value === METRICS_CONSTANTS.doneValue).map(({ name }) => name)
 
-const getFilteredStatuses = (
+const getFilteredStatus = (
   columns: { key: string; value: { name: string; statuses: string[] } }[],
   selectedDoneColumns: string[]
 ) => columns.filter(({ value }) => selectedDoneColumns.includes(value.name)).flatMap(({ value }) => value.statuses)
 
-const getDoneStatuses = (columns: { key: string; value: { name: string; statuses: string[] } }[]) =>
+const getDoneStatus = (columns: { key: string; value: { name: string; statuses: string[] } }[]) =>
   columns.find((column) => column.key === METRICS_CONSTANTS.doneKeyFromBackend)?.value.statuses ?? []
 
 export const RealDone = ({ columns, title, label }: realDoneProps) => {
   const dispatch = useAppDispatch()
   const selectedBoardColumns = useAppSelector(selectBoardColumns)
   const savedDoneColumns = useAppSelector(selectMetricsContent).doneColumn
-  const doneStatuses = getDoneStatuses(columns)
+  const doneStatus = getDoneStatus(columns)
   const selectedDoneColumns = getSelectedDoneColumns(selectedBoardColumns)
-  const filteredStatuses = getFilteredStatuses(columns, selectedDoneColumns)
-  const statuses = selectedDoneColumns.length < 1 ? doneStatuses : filteredStatuses
-  const [selectedDoneStatuses, setSelectedDoneStatuses] = useState([] as string[])
-  const isAllSelected = savedDoneColumns.length === statuses.length
+  const filteredStatus = getFilteredStatus(columns, selectedDoneColumns)
+  const status = selectedDoneColumns.length < 1 ? doneStatus : filteredStatus
+  const [selectedDoneStatus, setSelectedDoneStatus] = useState([] as string[])
+  const isAllSelected = savedDoneColumns.length === status.length
 
   useEffect(() => {
-    setSelectedDoneStatuses([])
+    setSelectedDoneStatus([])
   }, [selectedBoardColumns])
 
   const handleRealDoneChange = (event: SelectChangeEvent<string[]>) => {
     const value = event.target.value
     if (value[value.length - 1] === 'All') {
-      setSelectedDoneStatuses(selectedDoneStatuses.length === statuses.length ? [] : statuses)
-      dispatch(saveDoneColumn(selectedDoneStatuses.length === statuses.length ? [] : statuses))
+      setSelectedDoneStatus(selectedDoneStatus.length === status.length ? [] : status)
+      dispatch(saveDoneColumn(selectedDoneStatus.length === status.length ? [] : status))
       return
     }
-    setSelectedDoneStatuses([...value])
+    setSelectedDoneStatus([...value])
     dispatch(saveDoneColumn([...value]))
   }
 
@@ -66,7 +66,7 @@ export const RealDone = ({ columns, title, label }: realDoneProps) => {
             <Checkbox checked={isAllSelected} />
             <ListItemText primary='All' />
           </MenuItem>
-          {statuses.map((column) => {
+          {status.map((column) => {
             const isChecked = savedDoneColumns.includes(column)
             return (
               <MenuItem key={column} value={column}>

--- a/frontend/src/components/Metrics/MetricsStepper/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStepper/index.tsx
@@ -46,7 +46,7 @@ const MetricsStepper = () => {
   const { metrics, projectName, dateRange } = config.basic
 
   const selectedBoardColumns = useAppSelector(selectBoardColumns)
-  const isPipelineVerified = (type: string) => {
+  const verifyPipeline = (type: string) => {
     const pipelines =
       type === PIPELINE_SETTING_TYPES.LEAD_TIME_FOR_CHANGES_TYPE
         ? metricsConfig.leadTimeForChanges
@@ -59,32 +59,33 @@ const MetricsStepper = () => {
     isShowBoard && selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2
   const isShowDeploymentFrequency = isShowPipeline
   const isShowLeadTimeForChanges = isShowPipeline && isShowSourceControl
-  const isCrewsSettingVerified = metricsConfig.users.length > 0
-  const isRealDoneVerified = metricsConfig.doneColumn.length > 0
-  const isDeploymentFrequencyVerified = isPipelineVerified(PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE)
-  const isLeadTimeForChangesVerified = isPipelineVerified(PIPELINE_SETTING_TYPES.LEAD_TIME_FOR_CHANGES_TYPE)
+  const isCrewsSettingValid = metricsConfig.users.length > 0
+  const isRealDoneValid = metricsConfig.doneColumn.length > 0
+  const isDeploymentFrequencyValid = verifyPipeline(PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE)
+  const isLeadTimeForChangesValid = verifyPipeline(PIPELINE_SETTING_TYPES.LEAD_TIME_FOR_CHANGES_TYPE)
 
   useEffect(() => {
     if (!activeStep) {
-      const hasMetrics = metrics.length
-      const showNextButtonParams = [
-        { key: isShowBoard, value: isBoardVerified },
-        { key: isShowPipeline, value: isPipelineToolVerified },
-        { key: isShowSourceControl, value: isSourceControlVerified },
+      const nextButtonValidityOptions = [
+        { isShow: isShowBoard, isValid: isBoardVerified },
+        { isShow: isShowPipeline, isValid: isPipelineToolVerified },
+        { isShow: isShowSourceControl, isValid: isSourceControlVerified },
       ]
-      const activeParams = showNextButtonParams.filter(({ key }) => key)
-      projectName && dateRange.startDate && dateRange.endDate && hasMetrics
-        ? setIsDisableNextButton(!activeParams.every(({ value }) => value))
+      const activeNextButtonValidityOptions = nextButtonValidityOptions.filter(({ isShow }) => isShow)
+      projectName && dateRange.startDate && dateRange.endDate && metrics.length
+        ? setIsDisableNextButton(!activeNextButtonValidityOptions.every(({ isValid }) => isValid))
         : setIsDisableNextButton(true)
     } else if (activeStep === 1) {
-      const showNextButtonParams = [
-        { key: isShowCrewsSetting, value: isCrewsSettingVerified },
-        { key: isShowRealDone, value: isRealDoneVerified },
-        { key: isShowDeploymentFrequency, value: isDeploymentFrequencyVerified },
-        { key: isShowLeadTimeForChanges, value: isLeadTimeForChangesVerified },
+      const nextButtonValidityOptions = [
+        { isShow: isShowCrewsSetting, isValid: isCrewsSettingValid },
+        { isShow: isShowRealDone, isValid: isRealDoneValid },
+        { isShow: isShowDeploymentFrequency, isValid: isDeploymentFrequencyValid },
+        { isShow: isShowLeadTimeForChanges, isValid: isLeadTimeForChangesValid },
       ]
-      const activeParams = showNextButtonParams.filter(({ key }) => key)
-      activeParams.every(({ value }) => value) ? setIsDisableNextButton(false) : setIsDisableNextButton(true)
+      const activeNextButtonValidityOptions = nextButtonValidityOptions.filter(({ isShow }) => isShow)
+      activeNextButtonValidityOptions.every(({ isValid }) => isValid)
+        ? setIsDisableNextButton(false)
+        : setIsDisableNextButton(true)
     }
   }, [
     activeStep,

--- a/frontend/src/hooks/useMetricsStepValidationCheckContext.tsx
+++ b/frontend/src/hooks/useMetricsStepValidationCheckContext.tsx
@@ -23,6 +23,9 @@ interface ProviderContextType {
     type: string
   ) => void
   isPipelineValid: (type: string) => boolean
+  getDuplicatedPipeLineIds: (
+    pipelineSettings: { id: number; organization: string; pipelineName: string; step: string }[]
+  ) => number[]
 }
 
 interface ContextProviderProps {
@@ -35,6 +38,7 @@ export const ValidationContext = createContext<ProviderContextType>({
   clearErrorMessage: () => null,
   checkDuplicatedPipeline: () => null,
   isPipelineValid: () => false,
+  getDuplicatedPipeLineIds: () => [],
 })
 
 const emptyErrorMessages = {
@@ -160,6 +164,7 @@ export const ContextProvider = ({ children }: ContextProviderProps) => {
         clearErrorMessage,
         checkDuplicatedPipeline,
         isPipelineValid,
+        getDuplicatedPipeLineIds,
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
Only when all mandatory data in metrics page is filled, Next button is active, and users can click it to step into report page
card link: https://trello.com/c/Ko2O9LUV

## Before
<img width="1262" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/89b70a5c-7d57-4b57-a7d3-c13025706914">
Next button is always active

## After
<img width="1444" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/d5caacbd-f43b-43a0-9258-95d8bb32451d">
<img width="1366" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/5c345308-79f0-479b-b18b-2a49c6e825f8">
Next button is active only when all mandatory data in metrics page is filled
 
## Note

_Null_
