### PR TITLE
ADM-373 fix:[backend] fix prDelayTime is null issue

### DIFF
--- a/backend/src/main/java/heartbeat/client/dto/codebase/github/LeadTime.java
+++ b/backend/src/main/java/heartbeat/client/dto/codebase/github/LeadTime.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.lang.Nullable;
 
 @Data
 @Builder
@@ -13,17 +14,21 @@ public class LeadTime {
 
 	private String commitId;
 
-	private long prCreatedTime;
+	@Nullable
+	private Long prCreatedTime;
 
-	private long prMergedTime;
+	@Nullable
+	private Long prMergedTime;
 
-	private long firstCommitTimeInPr;
+	@Nullable
+	private Long firstCommitTimeInPr;
 
 	private long jobFinishTime;
 
 	private long pipelineCreateTime;
 
-	private long prDelayTime;
+	@Nullable
+	private Long prDelayTime;
 
 	private long pipelineDelayTime;
 

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/LeadTimeInfo.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/LeadTimeInfo.java
@@ -35,16 +35,16 @@ public class LeadTimeInfo {
 
 	public LeadTimeInfo(LeadTime leadTime) {
 		if (leadTime != null) {
-			if (leadTime.getFirstCommitTimeInPr() != 0) {
+			if (leadTime.getFirstCommitTimeInPr() != null) {
 				this.firstCommitTimeInPr = TimeUtil
 					.convertToISOFormat(String.valueOf(leadTime.getFirstCommitTimeInPr()));
 			}
 
-			if (leadTime.getPrCreatedTime() != 0) {
+			if (leadTime.getPrCreatedTime() != null) {
 				this.prCreatedTime = TimeUtil.convertToISOFormat(String.valueOf(leadTime.getPrCreatedTime()));
 			}
 
-			if (leadTime.getPrMergedTime() != 0) {
+			if (leadTime.getPrMergedTime() != null) {
 				this.prMergedTime = TimeUtil.convertToISOFormat(String.valueOf(leadTime.getPrMergedTime()));
 			}
 
@@ -52,11 +52,11 @@ public class LeadTimeInfo {
 
 			this.pipelineDelayTime = TimeUtil.msToHMS(leadTime.getPipelineDelayTime());
 
-			if (leadTime.getPrDelayTime() != 0.0) {
+			if (leadTime.getPrDelayTime() != null) {
 				this.prDelayTime = TimeUtil.msToHMS(leadTime.getPrDelayTime());
 			}
 
-			if (leadTime.getTotalTime() != 0.0) {
+			if (leadTime.getTotalTime() != 0) {
 				this.totalTime = TimeUtil.msToHMS(leadTime.getTotalTime());
 			}
 		}

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -33,6 +33,7 @@ import org.springframework.core.io.InputStreamResource;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -231,7 +232,7 @@ public class GenerateReporterService {
 				DeployInfo deployInfo = buildInfo.mapToDeployInfo(deploymentEnvironment.getStep(), REQUIRED_STATES,
 						startTime, endTime);
 
-				LeadTime noMergeDelayTime = gitHubService.getLeadTimeWithoutMergeDelayTime(deployInfo);
+				LeadTime noMergeDelayTime = getLeadTimeWithoutMergeDelayTime(deployInfo);
 
 				return PipelineCSVInfo.builder()
 					.pipeLineName(deploymentEnvironment.getName())
@@ -313,6 +314,19 @@ public class GenerateReporterService {
 				file.delete();
 			}
 		}
+	}
+
+	private LeadTime getLeadTimeWithoutMergeDelayTime(DeployInfo deployInfo) {
+		long jobFinishTime = Instant.parse(deployInfo.getJobFinishTime()).toEpochMilli();
+		long jobStartTime = Instant.parse(deployInfo.getJobStartTime()).toEpochMilli();
+		long pipelineCreateTime = Instant.parse(deployInfo.getPipelineCreateTime()).toEpochMilli();
+
+		return LeadTime.builder()
+			.commitId(deployInfo.getCommitId())
+			.pipelineCreateTime(pipelineCreateTime)
+			.jobFinishTime(jobFinishTime)
+			.pipelineDelayTime(jobFinishTime - jobStartTime)
+			.build();
 	}
 
 }

--- a/backend/src/main/java/heartbeat/service/source/github/GitHubService.java
+++ b/backend/src/main/java/heartbeat/service/source/github/GitHubService.java
@@ -191,19 +191,8 @@ public class GitHubService {
 			.pipelineCreateTime(pipelineCreateTime)
 			.jobFinishTime(jobFinishTime)
 			.pipelineDelayTime(jobFinishTime - jobStartTime)
-			.build();
-	}
-
-	public LeadTime getLeadTimeWithoutMergeDelayTime(DeployInfo deployInfo) {
-		long jobFinishTime = Instant.parse(deployInfo.getJobFinishTime()).toEpochMilli();
-		long jobStartTime = Instant.parse(deployInfo.getJobStartTime()).toEpochMilli();
-		long pipelineCreateTime = Instant.parse(deployInfo.getPipelineCreateTime()).toEpochMilli();
-
-		return LeadTime.builder()
-			.commitId(deployInfo.getCommitId())
-			.pipelineCreateTime(pipelineCreateTime)
-			.jobFinishTime(jobFinishTime)
-			.pipelineDelayTime(jobFinishTime - jobStartTime)
+			.totalTime(jobFinishTime - jobStartTime)
+			.prDelayTime(0L)
 			.build();
 	}
 

--- a/backend/src/test/java/heartbeat/service/pipeline/buildkite/builder/BuildKiteBuildInfoBuilder.java
+++ b/backend/src/test/java/heartbeat/service/pipeline/buildkite/builder/BuildKiteBuildInfoBuilder.java
@@ -36,4 +36,9 @@ public class BuildKiteBuildInfoBuilder {
 		return this;
 	}
 
+	public BuildKiteBuildInfoBuilder withPipelineCreateTime(String time) {
+		buildKiteBuildInfo.setPipelineCreateTime(time);
+		return this;
+	}
+
 }

--- a/backend/src/test/java/heartbeat/service/report/CalculateLeadTimeForChangesTest.java
+++ b/backend/src/test/java/heartbeat/service/report/CalculateLeadTimeForChangesTest.java
@@ -37,7 +37,7 @@ public class CalculateLeadTimeForChangesTest {
 				.firstCommitTimeInPr(165854910000L)
 				.jobFinishTime(1658549160000L)
 				.pipelineCreateTime(165854910000L)
-				.prDelayTime(60000)
+				.prDelayTime(60000L)
 				.pipelineDelayTime(60000)
 				.totalTime(120000)
 				.build()))

--- a/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
@@ -217,6 +217,7 @@ class GenerateReporterServiceTest {
 		when(buildKiteService.fetchPipelineBuilds(any(), any(), any(), any()))
 			.thenReturn(List.of(BuildKiteBuildInfoBuilder.withDefault()
 				.withJobs(List.of(BuildKiteJobBuilder.withDefault().build()))
+				.withPipelineCreateTime("2022-09-09T04:57:34Z")
 				.build()));
 
 		when(buildKiteService.countDeployTimes(any(), any(), any(), any())).thenReturn(
@@ -258,6 +259,7 @@ class GenerateReporterServiceTest {
 		when(buildKiteService.fetchPipelineBuilds(any(), any(), any(), any()))
 			.thenReturn(List.of(BuildKiteBuildInfoBuilder.withDefault()
 				.withJobs(List.of(BuildKiteJobBuilder.withDefault().build()))
+				.withPipelineCreateTime("2022-09-09T04:57:34Z")
 				.build()));
 
 		when(buildKiteService.countDeployTimes(any(), any(), any(), any())).thenReturn(
@@ -345,7 +347,7 @@ class GenerateReporterServiceTest {
 				.firstCommitTimeInPr(1658549100000L)
 				.jobFinishTime(1658549160000L)
 				.pipelineCreateTime(1658549100000L)
-				.prDelayTime(60000)
+				.prDelayTime(60000L)
 				.pipelineDelayTime(60000)
 				.totalTime(120000)
 				.build()))
@@ -370,6 +372,7 @@ class GenerateReporterServiceTest {
 		when(buildKiteService.fetchPipelineBuilds(any(), any(), any(), any()))
 			.thenReturn(List.of(BuildKiteBuildInfoBuilder.withDefault()
 				.withJobs(List.of(BuildKiteJobBuilder.withDefault().build()))
+				.withPipelineCreateTime("2022-09-09T04:57:34Z")
 				.build()));
 		when(buildKiteService.countDeployTimes(any(), any(), any(), any())).thenReturn(
 				DeployTimesBuilder.withDefault().withPassed(List.of(DeployInfoBuilder.withDefault().build())).build());
@@ -460,6 +463,7 @@ class GenerateReporterServiceTest {
 		when(buildKiteService.fetchPipelineBuilds(any(), any(), any(), any()))
 			.thenReturn(List.of(BuildKiteBuildInfoBuilder.withDefault()
 				.withJobs(List.of(BuildKiteJobBuilder.withDefault().build()))
+				.withPipelineCreateTime("2022-09-09T04:57:34Z")
 				.build()));
 		when(buildKiteService.countDeployTimes(any(), any(), any(), any())).thenReturn(
 				DeployTimesBuilder.withDefault().withPassed(List.of(DeployInfoBuilder.withDefault().build())).build());

--- a/backend/src/test/java/heartbeat/service/report/PipelineCsvFixture.java
+++ b/backend/src/test/java/heartbeat/service/report/PipelineCsvFixture.java
@@ -79,7 +79,7 @@ public class PipelineCsvFixture {
 				.firstCommitTimeInPr(1658549100000L)
 				.jobFinishTime(1658549160000L)
 				.pipelineCreateTime(1658549100000L)
-				.prDelayTime(60000)
+				.prDelayTime(60000L)
 				.pipelineDelayTime(60000)
 				.totalTime(120000)
 				.build()))

--- a/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
@@ -119,7 +119,7 @@ class GithubServiceTest {
 				.jobFinishTime(1658549160000L)
 				.pipelineDelayTime(1658549100000L)
 				.pipelineCreateTime(1658549100000L)
-				.prDelayTime(60000)
+				.prDelayTime(60000L)
 				.pipelineDelayTime(120000)
 				.totalTime(180000)
 				.build()))
@@ -223,7 +223,7 @@ class GithubServiceTest {
 			.jobFinishTime(1658549160000L)
 			.pipelineDelayTime(1658549100000L)
 			.pipelineCreateTime(1658549100000L)
-			.prDelayTime(60000)
+			.prDelayTime(60000L)
 			.pipelineDelayTime(120000)
 			.totalTime(180000)
 			.build();
@@ -239,11 +239,11 @@ class GithubServiceTest {
 			.commitId("111")
 			.prCreatedTime(1658548980000L)
 			.prMergedTime(1658549040000L)
-			.firstCommitTimeInPr(0)
+			.firstCommitTimeInPr(0L)
 			.jobFinishTime(1658549160000L)
 			.pipelineDelayTime(1658549100000L)
 			.pipelineCreateTime(1658549100000L)
-			.prDelayTime(60000)
+			.prDelayTime(60000L)
 			.pipelineDelayTime(120000)
 			.totalTime(180000)
 			.build();
@@ -259,11 +259,11 @@ class GithubServiceTest {
 			.commitId("111")
 			.prCreatedTime(1658548980000L)
 			.prMergedTime(1658549040000L)
-			.firstCommitTimeInPr(0)
+			.firstCommitTimeInPr(0L)
 			.jobFinishTime(1658549160000L)
 			.pipelineDelayTime(1658549100000L)
 			.pipelineCreateTime(1658549100000L)
-			.prDelayTime(60000)
+			.prDelayTime(60000L)
 			.pipelineDelayTime(120000)
 			.totalTime(180000L)
 			.build();
@@ -312,14 +312,11 @@ class GithubServiceTest {
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
-				.prCreatedTime(0)
-				.prMergedTime(0)
-				.firstCommitTimeInPr(0)
 				.jobFinishTime(1658549160000L)
 				.pipelineCreateTime(1658549100000L)
-				.prDelayTime(0)
+				.prDelayTime(0L)
 				.pipelineDelayTime(120000)
-				.totalTime(0)
+				.totalTime(120000)
 				.build()))
 			.build());
 
@@ -340,14 +337,11 @@ class GithubServiceTest {
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
-				.prCreatedTime(0)
-				.prMergedTime(0)
-				.firstCommitTimeInPr(0)
 				.jobFinishTime(1658549160000L)
 				.pipelineCreateTime(1658549100000L)
-				.prDelayTime(0)
+				.prDelayTime(0L)
 				.pipelineDelayTime(120000)
-				.totalTime(0)
+				.totalTime(120000)
 				.build()))
 			.build());
 
@@ -368,27 +362,6 @@ class GithubServiceTest {
 		CommitInfo result = githubService.fetchCommitInfo("12344", "org/repo", "mockToken");
 
 		assertEquals(result, commitInfo);
-	}
-
-	@Test
-	public void shouldReturnLeadTimeWithoutMergeDelayTimeWhenDeployHasNoMergeTime() {
-		DeployInfo deployInfo = DeployInfo.builder()
-			.commitId("123456")
-			.jobStartTime("2023-05-17T10:00:00Z")
-			.jobFinishTime("2023-05-17T10:30:00Z")
-			.pipelineCreateTime("2023-05-17T10:30:00Z")
-			.build();
-
-		LeadTime expectedLeadTime = LeadTime.builder()
-			.commitId("123456")
-			.pipelineCreateTime(1684319400000L)
-			.jobFinishTime(1684319400000L)
-			.pipelineDelayTime(1800000L)
-			.build();
-
-		LeadTime result = githubService.getLeadTimeWithoutMergeDelayTime(deployInfo);
-
-		assertEquals(expectedLeadTime, result);
 	}
 
 }


### PR DESCRIPTION
## Summary

Fix the issue that the non-PR prDelayTime is displayed as null.
When there is no PR, it should be displayed as 0:0:0

## Before

<img width="302" alt="Screenshot 2023-06-06 at 09 10 38" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/1db2d4f9-4996-44f7-97b8-aae7f432a12d">


## After
<img width="306" alt="Screenshot 2023-06-06 at 09 08 26" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/085131f2-ed9f-4b5b-8fbe-9928c3892d3d">

