### PR TITLE
ADM-452 Data import validation for the cycleTime and classification section

### DIFF
--- a/frontend/__tests__/src/components/HomeGuide/HomeGuide.test.tsx
+++ b/frontend/__tests__/src/components/HomeGuide/HomeGuide.test.tsx
@@ -2,12 +2,7 @@ import { HomeGuide } from '@src/components/HomeGuide'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { setupStore } from '../../utils/setupStoreUtil'
 import { Provider } from 'react-redux'
-import {
-  CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE,
-  CREATE_NEW_PROJECT,
-  IMPORTED_CONFIG_FIXTURE,
-  IMPORT_PROJECT_FROM_FILE,
-} from '../../fixtures'
+import { CREATE_NEW_PROJECT, IMPORT_PROJECT_FROM_FILE, IMPORTED_CONFIG_FIXTURE } from '../../fixtures'
 import userEvent from '@testing-library/user-event'
 import { navigateMock } from '../../../setupTests'
 
@@ -28,9 +23,6 @@ const setup = () => {
     </Provider>
   )
 }
-
-const copied = () => JSON.parse(JSON.stringify(IMPORTED_CONFIG_FIXTURE))
-
 describe('HomeGuide', () => {
   beforeEach(() => {
     store = setupStore()
@@ -84,69 +76,5 @@ describe('HomeGuide', () => {
 
     expect(navigateMock).toHaveBeenCalledTimes(1)
     expect(navigateMock).toHaveBeenCalledWith('/metrics')
-  })
-
-  describe('Test invalid config', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { projectName, ...noProjectNameConfig } = IMPORTED_CONFIG_FIXTURE
-
-    const noStartDateConfig = copied()
-    noStartDateConfig.dateRange.startDate = ''
-
-    const noEndDateConfig = copied()
-    noEndDateConfig.dateRange.endDate = ''
-
-    const noMetricsConfig = copied()
-    noMetricsConfig.metrics = []
-
-    it.each([
-      ['noProjectNameConfig', noProjectNameConfig],
-      ['noStartDateConfig', noStartDateConfig],
-      ['noEndDateConfig', noEndDateConfig],
-      ['noMetricsConfig', noMetricsConfig],
-    ])(
-      'should show error message when import project from file given file does not contain %s field',
-      async (_, config) => {
-        const { getByTestId, queryByText } = setup()
-
-        const file = new File([`${JSON.stringify(config)}`], 'test.json', {
-          type: 'file',
-        })
-        const input = getByTestId('testInput')
-
-        Object.defineProperty(input, 'files', {
-          value: [file],
-        })
-
-        fireEvent.change(input)
-
-        await waitFor(() => {
-          expect(mockedUseAppDispatch).toHaveBeenCalledTimes(0)
-          expect(queryByText(CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE)).toBeInTheDocument()
-        })
-      }
-    )
-  })
-
-  it('should show error message when import given invalid json', async () => {
-    const invalidConfig = JSON.stringify(IMPORTED_CONFIG_FIXTURE).slice(0, -1)
-
-    const { getByTestId, queryByText } = setup()
-
-    const file = new File([invalidConfig], 'test.json', {
-      type: 'file',
-    })
-    const input = getByTestId('testInput')
-
-    Object.defineProperty(input, 'files', {
-      value: [file],
-    })
-
-    fireEvent.change(input)
-
-    await waitFor(() => {
-      expect(mockedUseAppDispatch).toHaveBeenCalledTimes(0)
-      expect(queryByText(CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE)).toBeInTheDocument()
-    })
   })
 })

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
@@ -1,9 +1,10 @@
-import { fireEvent, Matcher, render, waitFor, within } from '@testing-library/react'
+import { act, fireEvent, Matcher, render, waitFor, within } from '@testing-library/react'
 import { ConfigStep } from '@src/components/Metrics/ConfigStep'
 import {
   CHINA_CALENDAR,
   CONFIG_TITLE,
   CYCLE_TIME,
+  ERROR_MESSAGE_TIME_DURATION,
   PROJECT_NAME_LABEL,
   REGULAR_CALENDAR,
   REQUIRED_DATA,
@@ -16,8 +17,6 @@ import { Provider } from 'react-redux'
 import { setupStore } from '../../../utils/setupStoreUtil'
 import dayjs from 'dayjs'
 import { fillBoardFieldsInformation } from './Board.test'
-import { act } from 'react-dom/test-utils'
-import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
 
 let store = null
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, Matcher, render, waitFor, within } from '@testing-library/react'
+import { fireEvent, Matcher, render, waitFor, within } from '@testing-library/react'
 import { ConfigStep } from '@src/components/Metrics/ConfigStep'
 import {
   CHINA_CALENDAR,
@@ -16,6 +16,7 @@ import { Provider } from 'react-redux'
 import { setupStore } from '../../../utils/setupStoreUtil'
 import dayjs from 'dayjs'
 import { fillBoardFieldsInformation } from './Board.test'
+import { act } from 'react-dom/test-utils'
 import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
 
 let store = null
@@ -23,7 +24,6 @@ jest.mock('@src/context/config/configSlice', () => ({
   ...jest.requireActual('@src/context/config/configSlice'),
   selectWarningMessage: jest.fn().mockReturnValue('Test warning Message'),
 }))
-jest.useFakeTimers()
 describe('ConfigStep', () => {
   const setup = () => {
     store = setupStore()
@@ -34,9 +34,14 @@ describe('ConfigStep', () => {
     )
   }
 
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
   afterEach(() => {
     store = null
     jest.clearAllMocks()
+    jest.useRealTimers()
   })
 
   it('should show project name when render configStep', () => {
@@ -163,11 +168,12 @@ describe('ConfigStep', () => {
     expect(queryByText(RESET)).toBeNull()
   })
 
-  it('should show warning message when selectWarningMessage has a value', () => {
+  it('should show warning message when selectWarningMessage has a value', async () => {
     const { getByText } = setup()
 
     expect(getByText('Test warning Message')).toBeVisible()
   })
+
   it('should show disable warning message When selectWarningMessage has a value after two seconds', async () => {
     const { queryByText } = setup()
 

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/Classification.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/Classification.test.tsx
@@ -3,6 +3,7 @@ import { Classification } from '@src/components/Metrics/MetricsStep/Classificati
 import userEvent from '@testing-library/user-event'
 import { setupStore } from '../../../utils/setupStoreUtil'
 import { Provider } from 'react-redux'
+import { ERROR_MESSAGE_TIME_DURATION } from '../../../fixtures'
 
 const mockTitle = 'Classification Setting'
 const mockLabel = 'Distinguished by'
@@ -14,6 +15,11 @@ const mockTargetFields = [
 jest.mock('@src/context/config/configSlice', () => ({
   ...jest.requireActual('@src/context/config/configSlice'),
   selectIsProjectCreated: jest.fn().mockReturnValue(false),
+}))
+
+jest.mock('@src/context/Metrics/metricsSlice', () => ({
+  ...jest.requireActual('@src/context/Metrics/metricsSlice'),
+  selectClassificationWarningMessage: jest.fn().mockReturnValue('Test warning Message'),
 }))
 
 let store = setupStore()
@@ -85,5 +91,19 @@ describe('Classification', () => {
 
     expect(listBox.getByRole('option', { name: names[0] })).toHaveProperty('selected', true)
     expect(listBox.getByRole('option', { name: names[1] })).toHaveProperty('selected', false)
+  })
+
+  it('should show warning message when classification warning message has a value in cycleTime component', () => {
+    const { getByText } = setup()
+
+    expect(getByText('Test warning Message')).toBeVisible()
+  })
+
+  it('should show disable warning message when classification warning message has a value after two seconds in cycleTime component', async () => {
+    const { queryByText } = setup()
+
+    setTimeout(() => {
+      expect(queryByText('Test warning Message')).not.toBeInTheDocument()
+    }, ERROR_MESSAGE_TIME_DURATION)
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
@@ -30,6 +30,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
       },
     ],
   }),
+  selectWarningMessage: jest.fn().mockReturnValue('Test warning Message'),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({
@@ -164,5 +165,19 @@ describe('CycleTime', () => {
 
       expect(queryByText(errorMessage)).not.toBeInTheDocument()
     })
+  })
+
+  it('should show warning message when selectWarningMessage has a value in cycleTime component', async () => {
+    const { getByText } = setup()
+
+    expect(getByText('Test warning Message')).toBeVisible()
+  })
+
+  it('should show disable warning message When selectWarningMessage has a value after two seconds in cycleTime component', async () => {
+    const { queryByText } = setup()
+
+    setTimeout(() => {
+      expect(queryByText('Test warning Message')).not.toBeInTheDocument()
+    }, 2000)
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
@@ -30,7 +30,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
       },
     ],
   }),
-  selectWarningMessage: jest.fn().mockReturnValue('Test warning Message'),
+  selectCycleTimeWarningMessage: jest.fn().mockReturnValue('Test warning Message'),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({
@@ -167,13 +167,13 @@ describe('CycleTime', () => {
     })
   })
 
-  it('should show warning message when selectWarningMessage has a value in cycleTime component', async () => {
+  it('should show warning message when selectWarningMessage has a value in cycleTime component', () => {
     const { getByText } = setup()
 
     expect(getByText('Test warning Message')).toBeVisible()
   })
 
-  it('should show disable warning message When selectWarningMessage has a value after two seconds in cycleTime component', async () => {
+  it('should show disable warning message when selectWarningMessage has a value after two seconds in cycleTime component', () => {
     const { queryByText } = setup()
 
     setTimeout(() => {

--- a/frontend/__tests__/src/context/configSlice.test.ts
+++ b/frontend/__tests__/src/context/configSlice.test.ts
@@ -1,10 +1,10 @@
 import configReducer, {
+  updateBasicConfigState,
   updateCalendarType,
   updateDateRange,
-  updateProjectName,
   updateMetrics,
-  updateBasicConfigState,
   updateProjectCreatedState,
+  updateProjectName,
 } from '@src/context/config/configSlice'
 import { CHINA_CALENDAR, MOCK_IMPORT_FILE, REGULAR_CALENDAR, VELOCITY } from '../fixtures'
 import initialConfigState from '../initialConfigState'
@@ -55,5 +55,23 @@ describe('config reducer', () => {
     const config = configReducer(initialConfigState, updateMetrics([VELOCITY])).basic
 
     expect(config.metrics).toEqual([VELOCITY])
+  })
+
+  it('should set warningMessage is null when projectName startDate endDate and metrics data is null', () => {
+    const action = {
+      type: 'config/updateBasicConfigState',
+      payload: {
+        projectName: 'Test Project',
+        dateRange: {
+          startDate: new Date(),
+          endDate: new Date(),
+        },
+        metrics: ['Metric 1', 'Metric 2'],
+      },
+    }
+
+    const config = configReducer(initialConfigState, action)
+
+    expect(config.warningMessage).toBeNull()
   })
 })

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -352,7 +352,6 @@ describe('saveMetricsSetting reducer', () => {
     expect(savedMetricsSetting.treatFlagCardAsBlock).toBe(false)
   })
 
-  //当导入的文件中的key值比response中的值多时,说明现在这个列被删除了
   it('should set warningMessage have value when there are more values in the import file than in the response', () => {
     const mockUpdateMetricsStateArguments = {
       ...mockJiraResponse,
@@ -377,8 +376,7 @@ describe('saveMetricsSetting reducer', () => {
     )
   })
 
-  //当导入文件中的key值比response中的值少时，说明是新增列
-  it('should set warningMessage is null when When the values in the import file are less than those in the response', () => {
+  it('should set warningMessage have value when the values in the import file are less than those in the response', () => {
     const mockUpdateMetricsStateArguments = {
       ...mockJiraResponse,
       isProjectCreated: false,
@@ -426,21 +424,9 @@ describe('saveMetricsSetting reducer', () => {
     )
   })
 
-  it('should set warningMessage have value when the key value in the imported file matches the value in the response and the value matches the fixed column', () => {
-    const mockJiraResponse1 = {
-      ...mockJiraResponse,
-      jiraColumns: [
-        {
-          key: 'indeterminate',
-          value: {
-            name: 'Testing',
-            statuses: ['TESTING'],
-          },
-        },
-      ],
-    }
+  it('should set warningMessage null when the key value in the imported file matches the value in the response and the value matches the fixed column', () => {
     const mockUpdateMetricsStateArguments = {
-      ...mockJiraResponse1,
+      ...mockJiraResponse,
       isProjectCreated: false,
     }
     const savedMetricsSetting = saveMetricsSettingReducer(
@@ -449,7 +435,7 @@ describe('saveMetricsSetting reducer', () => {
         importedData: {
           ...initState.importedData,
           importedCycleTime: {
-            importedCycleTimeSettings: [{ Testing: 'Analysis' }],
+            importedCycleTimeSettings: [{ Testing: 'Testing' }, { Doing: 'done' }],
             importedTreatFlagCardAsBlock: true,
           },
         },

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -39,7 +39,8 @@ const initState = {
     importedDeployment: [],
     importedLeadTime: [],
   },
-  warningMessage: null,
+  cycleTimeWarningMessage: null,
+  classificationWarningMessage: null,
 }
 
 const mockJiraResponse = {
@@ -371,7 +372,7 @@ describe('saveMetricsSetting reducer', () => {
       updateMetricsState(mockUpdateMetricsStateArguments)
     )
 
-    expect(savedMetricsSetting.warningMessage).toEqual(
+    expect(savedMetricsSetting.cycleTimeWarningMessage).toEqual(
       'The column of ToDo is a deleted column, which means this column existed the time you saved config, but was deleted. Please confirm!'
     )
   })
@@ -395,7 +396,7 @@ describe('saveMetricsSetting reducer', () => {
       updateMetricsState(mockUpdateMetricsStateArguments)
     )
 
-    expect(savedMetricsSetting.warningMessage).toEqual(
+    expect(savedMetricsSetting.cycleTimeWarningMessage).toEqual(
       'The column of Testing is a new column. Please select a value for it!'
     )
   })
@@ -419,7 +420,7 @@ describe('saveMetricsSetting reducer', () => {
       updateMetricsState(mockUpdateMetricsStateArguments)
     )
 
-    expect(savedMetricsSetting.warningMessage).toEqual(
+    expect(savedMetricsSetting.cycleTimeWarningMessage).toEqual(
       'The value of Doing in imported json is not in dropdown list now. Please select a value for it!'
     )
   })
@@ -443,6 +444,47 @@ describe('saveMetricsSetting reducer', () => {
       updateMetricsState(mockUpdateMetricsStateArguments)
     )
 
-    expect(savedMetricsSetting.warningMessage).toBeNull()
+    expect(savedMetricsSetting.cycleTimeWarningMessage).toBeNull()
+  })
+
+  //当导入的classification 值不在response中时，显示warning
+  it('should set classification warningMessage null when the key value in the imported file matches the value in the response and the value matches the fixed column', () => {
+    const mockUpdateMetricsStateArguments = {
+      ...mockJiraResponse,
+      isProjectCreated: false,
+    }
+    const savedMetricsSetting = saveMetricsSettingReducer(
+      {
+        ...initState,
+        importedData: {
+          ...initState.importedData,
+          importedClassification: ['issuetype'],
+        },
+      },
+      updateMetricsState(mockUpdateMetricsStateArguments)
+    )
+
+    expect(savedMetricsSetting.classificationWarningMessage).toBeNull()
+  })
+
+  it('should set classification warningMessage have value when the key value in the imported file matches the value in the response and the value matches the fixed column', () => {
+    const mockUpdateMetricsStateArguments = {
+      ...mockJiraResponse,
+      isProjectCreated: false,
+    }
+    const savedMetricsSetting = saveMetricsSettingReducer(
+      {
+        ...initState,
+        importedData: {
+          ...initState.importedData,
+          importedClassification: ['test'],
+        },
+      },
+      updateMetricsState(mockUpdateMetricsStateArguments)
+    )
+
+    expect(savedMetricsSetting.classificationWarningMessage).toEqual(
+      'Some classifications in import data might be removed now.'
+    )
   })
 })

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -17,6 +17,7 @@ import saveMetricsSettingReducer, {
   updateTreatFlagCardAsBlock,
 } from '@src/context/Metrics/metricsSlice'
 import { store } from '@src/store'
+import { CLASSIFICATION_WARNING_MESSAGE } from '../fixtures'
 
 const initState = {
   jiraColumns: [],
@@ -483,8 +484,6 @@ describe('saveMetricsSetting reducer', () => {
       updateMetricsState(mockUpdateMetricsStateArguments)
     )
 
-    expect(savedMetricsSetting.classificationWarningMessage).toEqual(
-      'Some classifications in import data might be removed now.'
-    )
+    expect(savedMetricsSetting.classificationWarningMessage).toEqual(CLASSIFICATION_WARNING_MESSAGE)
   })
 })

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -448,7 +448,6 @@ describe('saveMetricsSetting reducer', () => {
     expect(savedMetricsSetting.cycleTimeWarningMessage).toBeNull()
   })
 
-  //当导入的classification 值不在response中时，显示warning
   it('should set classification warningMessage null when the key value in the imported file matches the value in the response and the value matches the fixed column', () => {
     const mockUpdateMetricsStateArguments = {
       ...mockJiraResponse,

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -492,3 +492,4 @@ export const IMPORTED_CONFIG_FIXTURE = {
 }
 
 export const ERROR_MESSAGE_TIME_DURATION = 2000
+export const CLASSIFICATION_WARNING_MESSAGE = `Some classifications in import data might be removed now.`

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -490,3 +490,5 @@ export const IMPORTED_CONFIG_FIXTURE = {
     },
   ],
 }
+
+export const ERROR_MESSAGE_TIME_DURATION = 2000

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -450,6 +450,7 @@ export const EXPECTED_REPORT_VALUES = {
     },
   ],
 }
+
 export const CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE =
   'Imported data is not perfectly matched. Please review carefully before going next!'
 
@@ -493,3 +494,6 @@ export const IMPORTED_CONFIG_FIXTURE = {
 
 export const ERROR_MESSAGE_TIME_DURATION = 2000
 export const CLASSIFICATION_WARNING_MESSAGE = `Some classifications in import data might be removed now.`
+
+export const HOME_VERIFY_IMPORT_WARNING_MESSAGE =
+  'The content of the imported JSON file is empty. Please confirm carefully'

--- a/frontend/__tests__/src/initialConfigState.ts
+++ b/frontend/__tests__/src/initialConfigState.ts
@@ -52,6 +52,7 @@ const initialConfigState: BasicConfigState = {
       repoList: [],
     },
   },
+  warningMessage: '',
 }
 
 export default initialConfigState

--- a/frontend/__tests__/src/updatedConfigState.ts
+++ b/frontend/__tests__/src/updatedConfigState.ts
@@ -1,5 +1,10 @@
-import { CHINA_CALENDAR } from './fixtures'
-import { BOARD_TYPES, PIPELINE_TOOL_TYPES, SOURCE_CONTROL_TYPES } from '@src/constants'
+import {
+  BOARD_TYPES,
+  CHINA_CALENDAR,
+  CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE,
+  PIPELINE_TOOL_TYPES,
+  SOURCE_CONTROL_TYPES,
+} from './fixtures'
 
 const updatedConfigState = {
   isProjectCreated: true,
@@ -51,6 +56,7 @@ const updatedConfigState = {
       repoList: [],
     },
   },
+  warningMessage: CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE,
 }
 
 export default updatedConfigState

--- a/frontend/src/components/Common/ErrorNotificationAutoDismiss/index.tsx
+++ b/frontend/src/components/Common/ErrorNotificationAutoDismiss/index.tsx
@@ -1,17 +1,13 @@
 import { useEffect, useState } from 'react'
 import { ErrorBarAutoDismiss, StyledAlert } from './style'
 import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
-import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { updateWarningMessage } from '@src/context/config/configSlice'
 
 export const ErrorNotificationAutoDismiss = (props: { message: string }) => {
   const { message } = props
-  const dispatch = useAppDispatch()
   const [open, setOpen] = useState(true)
   useEffect(() => {
     const timer = setTimeout(() => {
       setOpen(false)
-      dispatch(updateWarningMessage(null))
     }, ERROR_MESSAGE_TIME_DURATION)
 
     return () => {

--- a/frontend/src/components/Common/ErrorNotificationAutoDismiss/index.tsx
+++ b/frontend/src/components/Common/ErrorNotificationAutoDismiss/index.tsx
@@ -1,13 +1,17 @@
 import { useEffect, useState } from 'react'
 import { ErrorBarAutoDismiss, StyledAlert } from './style'
 import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
+import { useAppDispatch } from '@src/hooks/useAppDispatch'
+import { updateWarningMessage } from '@src/context/config/configSlice'
 
 export const ErrorNotificationAutoDismiss = (props: { message: string }) => {
   const { message } = props
+  const dispatch = useAppDispatch()
   const [open, setOpen] = useState(true)
   useEffect(() => {
     const timer = setTimeout(() => {
       setOpen(false)
+      dispatch(updateWarningMessage(null))
     }, ERROR_MESSAGE_TIME_DURATION)
 
     return () => {
@@ -16,7 +20,7 @@ export const ErrorNotificationAutoDismiss = (props: { message: string }) => {
   }, [])
   return (
     <ErrorBarAutoDismiss open={open}>
-      <StyledAlert severity='error'>{message}</StyledAlert>
+      <StyledAlert severity='warning'>{message}</StyledAlert>
     </ErrorBarAutoDismiss>
   )
 }

--- a/frontend/src/components/HomeGuide/index.tsx
+++ b/frontend/src/components/HomeGuide/index.tsx
@@ -5,11 +5,9 @@ import { styled } from '@mui/material/styles'
 import { theme } from '@src/theme'
 import { useNavigate } from 'react-router-dom'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { updateProjectCreatedState, updateBasicConfigState } from '@src/context/config/configSlice'
-import React, { useState } from 'react'
+import { updateBasicConfigState, updateProjectCreatedState } from '@src/context/config/configSlice'
+import React from 'react'
 import { updateMetricsImportedData } from '@src/context/Metrics/metricsSlice'
-import { ErrorNotificationAutoDismiss } from '../Common/ErrorNotificationAutoDismiss'
-import { CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE } from '@src/constants'
 
 const basicStyle = {
   backgroundColor: theme.main.backgroundColor,
@@ -39,23 +37,7 @@ const GuideButton = styled(Button)<ButtonProps>({
 export const HomeGuide = () => {
   const navigate = useNavigate()
   const dispatch = useAppDispatch()
-  const [validConfig, setValidConfig] = useState(true)
-
   const getImportFileElement = () => document.getElementById('importJson') as HTMLInputElement
-
-  const isValidImportedConfig = (configStr: string) => {
-    try {
-      const importedConfig = JSON.parse(configStr)
-      const {
-        projectName,
-        metrics,
-        dateRange: { startDate, endDate },
-      } = importedConfig
-      return !!projectName && !!startDate && !!endDate && metrics.length > 0
-    } catch {
-      return false
-    }
-  }
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const input = e.target.files?.[0]
@@ -63,15 +45,11 @@ export const HomeGuide = () => {
     if (input) {
       reader.onload = () => {
         if (reader.result && typeof reader.result === 'string') {
-          if (isValidImportedConfig(reader.result)) {
-            dispatch(updateProjectCreatedState(false))
-            const importedConfig = JSON.parse(reader.result)
-            dispatch(updateBasicConfigState(importedConfig))
-            dispatch(updateMetricsImportedData(importedConfig))
-            navigate('/metrics')
-          } else {
-            setValidConfig(false)
-          }
+          dispatch(updateProjectCreatedState(false))
+          const importedConfig = JSON.parse(reader.result)
+          dispatch(updateBasicConfigState(importedConfig))
+          dispatch(updateMetricsImportedData(importedConfig))
+          navigate('/metrics')
         }
         const fileInput = getImportFileElement()
         fileInput.value = ''
@@ -81,7 +59,6 @@ export const HomeGuide = () => {
   }
 
   const openFileImportBox = () => {
-    setValidConfig(true)
     const fileInput = getImportFileElement()
     fileInput.click()
   }
@@ -92,7 +69,6 @@ export const HomeGuide = () => {
 
   return (
     <>
-      {!validConfig && <ErrorNotificationAutoDismiss message={CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE} />}
       <Stack direction='column' justifyContent='center' alignItems='center' flex={'auto'}>
         <GuideButton onClick={openFileImportBox}>Import project from file</GuideButton>
         <input hidden type='file' data-testid='testInput' id='importJson' accept='.json' onChange={handleChange} />

--- a/frontend/src/components/Metrics/ConfigStep/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/index.tsx
@@ -8,22 +8,26 @@ import { MetricsTypeCheckbox } from '@src/components/Metrics/ConfigStep/MetricsT
 import {
   selectCalendarType,
   selectProjectName,
+  selectWarningMessage,
   updateBoardVerifyState,
   updateCalendarType,
   updatePipelineToolVerifyState,
   updateProjectName,
   updateSourceControlVerifyState,
 } from '@src/context/config/configSlice'
+import { ErrorNotificationAutoDismiss } from '@src/components/Common/ErrorNotificationAutoDismiss'
 
 export const ConfigStep = () => {
   const dispatch = useAppDispatch()
   const projectName = useAppSelector(selectProjectName)
   const calendarType = useAppSelector(selectCalendarType)
+  const warningMessage = useAppSelector(selectWarningMessage)
 
   const [isEmptyProjectName, setIsEmptyProjectName] = useState<boolean>(false)
 
   return (
     <ConfigStepWrapper>
+      {warningMessage && <ErrorNotificationAutoDismiss message={warningMessage} />}
       <ProjectNameInput
         required
         label='Project name'

--- a/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/Classification/index.tsx
@@ -1,12 +1,13 @@
 import { Checkbox, FormControl, InputLabel, ListItemText, MenuItem, Select, SelectChangeEvent } from '@mui/material'
 import React, { useState } from 'react'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { saveTargetFields } from '@src/context/Metrics/metricsSlice'
+import { saveTargetFields, selectClassificationWarningMessage } from '@src/context/Metrics/metricsSlice'
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle'
 import { SELECTED_VALUE_SEPARATOR } from '@src/constants'
 import { useAppSelector } from '@src/hooks'
 import { WaringDone } from '@src/components/Metrics/MetricsStep/CycleTime/style'
 import { selectIsProjectCreated } from '@src/context/config/configSlice'
+import { ErrorNotificationAutoDismiss } from '@src/components/Common/ErrorNotificationAutoDismiss'
 
 interface classificationProps {
   title: string
@@ -17,6 +18,7 @@ interface classificationProps {
 export const Classification = ({ targetFields, title, label }: classificationProps) => {
   const dispatch = useAppDispatch()
   const isProjectCreated = useAppSelector(selectIsProjectCreated)
+  const classificationWarningMessage = useAppSelector(selectClassificationWarningMessage)
   const classificationSettings = targetFields
     .filter((targetField) => targetField.flag)
     .map((targetField) => targetField.name)
@@ -42,6 +44,7 @@ export const Classification = ({ targetFields, title, label }: classificationPro
   return (
     <>
       <MetricsSettingTitle title={title} />
+      {classificationWarningMessage && <ErrorNotificationAutoDismiss message={classificationWarningMessage} />}
       {!isProjectCreated && (
         <WaringDone>
           <span>Warning: Some classifications in import data might be removed now.</span>

--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
@@ -4,7 +4,11 @@ import FlagCard from '@src/components/Metrics/MetricsStep/CycleTime/FlagCard'
 import { FormSelectPart } from '@src/components/Metrics/MetricsStep/CycleTime/FormSelectPart'
 import { ErrorDone } from '@src/components/Metrics/MetricsStep/CycleTime/style'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { saveCycleTimeSettings, selectMetricsContent, selectWarningMessage } from '@src/context/Metrics/metricsSlice'
+import {
+  saveCycleTimeSettings,
+  selectCycleTimeWarningMessage,
+  selectMetricsContent,
+} from '@src/context/Metrics/metricsSlice'
 import { useAppSelector } from '@src/hooks'
 import { ErrorNotificationAutoDismiss } from '@src/components/Common/ErrorNotificationAutoDismiss'
 
@@ -16,7 +20,7 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
   const dispatch = useAppDispatch()
   const [isError, setIsError] = useState(false)
   const { cycleTimeSettings } = useAppSelector(selectMetricsContent)
-  const warningMessage = useAppSelector(selectWarningMessage)
+  const warningMessage = useAppSelector(selectCycleTimeWarningMessage)
   const [cycleTimeOptions, setCycleTimeOptions] = useState(cycleTimeSettings)
 
   const saveCycleTimeOptions = (name: string, value: string) =>
@@ -37,8 +41,8 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
 
   return (
     <>
-      {warningMessage && <ErrorNotificationAutoDismiss message={warningMessage} />}
       <MetricsSettingTitle title={title} />
+      {warningMessage && <ErrorNotificationAutoDismiss message={warningMessage} />}
       {isError && (
         <ErrorDone>
           <span>Only one column can be selected as &quot;Done&quot;</span>

--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
@@ -4,8 +4,9 @@ import FlagCard from '@src/components/Metrics/MetricsStep/CycleTime/FlagCard'
 import { FormSelectPart } from '@src/components/Metrics/MetricsStep/CycleTime/FormSelectPart'
 import { ErrorDone } from '@src/components/Metrics/MetricsStep/CycleTime/style'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
-import { saveCycleTimeSettings, selectMetricsContent } from '@src/context/Metrics/metricsSlice'
+import { saveCycleTimeSettings, selectMetricsContent, selectWarningMessage } from '@src/context/Metrics/metricsSlice'
 import { useAppSelector } from '@src/hooks'
+import { ErrorNotificationAutoDismiss } from '@src/components/Common/ErrorNotificationAutoDismiss'
 
 interface cycleTimeProps {
   title: string
@@ -15,6 +16,7 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
   const dispatch = useAppDispatch()
   const [isError, setIsError] = useState(false)
   const { cycleTimeSettings } = useAppSelector(selectMetricsContent)
+  const warningMessage = useAppSelector(selectWarningMessage)
   const [cycleTimeOptions, setCycleTimeOptions] = useState(cycleTimeSettings)
 
   const saveCycleTimeOptions = (name: string, value: string) =>
@@ -35,6 +37,7 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
 
   return (
     <>
+      {warningMessage && <ErrorNotificationAutoDismiss message={warningMessage} />}
       <MetricsSettingTitle title={title} />
       {isError && (
         <ErrorDone>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -171,6 +171,9 @@ export const INIT_REPORT_DATA_WITH_THREE_COLUMNS: ReportDataWithThreeColumns[] =
 
 export const GET_STEPS_FAILED_MESSAGE = 'get steps failed'
 
+export const HOME_VERIFY_IMPORT_WARNING_MESSAGE =
+  'The content of the imported JSON file is empty. Please confirm carefully'
+
 export const CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE =
   'Imported data is not perfectly matched. Please review carefully before going next!'
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -173,3 +173,5 @@ export const GET_STEPS_FAILED_MESSAGE = 'get steps failed'
 
 export const CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE =
   'Imported data is not perfectly matched. Please review carefully before going next!'
+
+export const CLASSIFICATION_WARNING_MESSAGE = `Some classifications in import data might be removed now.`

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -1,7 +1,7 @@
 import { createSlice } from '@reduxjs/toolkit'
 import camelCase from 'lodash.camelcase'
 import { RootState } from '@src/store'
-import { CYCLE_TIME_LIST, METRICS_CONSTANTS } from '@src/constants'
+import { CLASSIFICATION_WARNING_MESSAGE, CYCLE_TIME_LIST, METRICS_CONSTANTS } from '@src/constants'
 
 export interface IPipelineConfig {
   id: number
@@ -175,10 +175,11 @@ export const metricsSlice = createSlice({
 
       //classification warningMessage
       const keyArray = targetFields?.map((field: { key: string; name: string; flag: boolean }) => field.key)
+
       if (importedClassification?.every((item) => keyArray.includes(item))) {
         state.classificationWarningMessage = null
       } else {
-        state.classificationWarningMessage = `Some classifications in import data might be removed now.`
+        state.classificationWarningMessage = CLASSIFICATION_WARNING_MESSAGE
       }
 
       state.cycleTimeSettings = jiraColumns?.map(

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -89,9 +89,9 @@ export const configSlice = createSlice({
       const { projectName, dateRange, metrics } = state.basic
 
       state.warningMessage =
-        !projectName || !dateRange.startDate || !dateRange.endDate || metrics.length == 0
-          ? CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE
-          : null
+        projectName && dateRange.startDate && dateRange.endDate && metrics.length > 0
+          ? null
+          : CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE
       state.board.config = action.payload.board || state.board.config
       state.pipelineTool.config = action.payload.pipelineTool || state.pipelineTool.config
       state.sourceControl.config = action.payload.sourceControl || state.sourceControl.config

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -147,9 +147,6 @@ export const configSlice = createSlice({
       const { githubRepos } = action.payload
       state.sourceControl.verifiedResponse.repoList = githubRepos
     },
-    updateWarningMessage: (state, action) => {
-      state.warningMessage = action.payload
-    },
   },
 })
 export const {
@@ -169,7 +166,6 @@ export const {
   updateSourceControlVerifyState,
   updateSourceControlVerifiedResponse,
   updatePipelineToolVerifyResponseSteps,
-  updateWarningMessage,
 } = configSlice.actions
 
 export const selectProjectName = (state: RootState) => state.config.basic.projectName

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { RootState } from '@src/store'
-import { REGULAR_CALENDAR, REQUIRED_DATA } from '@src/constants'
+import { CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE, REGULAR_CALENDAR, REQUIRED_DATA } from '@src/constants'
 import { IBoardState, initialBoardState } from '@src/context/config/board/boardSlice'
 import { initialPipelineToolState, IPipelineToolState } from '@src/context/config/pipelineTool/pipelineToolSlice'
 import { initialSourceControlState, ISourceControl } from '@src/context/config/sourceControl/sourceControlSlice'
@@ -21,6 +21,7 @@ export interface BasicConfigState {
   board: IBoardState
   pipelineTool: IPipelineToolState
   sourceControl: ISourceControl
+  warningMessage: string | null
 }
 
 export const initialBasicConfigState: BasicConfigState = {
@@ -37,6 +38,7 @@ export const initialBasicConfigState: BasicConfigState = {
   board: initialBoardState,
   pipelineTool: initialPipelineToolState,
   sourceControl: initialSourceControlState,
+  warningMessage: null,
 }
 
 export const configSlice = createSlice({
@@ -84,6 +86,12 @@ export const configSlice = createSlice({
     },
     updateBasicConfigState: (state, action) => {
       state.basic = action.payload
+      const { projectName, dateRange, metrics } = state.basic
+
+      state.warningMessage =
+        projectName === '' || dateRange.startDate === null || dateRange.endDate === null || metrics.length == 0
+          ? CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE
+          : null
       state.board.config = action.payload.board || state.board.config
       state.pipelineTool.config = action.payload.pipelineTool || state.pipelineTool.config
       state.sourceControl.config = action.payload.sourceControl || state.sourceControl.config
@@ -139,6 +147,9 @@ export const configSlice = createSlice({
       const { githubRepos } = action.payload
       state.sourceControl.verifiedResponse.repoList = githubRepos
     },
+    updateWarningMessage: (state, action) => {
+      state.warningMessage = action.payload
+    },
   },
 })
 export const {
@@ -158,6 +169,7 @@ export const {
   updateSourceControlVerifyState,
   updateSourceControlVerifiedResponse,
   updatePipelineToolVerifyResponseSteps,
+  updateWarningMessage,
 } = configSlice.actions
 
 export const selectProjectName = (state: RootState) => state.config.basic.projectName
@@ -169,6 +181,8 @@ export const isPipelineToolVerified = (state: RootState) => state.config.pipelin
 export const selectPipelineTool = (state: RootState) => state.config.pipelineTool.config
 export const isSourceControlVerified = (state: RootState) => state.config.sourceControl.isVerified
 export const selectSourceControl = (state: RootState) => state.config.sourceControl.config
+export const selectWarningMessage = (state: RootState) => state.config.warningMessage
+
 export const selectConfig = (state: RootState) => state.config
 
 export const selectIsBoardVerified = (state: RootState) => state.config.board.isVerified

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -89,7 +89,7 @@ export const configSlice = createSlice({
       const { projectName, dateRange, metrics } = state.basic
 
       state.warningMessage =
-        projectName === '' || dateRange.startDate === null || dateRange.endDate === null || metrics.length == 0
+        !projectName || !dateRange.startDate || !dateRange.endDate || metrics.length == 0
           ? CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE
           : null
       state.board.config = action.payload.board || state.board.config


### PR DESCRIPTION
## Summary

Data import validation for the cycleTime section

case1 : Compare the key value of the imported data with the name of each object in the response in the board.

    （1）When different output values belong to imported data, it indicates that the current column has been deleted.

    （2）When the output values before different values belong to the response, it prompts that the current column is a newly added column.

case2：Compare the value values of imported data with fixed columns.

    Different values belong to imported data, indicating that the current data does not belong to a fixed column.

Data import validation for the classfication section
    Display a warning message when the imported data does not match the targetFields value in the response

## After
Data import validation for the cycleTime section
case1:
（1）When different output values belong to imported data, it indicates that the current column has been deleted.
<img width="1200" alt="Screen Shot 2023-05-23 at 3 54 56 PM" src="https://github.com/au-heartbeat/Heartbeat/assets/110439025/594b1b75-baf6-420d-8f84-3ef483fdefa9">
（2）When the output values before different values belong to the response, it prompts that the current column is a newly added column.
<img width="1141" alt="Screen Shot 2023-05-23 at 3 52 15 PM" src="https://github.com/au-heartbeat/Heartbeat/assets/110439025/0d73a5b8-8024-4fda-9c0b-44fe27ca5c30">
case2:
  Different values belong to imported data, indicating that the current data does not belong to a fixed column.
<img width="1064" alt="Screen Shot 2023-05-23 at 4 01 07 PM" src="https://github.com/au-heartbeat/Heartbeat/assets/110439025/036bf5c2-ca85-42aa-8169-2f4f3cfb02d3">

Data import validation for the classfication section
<img width="1190" alt="Screen Shot 2023-05-23 at 5 01 55 PM" src="https://github.com/au-heartbeat/Heartbeat/assets/110439025/55608a5f-ebc8-46bd-8dfb-0912f27f9739">

