### PR TITLE
ADM-428: fix bugs when config.json file is broken

### DIFF
--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -104,12 +104,12 @@ export const metricsSlice = createSlice({
     updateMetricsState: (state, action) => {
       const { targetFields, users, jiraColumns, isProjectCreated } = action.payload
       const { importedCrews, importedClassification, importedCycleTime } = state.importedData
-      state.users = isProjectCreated ? users : users?.filter((item: string) => importedCrews.includes(item))
+      state.users = isProjectCreated ? users : users?.filter((item: string) => importedCrews?.includes(item))
       state.targetFields = isProjectCreated
         ? []
         : targetFields?.map((item: { name: string; key: string; flag: boolean }) => ({
             ...item,
-            flag: importedClassification.includes(item.key),
+            flag: importedClassification?.includes(item.key),
           }))
       state.cycleTimeSettings = jiraColumns?.map(
         (item: { key: string; value: { name: string; statuses: string[] } }) => {


### PR DESCRIPTION
## Summary

when imported json file is broken, for example: classification or crews have been deleted, it will affect display in metrics page

## Before
<img width="719" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/1fc0a57a-75f5-4f38-a022-7fe52e9a272f">
<img width="1112" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/1d74f207-e4bf-4e12-8f6a-a2419a02daa3">


## After

<img width="1147" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/eaedfd56-8bc4-4adf-a21c-4ca4ef16f49a">

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
