### PR TITLE
ADM-455 Value in classification disappear after being back to metrics page from report page

### DIFF
--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -13,6 +13,7 @@ import saveMetricsSettingReducer, {
   initDeploymentFrequencySettings,
   initLeadTimeForChanges,
   updateTreatFlagCardAsBlock,
+  updateClassification,
 } from '@src/context/Metrics/metricsSlice'
 import { store } from '@src/store'
 
@@ -106,6 +107,13 @@ describe('saveMetricsSetting reducer', () => {
     )
 
     expect(savedMetricsSetting.boardColumns).toEqual(mockSavedBoardColumns)
+  })
+
+  it('should update classification settings when its value changed given initial state', () => {
+    const mockClassification = ['classification1', 'classification2']
+    const savedMetricsSetting = saveMetricsSettingReducer(initState, updateClassification(mockClassification))
+
+    expect(savedMetricsSetting.classification).toEqual(mockClassification)
   })
 
   it('should update deploymentFrequencySettings when handle updateDeploymentFrequencySettings given initial state', () => {

--- a/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
@@ -1,7 +1,7 @@
 import { Checkbox, FormControl, InputLabel, MenuItem, Select, ListItemText, SelectChangeEvent } from '@mui/material'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { saveTargetFields, selectMetricsContent } from '@src/context/Metrics/metricsSlice'
+import { saveTargetFields, selectMetricsContent, updateClassification } from '@src/context/Metrics/metricsSlice'
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle'
 import { SELECTED_VALUE_SEPARATOR } from '@src/constants'
 import { useAppSelector } from '@src/hooks'
@@ -21,7 +21,7 @@ export const Classification = ({ options, title, label }: classificationProps) =
   const optionsName = options.map((e) => e.name)
 
   const defaultInput = getArrayIntersection(optionsName, importClassification)
-  const [selectedTargetField, setSelectedTargetField] = useState(isProjectCreated ? [] : defaultInput)
+  const [selectedTargetField, setSelectedTargetField] = useState(defaultInput)
   const isAllSelected = selectedTargetField.length > 0 && selectedTargetField.length === options.length
 
   const handleTargetFieldChange = (event: SelectChangeEvent<string[]>) => {
@@ -29,18 +29,17 @@ export const Classification = ({ options, title, label }: classificationProps) =
     const targetFieldNames = options.map((item) => item.name)
     if (value[value.length - 1] === 'All') {
       setSelectedTargetField(isAllSelected ? [] : targetFieldNames)
+      dispatch(updateClassification(isAllSelected ? [] : targetFieldNames))
       return
     }
     setSelectedTargetField([...value])
-  }
-
-  useEffect(() => {
+    dispatch(updateClassification(value))
     const updatedTargetFields = options.map((option) => ({
       ...option,
       flag: selectedTargetField.includes(option.name),
     }))
     dispatch(saveTargetFields(updatedTargetFields))
-  }, [selectedTargetField, dispatch, options])
+  }
 
   return (
     <>

--- a/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControl, InputLabel, MenuItem, Select, ListItemText, SelectChangeEvent } from '@mui/material'
+import { Checkbox, FormControl, InputLabel, ListItemText, MenuItem, Select, SelectChangeEvent } from '@mui/material'
 import React, { useState } from 'react'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
 import { saveTargetFields, selectMetricsContent, updateClassification } from '@src/context/Metrics/metricsSlice'
@@ -16,28 +16,24 @@ interface classificationProps {
 
 export const Classification = ({ options, title, label }: classificationProps) => {
   const dispatch = useAppDispatch()
-  const importClassification = useAppSelector(selectMetricsContent).classification
   const isProjectCreated = useAppSelector(selectMetricsContent).isProjectCreated
-  const optionsName = options.map((e) => e.name)
-
-  const defaultInput = getArrayIntersection(optionsName, importClassification)
-  const [selectedTargetField, setSelectedTargetField] = useState(defaultInput)
-  const isAllSelected = selectedTargetField.length > 0 && selectedTargetField.length === options.length
+  const importClassification = useAppSelector(selectMetricsContent).classification
+  const targetFieldNames = options.map((e) => e.name)
+  const [selectedClassification, setSelectedClassification] = useState(
+    getArrayIntersection(targetFieldNames, importClassification)
+  )
+  const isAllSelected = selectedClassification.length > 0 && selectedClassification.length === options.length
 
   const handleTargetFieldChange = (event: SelectChangeEvent<string[]>) => {
     const value = event.target.value
-    const targetFieldNames = options.map((item) => item.name)
-    if (value[value.length - 1] === 'All') {
-      setSelectedTargetField(isAllSelected ? [] : targetFieldNames)
-      dispatch(updateClassification(isAllSelected ? [] : targetFieldNames))
-      return
-    }
-    setSelectedTargetField([...value])
-    dispatch(updateClassification(value))
+    const classificationSettings =
+      value[value.length - 1] === 'All' ? (isAllSelected ? [] : targetFieldNames) : [...value]
     const updatedTargetFields = options.map((option) => ({
       ...option,
-      flag: selectedTargetField.includes(option.name),
+      flag: selectedClassification.includes(option.name),
     }))
+    setSelectedClassification(classificationSettings)
+    dispatch(updateClassification(classificationSettings))
     dispatch(saveTargetFields(updatedTargetFields))
   }
 
@@ -54,7 +50,7 @@ export const Classification = ({ options, title, label }: classificationProps) =
         <Select
           multiple
           labelId='classification-check-box'
-          value={selectedTargetField}
+          value={selectedClassification}
           onChange={handleTargetFieldChange}
           renderValue={(selectedTargetField: string[]) => selectedTargetField.join(SELECTED_VALUE_SEPARATOR)}
         >
@@ -64,7 +60,7 @@ export const Classification = ({ options, title, label }: classificationProps) =
           </MenuItem>
           {options.map((targetField) => (
             <MenuItem key={targetField.key} value={targetField.name}>
-              <Checkbox checked={selectedTargetField.includes(targetField.name)} />
+              <Checkbox checked={selectedClassification.includes(targetField.name)} />
               <ListItemText primary={targetField.name} />
             </MenuItem>
           ))}

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -52,7 +52,9 @@ export const metricsSlice = createSlice({
     saveBoardColumns: (state, action) => {
       state.boardColumns = action.payload
     },
-
+    updateClassification: (state, action) => {
+      state.classification = action.payload
+    },
     addADeploymentFrequencySetting: (state) => {
       const newId = state.deploymentFrequencySettings[state.deploymentFrequencySettings.length - 1].id + 1
       state.deploymentFrequencySettings = [
@@ -134,6 +136,7 @@ export const {
   saveDoneColumn,
   saveUsers,
   saveBoardColumns,
+  updateClassification,
   addADeploymentFrequencySetting,
   updateDeploymentFrequencySettings,
   deleteADeploymentFrequencySetting,


### PR DESCRIPTION
## Summary

fix classification settings information disappear after being back to metrics page from report page

## Before
set information in classification:
<img width="1131" alt="before-20230427-084206" src="https://github.com/au-heartbeat/Heartbeat/assets/112381997/1ff150fe-a4f6-4e03-b757-7bb297baa2c6">
skip to next page and back:
<img width="1131" alt="after-20230427-084205" src="https://github.com/au-heartbeat/Heartbeat/assets/112381997/1871128c-fb42-443a-8c4b-f36d3498b9ad">

## After
set information in classification:
![Screen Shot 2023-05-16 at 14 18 06](https://github.com/au-heartbeat/Heartbeat/assets/112381997/b747cf67-1447-4422-b5fe-cd2818b2f5d2)

skip to next page and back:
![Screen Shot 2023-05-16 at 14 18 15](https://github.com/au-heartbeat/Heartbeat/assets/112381997/7e1d91bd-a835-4e98-a622-32099549c587)

