### PR TITLE
ADM-428 [Frontend] fix import feature in config file

### DIFF
--- a/frontend/cypress/fixtures/ConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/ConfigFileForImporting.json
@@ -6,7 +6,7 @@
     "endDate": "2023-03-30T23:59:59.999+08:00"
   },
   "calendarType": "Calendar with Chinese Holiday",
-  "boardConfig": {
+  "board": {
     "type": "Classic Jira",
     "verifyToken": "mockVerifyToken",
     "boardId": "1963",
@@ -15,12 +15,12 @@
     "email": "test@test.com",
     "projectKey": "PLL"
   },
-  "pipelineConfig": "mockToken",
-  "pipelineToolConfig": {
+  "pipeline": "mockToken",
+  "pipelineTool": {
     "type": "BuildKite",
     "token": "mockToken"
   },
-  "sourceControlConfig": {
+  "sourceControl": {
     "type": "GitHub",
     "token": ""
   },

--- a/frontend/cypress/plugins/updateConfigJson.ts
+++ b/frontend/cypress/plugins/updateConfigJson.ts
@@ -11,7 +11,7 @@ function generateTestData() {
   fs.readFile(configJsonFilePath, (err, data) => {
     if (err) throw err
     const mockedImportConfigJSON = JSON.parse(data.toString())
-    mockedImportConfigJSON.sourceControlConfig.token = `ghp_${'Abc123'.repeat(6)}`
+    mockedImportConfigJSON.sourceControl.token = `ghp_${'Abc123'.repeat(6)}`
 
     fs.writeFile(configJsonFilePath, JSON.stringify(mockedImportConfigJSON, null, 2), (e) => {
       console.error(e)

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -84,9 +84,9 @@ export const configSlice = createSlice({
     },
     updateBasicConfigState: (state, action) => {
       state.basic = action.payload
-      state.board.config = action.payload.boardConfig || state.board.config
-      state.pipelineTool.config = action.payload.pipelineToolConfig || state.pipelineTool.config
-      state.sourceControl.config = action.payload.sourceControlConfig || state.sourceControl.config
+      state.board.config = action.payload.board || state.board.config
+      state.pipelineTool.config = action.payload.pipelineTool || state.pipelineTool.config
+      state.sourceControl.config = action.payload.sourceControl || state.sourceControl.config
     },
     updateProjectCreatedState: (state, action) => {
       state.isProjectCreated = action.payload


### PR DESCRIPTION
## Summary
fix import feature in config page: when import a json file, it failed to render data in board, pipelineTool and sourceControl

## Before
<img width="1212" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/09711ad2-d493-458c-a02e-b26b6a114c3f">


## After
<img width="1257" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/e11730c7-3744-45bd-922d-4697913f17c6">

