### PR TITLE
ADM-508 [Frontend]Remove average from export summary 

### DIFF
--- a/frontend/src/components/Common/ReportForThreeColumns/index.tsx
+++ b/frontend/src/components/Common/ReportForThreeColumns/index.tsx
@@ -3,6 +3,7 @@ import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle'
 import { Container, Row } from '@src/components/Common/ReportForTwoColumns/style'
 import React, { Fragment } from 'react'
 import { ReportDataWithThreeColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
+import { AVERAGE_FIELD } from '@src/constants'
 
 interface ReportForThreeColumnsProps {
   title: string
@@ -12,8 +13,8 @@ interface ReportForThreeColumnsProps {
 }
 
 export const ReportForThreeColumns = ({ title, fieldName, listName, data }: ReportForThreeColumnsProps) => {
-  const renderRows = () => {
-    return data.map((row) => (
+  const renderRows = () =>
+    data.slice(0, data.length === 2 && data[1].name === AVERAGE_FIELD ? 1 : data.length).map((row) => (
       <Fragment key={row.id}>
         <TableRow>
           <TableCell rowSpan={row.valuesList.length + 1}>{row.name}</TableCell>
@@ -26,7 +27,6 @@ export const ReportForThreeColumns = ({ title, fieldName, listName, data }: Repo
         ))}
       </Fragment>
     ))
-  }
 
   return (
     <>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -143,6 +143,8 @@ export const PIPELINE_STEP = 'Pipeline/step'
 
 export const NAME = 'Name'
 
+export const AVERAGE_FIELD = 'Average'
+
 export enum Unit {
   PER_SP = '(days/SP)',
   PER_CARD = '(days/card)',


### PR DESCRIPTION
## Summary

refinement display when just one item, don't show average item

## Before
<img width="1235" alt="Screen Shot 2023-06-09 at 10 26 27" src="https://github.com/au-heartbeat/Heartbeat/assets/112381997/3bc07764-091e-4a3a-9eea-15dd35a6b72d">

## After
<img width="1235" alt="Screen Shot 2023-06-09 at 11 09 12" src="https://github.com/au-heartbeat/Heartbeat/assets/112381997/b3de3012-703f-4ca6-a025-fc2108ad7719">



