### PR TITLE
ADM-466 [frontend] Remove Crew setting and Real done in metrics page

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
@@ -28,7 +28,8 @@ const setup = () =>
   )
 
 describe('MetricsStep', () => {
-  it('should render Crews and Real Done components', () => {
+  it('should render Crews and Real Done components when select velocity', async () => {
+    await store.dispatch(updateMetrics([REQUIRED_DATA_LIST[1]]))
     const { getByText, queryByText } = setup()
 
     expect(getByText(CREWS_SETTING)).toBeInTheDocument()
@@ -44,7 +45,8 @@ describe('MetricsStep', () => {
     expect(getByText(CYCLE_TIME_SETTINGS)).toBeInTheDocument()
   })
 
-  it('should show Real Done when selectedColumns include done column', async () => {
+  it('should show Real Done when select velocity and selectedColumns include done column', async () => {
+    await store.dispatch(updateMetrics([REQUIRED_DATA_LIST[1]]))
     const mockColumnsList = [
       {
         key: 'done',

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -15,19 +15,32 @@ export const MetricsStep = () => {
   const jiraColumns = useAppSelector(selectJiraColumns)
   const targetFields = useAppSelector(selectTargetFields)
   const selectedBoardColumns = useAppSelector(selectBoardColumns)
+  const isShowCrewsAndRealDone =
+    requiredData.includes(REQUIRED_DATA.VELOCITY) ||
+    requiredData.includes(REQUIRED_DATA.CYCLE_TIME) ||
+    requiredData.includes(REQUIRED_DATA.CLASSIFICATION)
+
   return (
     <>
-      <Crews options={users} title={'Crews setting'} label={'Included Crews'} />
+      {isShowCrewsAndRealDone && <Crews options={users} title={'Crews setting'} label={'Included Crews'} />}
+
       {requiredData.includes(REQUIRED_DATA.CYCLE_TIME) && (
         <CycleTime columns={jiraColumns} title={'Cycle time settings'} />
       )}
-      {selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2 && (
-        <RealDone columns={jiraColumns} title={'Real done'} label={'Consider as Done'} />
-      )}
+
+      {isShowCrewsAndRealDone &&
+        selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2 && (
+          <RealDone columns={jiraColumns} title={'Real done'} label={'Consider as Done'} />
+        )}
+
       {requiredData.includes(REQUIRED_DATA.CLASSIFICATION) && (
         <Classification options={targetFields} title={'Classification setting'} label={'Distinguished By'} />
       )}
-      {requiredData.includes(REQUIRED_DATA.DEPLOYMENT_FREQUENCY) && <DeploymentFrequencySettings />}
+
+      {(requiredData.includes(REQUIRED_DATA.DEPLOYMENT_FREQUENCY) ||
+        requiredData.includes(REQUIRED_DATA.CHANGE_FAILURE_RATE) ||
+        requiredData.includes(REQUIRED_DATA.MEAN_TIME_TO_RECOVERY)) && <DeploymentFrequencySettings />}
+
       {requiredData.includes(REQUIRED_DATA.LEAD_TIME_FOR_CHANGES) && <LeadTimeForChanges />}
     </>
   )

--- a/frontend/src/components/Metrics/MetricsStepper/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStepper/index.tsx
@@ -58,7 +58,10 @@ const MetricsStepper = () => {
   const isShowCrewsSetting = isShowBoard
   const isShowRealDone =
     isShowBoard && selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2
-  const isShowDeploymentFrequency = requiredData.includes(REQUIRED_DATA.DEPLOYMENT_FREQUENCY)
+  const isShowDeploymentFrequency =
+    requiredData.includes(REQUIRED_DATA.DEPLOYMENT_FREQUENCY) ||
+    requiredData.includes(REQUIRED_DATA.CHANGE_FAILURE_RATE) ||
+    requiredData.includes(REQUIRED_DATA.MEAN_TIME_TO_RECOVERY)
   const isShowLeadTimeForChanges = requiredData.includes(REQUIRED_DATA.LEAD_TIME_FOR_CHANGES)
   const isCrewsSettingValid = metricsConfig.users.length > 0
   const isRealDoneValid = metricsConfig.doneColumn.length > 0


### PR DESCRIPTION
## Summary

1. Remove Crew setting and Real done in metrics page for:
    - LeadTime for changes
    - Change failure rate
    - Deployment frequency
    - MTTR

2. When select Change failure rate and MTTR, it will show Deployment frequency settings component in metrics page.

## Screenshots

### Issue1

 **Before**
<img width="1146" alt="Screenshot 2023-05-12 at 13 49 04" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/aa5f060f-e7d6-454e-843d-6319154d2e2f">

 **After**
<img width="1192" alt="Screenshot 2023-05-12 at 13 45 28" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/3365f5bd-3ca9-453f-8be7-9af3625235c4">

### Issue2
 **Before**
<img width="1117" alt="Screenshot 2023-05-12 at 13 53 19" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/383babfe-442d-48f7-9fe5-bf72caceec97">

 **After**
<img width="1121" alt="Screenshot 2023-05-12 at 13 53 37" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/9980ba8b-6c78-4eb2-8773-4f75f32eef8b">
