### PR TITLE
ADM-493 Verify import config file for deploymentFrequency and leadTimeForChanges[frontend][backend]

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
@@ -24,6 +24,8 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
     { id: 0, organization: '', pipelineName: '', steps: '' },
     { id: 1, organization: '', pipelineName: '', steps: '' },
   ]),
+  selectOrganizationWarningMessage: jest.fn().mockReturnValue(null),
+  selectPipelineNameWarningMessage: jest.fn().mockReturnValue(null),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
@@ -26,6 +26,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
   ]),
   selectOrganizationWarningMessage: jest.fn().mockReturnValue(null),
   selectPipelineNameWarningMessage: jest.fn().mockReturnValue(null),
+  selectStepWarningMessage: jest.fn().mockReturnValue(null),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -19,6 +19,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
   deleteADeploymentFrequencySetting: jest.fn().mockReturnValue({ type: 'DELETE_DEPLOYMENT_FREQUENCY_SETTING' }),
   selectOrganizationWarningMessage: jest.fn().mockReturnValue('Test organization warning message'),
   selectPipelineNameWarningMessage: jest.fn().mockReturnValue('Test pipelineName warning message'),
+  selectStepWarningMessage: jest.fn().mockReturnValue('Test step warning message'),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({
@@ -177,6 +178,7 @@ describe('PipelineMetricSelection', () => {
 
     expect(getByText('Test organization warning message')).toBeInTheDocument()
     expect(getByText('Test pipelineName warning message')).toBeInTheDocument()
+    expect(getByText('Test step warning message')).toBeInTheDocument()
   })
 
   it('should clear warning message when organization and pipelineName warning messages have value after four seconds', async () => {
@@ -190,6 +192,7 @@ describe('PipelineMetricSelection', () => {
     await waitFor(() => {
       expect(queryByText('Test organization warning message')).not.toBeInTheDocument()
       expect(queryByText('Test pipelineName warning message')).not.toBeInTheDocument()
+      expect(queryByText('Test step warning message')).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/LeadTimeForChanges.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/LeadTimeForChanges.test.tsx
@@ -22,6 +22,8 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
   addALeadTimeForChanges: jest.fn(),
   deleteALeadTimeForChange: jest.fn(),
   updateLeadTimeForChanges: jest.fn(),
+  selectOrganizationWarningMessage: jest.fn().mockReturnValue(null),
+  selectPipelineNameWarningMessage: jest.fn().mockReturnValue(null),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/LeadTimeForChanges.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/LeadTimeForChanges.test.tsx
@@ -24,6 +24,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
   updateLeadTimeForChanges: jest.fn(),
   selectOrganizationWarningMessage: jest.fn().mockReturnValue(null),
   selectPipelineNameWarningMessage: jest.fn().mockReturnValue(null),
+  selectStepWarningMessage: jest.fn().mockReturnValue(null),
 }))
 
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -198,7 +198,7 @@ describe('saveMetricsSetting reducer', () => {
       crews: undefined,
       cycleTime: {
         jiraColumns: undefined,
-        treatFlagCardAsBlock: true,
+        treatFlagCardAsBlock: undefined,
       },
       doneStatus: undefined,
       classification: undefined,
@@ -213,6 +213,7 @@ describe('saveMetricsSetting reducer', () => {
     expect(savedMetricsSetting.jiraColumns).toEqual([])
     expect(savedMetricsSetting.doneColumn).toEqual([])
     expect(savedMetricsSetting.cycleTimeSettings).toEqual([])
+    expect(savedMetricsSetting.treatFlagCardAsBlock).toEqual(true)
     expect(savedMetricsSetting.deploymentFrequencySettings).toEqual([
       { id: 0, organization: '', pipelineName: '', step: '' },
     ])

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -201,15 +201,15 @@ describe('saveMetricsSetting reducer', () => {
 
   it('should not update metricsImportedData when imported data is broken given initial state', () => {
     const mockMetricsImportedData = {
-      crews: undefined,
+      crews: null,
       cycleTime: {
-        jiraColumns: undefined,
-        treatFlagCardAsBlock: undefined,
+        jiraColumns: null,
+        treatFlagCardAsBlock: null,
       },
-      doneStatus: undefined,
-      classification: undefined,
-      deployment: undefined,
-      leadTime: undefined,
+      doneStatus: null,
+      classification: null,
+      deployment: null,
+      leadTime: null,
     }
 
     const savedMetricsSetting = saveMetricsSettingReducer(initState, updateMetricsImportedData(mockMetricsImportedData))

--- a/frontend/cypress/e2e/createANewProject.cy.ts
+++ b/frontend/cypress/e2e/createANewProject.cy.ts
@@ -1,4 +1,4 @@
-import { GITHUB_TOKEN, PIPELINE_CSV_HEADERS } from '../fixtures/fixtures'
+import { GITHUB_TOKEN } from '../fixtures/fixtures'
 import homePage from '../pages/home'
 import configPage from '../pages/metrics/config'
 import metricsPage from '../pages/metrics/metrics'

--- a/frontend/cypress/plugins/readDir.ts
+++ b/frontend/cypress/plugins/readDir.ts
@@ -1,7 +1,7 @@
 // <reference types="cypress" />
 import fs = require('fs')
 
-module.exports = (on, config) => {
+module.exports = (on) => {
   on('task', {
     readDir: async (path) => {
       return new Promise((resolve, reject) => {

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -13,7 +13,12 @@ import {
   updatePipelineToolVerifyResponseSteps,
 } from '@src/context/config/configSlice'
 import { store } from '@src/store'
-import { updatePipelineStep } from '@src/context/Metrics/metricsSlice'
+import {
+  selectOrganizationWarningMessage,
+  selectPipelineNameWarningMessage,
+  updatePipelineStep,
+} from '@src/context/Metrics/metricsSlice'
+import { WarningNotification } from '@src/components/Common/WarningNotification'
 
 interface pipelineMetricSelectionProps {
   type: string
@@ -43,6 +48,8 @@ export const PipelineMetricSelection = ({
   const organizationNameOptions = selectPipelineOrganizations(store.getState())
   const pipelineNameOptions = selectPipelineNames(store.getState(), organization)
   const stepsOptions = selectSteps(store.getState(), organization, pipelineName)
+  const organizationWarningMessage = selectOrganizationWarningMessage(store.getState(), id, type)
+  const pipelineNameWarningMessage = selectPipelineNameWarningMessage(store.getState(), id, type)
 
   const handleClick = () => {
     onRemovePipeline(id)
@@ -63,6 +70,8 @@ export const PipelineMetricSelection = ({
 
   return (
     <PipelineMetricSelectionWrapper>
+      {organizationWarningMessage && <WarningNotification message={organizationWarningMessage} />}
+      {pipelineNameWarningMessage && <WarningNotification message={pipelineNameWarningMessage} />}
       {isLoading && <Loading />}
       {duplicatedIds.includes(id) && <WarningMessage>This pipeline is the same as another one!</WarningMessage>}
       {errorMessage && <ErrorNotification message={errorMessage} />}

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SingleSelection } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection'
 import { useAppDispatch } from '@src/hooks'
 import { ButtonWrapper, PipelineMetricSelectionWrapper, RemoveButton, WarningMessage } from './style'
@@ -16,9 +16,11 @@ import { store } from '@src/store'
 import {
   selectOrganizationWarningMessage,
   selectPipelineNameWarningMessage,
+  selectStepWarningMessage,
   updatePipelineStep,
 } from '@src/context/Metrics/metricsSlice'
 import { WarningNotification } from '@src/components/Common/WarningNotification'
+import { NO_STEP_WARNING_MESSAGE } from '@src/constants'
 
 interface pipelineMetricSelectionProps {
   type: string
@@ -50,6 +52,8 @@ export const PipelineMetricSelection = ({
   const stepsOptions = selectSteps(store.getState(), organization, pipelineName)
   const organizationWarningMessage = selectOrganizationWarningMessage(store.getState(), id, type)
   const pipelineNameWarningMessage = selectPipelineNameWarningMessage(store.getState(), id, type)
+  const stepWarningMessage = selectStepWarningMessage(store.getState(), id, type)
+  const [isShowNoStepWarning, setIsShowNoStepWarning] = useState(false)
 
   const handleClick = () => {
     onRemovePipeline(id)
@@ -63,6 +67,7 @@ export const PipelineMetricSelection = ({
     )
     getSteps(params, organizationId, buildId, pipelineType, token).then((res) => {
       const steps = res ? Object.values(res) : []
+      setIsShowNoStepWarning(!steps.length)
       dispatch(updatePipelineToolVerifyResponseSteps({ organization, pipelineName: _pipelineName, steps }))
       dispatch(updatePipelineStep({ steps, id, type }))
     })
@@ -72,6 +77,8 @@ export const PipelineMetricSelection = ({
     <PipelineMetricSelectionWrapper>
       {organizationWarningMessage && <WarningNotification message={organizationWarningMessage} />}
       {pipelineNameWarningMessage && <WarningNotification message={pipelineNameWarningMessage} />}
+      {stepWarningMessage && <WarningNotification message={stepWarningMessage} />}
+      {isShowNoStepWarning && <WarningNotification message={NO_STEP_WARNING_MESSAGE} />}
       {isLoading && <Loading />}
       {duplicatedIds.includes(id) && <WarningMessage>This pipeline is the same as another one!</WarningMessage>}
       {errorMessage && <ErrorNotification message={errorMessage} />}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -180,3 +180,7 @@ export const CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE =
 export const CLASSIFICATION_WARNING_MESSAGE = `Some classifications in import data might be removed.`
 
 export const REAL_DONE_WARNING_MESSAGE = 'Some selected doneStatus in import data might be removed'
+
+export const ORGANIZATION_WARNING_MESSAGE = 'This organization in import data might be removed'
+
+export const PIPELINE_NAME_WARNING_MESSAGE = 'This Pipeline in import data might be removed'

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -184,3 +184,8 @@ export const REAL_DONE_WARNING_MESSAGE = 'Some selected doneStatus in import dat
 export const ORGANIZATION_WARNING_MESSAGE = 'This organization in import data might be removed'
 
 export const PIPELINE_NAME_WARNING_MESSAGE = 'This Pipeline in import data might be removed'
+
+export const STEP_WARNING_MESSAGE = 'Selected step of this pipeline in import data might be removed'
+
+export const NO_STEP_WARNING_MESSAGE =
+  'There is no step during this period for this pipeline! Please change the search time in the Config page!'

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -9,6 +9,7 @@ import {
   PIPELINE_NAME_WARNING_MESSAGE,
   PIPELINE_SETTING_TYPES,
   REAL_DONE_WARNING_MESSAGE,
+  STEP_WARNING_MESSAGE,
 } from '@src/constants'
 import { pipeline } from '@src/context/config/pipelineTool/verifyResponseSlice'
 
@@ -318,6 +319,7 @@ export const metricsSlice = createSlice({
         ? ''
         : updatedImportedPipeline.filter((pipeline) => pipeline.id === id)[0]?.step ?? ''
       const validStep = steps.includes(updatedImportedPipelineStep) ? updatedImportedPipelineStep : ''
+      const stepWarningMessage = steps.includes(updatedImportedPipelineStep) ? null : STEP_WARNING_MESSAGE
 
       const getPipelineSettings = (pipelines: IPipelineConfig[]) =>
         pipelines.map((pipeline) =>
@@ -329,9 +331,27 @@ export const metricsSlice = createSlice({
             : pipeline
         )
 
+      const getStepWarningMessage = (pipelines: IPipelineWarningMessageConfig[]) => {
+        if (pipelines.length > 0) {
+          return pipelines.map((pipeline) =>
+            pipeline.id === id
+              ? {
+                  ...pipeline,
+                  step: stepWarningMessage,
+                }
+              : pipeline
+          )
+        }
+        return []
+      }
+
       type === PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE
         ? (state.deploymentFrequencySettings = getPipelineSettings(state.deploymentFrequencySettings))
         : (state.leadTimeForChanges = getPipelineSettings(state.leadTimeForChanges))
+
+      type === PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE
+        ? (state.deploymentWarningMessage = getStepWarningMessage(state.deploymentWarningMessage))
+        : (state.leadTimeWarningMessage = getStepWarningMessage(state.leadTimeWarningMessage))
     },
 
     deleteADeploymentFrequencySetting: (state, action) => {
@@ -425,6 +445,15 @@ export const selectPipelineNameWarningMessage = (state: RootState, id: number, t
       ? deploymentWarningMessage
       : leadTimeWarningMessage
   return warningMessage.find((item) => item.id === id)?.pipelineName
+}
+
+export const selectStepWarningMessage = (state: RootState, id: number, type: string) => {
+  const { deploymentWarningMessage, leadTimeWarningMessage } = state.metrics
+  const warningMessage =
+    type === PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE
+      ? deploymentWarningMessage
+      : leadTimeWarningMessage
+  return warningMessage.find((item) => item.id === id)?.step
 }
 
 export default metricsSlice.reducer

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -182,13 +182,15 @@ export const metricsSlice = createSlice({
 
     updateMetricsImportedData: (state, action) => {
       const { crews, cycleTime, doneStatus, classification, deployment, leadTime } = action.payload
-      state.importedData.importedCrews = crews
-      state.importedData.importedCycleTime.importedCycleTimeSettings = cycleTime?.jiraColumns
-      state.importedData.importedCycleTime.importedTreatFlagCardAsBlock = cycleTime?.treatFlagCardAsBlock
-      state.importedData.importedDoneStatus = doneStatus
-      state.importedData.importedClassification = classification
-      state.importedData.importedDeployment = deployment ?? []
-      state.importedData.importedLeadTime = leadTime ?? []
+      state.importedData.importedCrews = crews || state.importedData.importedCrews
+      state.importedData.importedCycleTime.importedCycleTimeSettings =
+        cycleTime?.jiraColumns || state.importedData.importedCycleTime.importedCycleTimeSettings
+      state.importedData.importedCycleTime.importedTreatFlagCardAsBlock =
+        cycleTime?.treatFlagCardAsBlock || state.importedData.importedCycleTime.importedTreatFlagCardAsBlock
+      state.importedData.importedDoneStatus = doneStatus || state.importedData.importedDoneStatus
+      state.importedData.importedClassification = classification || state.importedData.importedClassification
+      state.importedData.importedDeployment = deployment || state.importedData.importedDeployment
+      state.importedData.importedLeadTime = leadTime || state.importedData.importedLeadTime
     },
 
     updateMetricsState: (state, action) => {


### PR DESCRIPTION
## Summary
when import deployment and leadTime for changes in a json file, it will verify if organization, pipelineName and step exist in buildKike response. If not, show warning message 'This organization in import data might be removed', 'This Pipeline in import data might be removed', 'Selected step of this pipeline in import data might be removed' and 'There is no step during this period for this pipeline! Please change the search time in the Config page!'.

## Before
no warning
![image](https://github.com/au-heartbeat/Heartbeat/assets/110760470/2af59c54-431b-4a6b-80b6-7c9d20e98d20)

## After
![image](https://github.com/au-heartbeat/Heartbeat/assets/110760470/89833ee1-9db3-4414-a896-2ea021ea6b11)

## Note
The card is: https://trello.com/c/i1eix9d1
