### PR TITLE
Adm 493 [frontend] add warning message when get no steps

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -142,6 +142,26 @@ describe('PipelineMetricSelection', () => {
     })
     expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
   })
+  it('should show no steps warning message when getSteps succeed but get no steps', async () => {
+    metricsClient.getSteps = jest.fn().mockImplementation(() => [])
+    const { getByText, getByRole } = await setup(
+      { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: '' },
+      false,
+      false
+    )
+
+    await userEvent.click(getByRole('button', { name: PIPELINE_NAME }))
+    const listBox = within(getByRole('listbox'))
+    await userEvent.click(listBox.getByText('mockName2'))
+
+    await waitFor(() => {
+      expect(
+        getByText(
+          'There is no step during this period for this pipeline! Please change the search time in the Config page!'
+        )
+      ).toBeInTheDocument()
+    })
+  })
 
   it('should show steps selection when getSteps succeed ', async () => {
     metricsClient.getSteps = jest.fn().mockImplementation(() => ['steps'])

--- a/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
@@ -177,7 +177,7 @@ export const Board = () => {
       if (res) {
         dispatch(updateBoardVerifyState(res.isBoardVerify))
         dispatch(updateJiraVerifyResponse(res.response))
-        dispatch(updateMetricsState({ ...res.response, isProjectCreated }))
+        res.isBoardVerify && dispatch(updateMetricsState({ ...res.response, isProjectCreated }))
         setIsNoDoneCard(res.isNoDoneCard)
       }
     })

--- a/frontend/src/components/Metrics/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/PipelineTool/index.tsx
@@ -138,7 +138,7 @@ export const PipelineTool = () => {
         dispatch(updatePipelineToolVerifyResponse(res.response))
         dispatch(initDeploymentFrequencySettings())
         dispatch(initLeadTimeForChanges())
-        dispatch(updatePipelineSettings({ ...res.response, isProjectCreated }))
+        res.isPipelineToolVerified && dispatch(updatePipelineSettings({ ...res.response, isProjectCreated }))
       }
     })
   }

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -66,7 +66,7 @@ export const PipelineMetricSelection = ({
     getSteps(params, organizationId, buildId, pipelineType, token).then((res) => {
       const steps = res ? Object.values(res) : []
       dispatch(updatePipelineToolVerifyResponseSteps({ organization, pipelineName: _pipelineName, steps }))
-      dispatch(updatePipelineStep({ steps, id, type }))
+      !!steps.length && dispatch(updatePipelineStep({ steps, id, type }))
     })
   }
 

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { SingleSelection } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/SingleSelection'
 import { useAppDispatch } from '@src/hooks'
 import { ButtonWrapper, PipelineMetricSelectionWrapper, RemoveButton, WarningMessage } from './style'
@@ -20,6 +20,7 @@ import {
   updatePipelineStep,
 } from '@src/context/Metrics/metricsSlice'
 import { WarningNotification } from '@src/components/Common/WarningNotification'
+import { NO_STEP_WARNING_MESSAGE } from '@src/constants'
 
 interface pipelineMetricSelectionProps {
   type: string
@@ -52,6 +53,7 @@ export const PipelineMetricSelection = ({
   const organizationWarningMessage = selectOrganizationWarningMessage(store.getState(), id, type)
   const pipelineNameWarningMessage = selectPipelineNameWarningMessage(store.getState(), id, type)
   const stepWarningMessage = selectStepWarningMessage(store.getState(), id, type)
+  const [isShowNoStepWarning, setIsShowNoStepWarning] = useState(false)
 
   const handleClick = () => {
     onRemovePipeline(id)
@@ -67,6 +69,7 @@ export const PipelineMetricSelection = ({
       const steps = res ? Object.values(res) : []
       dispatch(updatePipelineToolVerifyResponseSteps({ organization, pipelineName: _pipelineName, steps }))
       !!steps.length && dispatch(updatePipelineStep({ steps, id, type }))
+      res && setIsShowNoStepWarning(!steps.length)
     })
   }
 
@@ -75,6 +78,7 @@ export const PipelineMetricSelection = ({
       {organizationWarningMessage && <WarningNotification message={organizationWarningMessage} />}
       {pipelineNameWarningMessage && <WarningNotification message={pipelineNameWarningMessage} />}
       {stepWarningMessage && <WarningNotification message={stepWarningMessage} />}
+      {isShowNoStepWarning && <WarningNotification message={NO_STEP_WARNING_MESSAGE} />}
       {isLoading && <Loading />}
       {isDuplicated && <WarningMessage>This pipeline is the same as another one!</WarningMessage>}
       {errorMessage && <ErrorNotification message={errorMessage} />}

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -186,3 +186,6 @@ export const ORGANIZATION_WARNING_MESSAGE = 'This organization in import data mi
 export const PIPELINE_NAME_WARNING_MESSAGE = 'This Pipeline in import data might be removed'
 
 export const STEP_WARNING_MESSAGE = 'Selected step of this pipeline in import data might be removed'
+
+export const NO_STEP_WARNING_MESSAGE =
+  'There is no step during this period for this pipeline! Please change the search time in the Config page!'


### PR DESCRIPTION
## Summary
show warning message 'There is no step during this period for this pipeline! Please change the search time in the Config page!' when getSteps succeed but get empty array

## Before
no warning:
<img width="1145" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/6e7ee885-a25a-4f8b-bb1b-10e0d9b3d573">

## After
show warning message: 
<img width="1191" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/110760470/ab1f2ecb-ca74-4dd5-86ae-cebd8952eb3b">
## Note

_Null_
