### PR TITLE
Adm 510 [backend] Resolve concurrency and synchronization issues in Spring backend

### DIFF
--- a/backend/src/main/java/heartbeat/client/dto/board/jira/CardHistoryResponseDTO.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/CardHistoryResponseDTO.java
@@ -1,5 +1,6 @@
 package heartbeat.client.dto.board.jira;
 
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +12,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CardHistoryResponseDTO {
+public class CardHistoryResponseDTO implements Serializable {
 
 	private List<HistoryDetail> items;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/FieldResponseDTO.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/FieldResponseDTO.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class FieldResponseDTO {
+public class FieldResponseDTO implements Serializable {
 
 	private List<Project> projects;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/HistoryDetail.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/HistoryDetail.java
@@ -1,11 +1,12 @@
 package heartbeat.client.dto.board.jira;
 
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @Data
 @AllArgsConstructor
-public class HistoryDetail {
+public class HistoryDetail implements Serializable {
 
 	private long timestamp;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/IssueField.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/IssueField.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class IssueField {
+public class IssueField implements Serializable {
 
 	private String key;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/JiraBoardConfigDTO.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/JiraBoardConfigDTO.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JiraBoardConfigDTO {
+public class JiraBoardConfigDTO implements Serializable {
 
 	private String id;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumn.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumn.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JiraColumn {
+public class JiraColumn implements Serializable {
 
 	private String name;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumnConfig.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumnConfig.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JiraColumnConfig {
+public class JiraColumnConfig implements Serializable {
 
 	private List<JiraColumn> columns;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumnStatus.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/JiraColumnStatus.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,7 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JiraColumnStatus {
+public class JiraColumnStatus implements Serializable {
 
 	private String id;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/Project.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/Project.java
@@ -1,6 +1,7 @@
 package heartbeat.client.dto.board.jira;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Project {
+public class Project implements Serializable {
 
 	private List<Issuetype> issuetypes;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/Status.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/Status.java
@@ -2,6 +2,7 @@ package heartbeat.client.dto.board.jira;
 
 import heartbeat.service.report.ICardFieldDisplayName;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Builder
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class Status implements ICardFieldDisplayName {
+public class Status implements ICardFieldDisplayName, Serializable {
 
 	private String displayValue;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/StatusCategory.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/StatusCategory.java
@@ -1,11 +1,12 @@
 package heartbeat.client.dto.board.jira;
 
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 @AllArgsConstructor
 @Data
-public class StatusCategory {
+public class StatusCategory implements Serializable {
 
 	private String key;
 

--- a/backend/src/main/java/heartbeat/client/dto/board/jira/StatusSelfDTO.java
+++ b/backend/src/main/java/heartbeat/client/dto/board/jira/StatusSelfDTO.java
@@ -1,5 +1,6 @@
 package heartbeat.client.dto.board.jira;
 
+import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -7,7 +8,7 @@ import lombok.Data;
 @AllArgsConstructor
 @Data
 @Builder
-public class StatusSelfDTO {
+public class StatusSelfDTO implements Serializable {
 
 	private String untranslatedName;
 

--- a/backend/src/main/java/heartbeat/config/CacheConfig.java
+++ b/backend/src/main/java/heartbeat/config/CacheConfig.java
@@ -33,8 +33,9 @@ public class CacheConfig {
 		return cacheManager;
 	}
 
+	@SuppressWarnings("unchecked")
 	private <K, V> javax.cache.configuration.Configuration<K, V> getCacheConfiguration(Class<V> valueType) {
-		val offHeap = ResourcePoolsBuilder.newResourcePoolsBuilder().heap(1, MemoryUnit.MB);
+		val offHeap = ResourcePoolsBuilder.newResourcePoolsBuilder().offheap(2, MemoryUnit.MB);
 		val timeToLive = Duration.ofSeconds(20);
 		CacheConfigurationBuilder<K, V> configuration = CacheConfigurationBuilder
 			.newCacheConfigurationBuilder((Class<K>) String.class, valueType, offHeap)

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -70,6 +70,10 @@ public class JiraService {
 	private final ThreadPoolTaskExecutor customTaskExecutor;
 
 	public static final int QUERY_COUNT = 100;
+	private static final String DONE_CARD_TAG = "done";
+
+	public static final List<String> FIELDS_IGNORE = List.of("summary", "description", "attachment", "duedate",
+		"issuelinks");
 
 	private final JiraFeignClient jiraFeignClient;
 
@@ -81,11 +85,6 @@ public class JiraService {
 	public void shutdownExecutor() {
 		customTaskExecutor.shutdown();
 	}
-
-	private static final String DONE_CARD_TAG = "done";
-
-	public static final List<String> FIELDS_IGNORE = List.of("summary", "description", "attachment", "duedate",
-			"issuelinks");
 
 	public BoardConfigDTO getJiraConfiguration(BoardType boardType, BoardRequestParam boardRequestParam) {
 		URI baseUrl = urlGenerator.getUri(boardRequestParam.getSite());

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -77,10 +77,6 @@ public class JiraService {
 
 	private final BoardUtil boardUtil;
 
-	private CardCustomFieldKey cardCustomFieldKey;
-
-	private List<TargetField> targetFields;
-
 	@PreDestroy
 	public void shutdownExecutor() {
 		customTaskExecutor.shutdown();
@@ -93,11 +89,10 @@ public class JiraService {
 
 	public BoardConfigDTO getJiraConfiguration(BoardType boardType, BoardRequestParam boardRequestParam) {
 		URI baseUrl = urlGenerator.getUri(boardRequestParam.getSite());
-		JiraBoardConfigDTO jiraBoardConfigDTO;
 		try {
 			log.info("Start to get configuration for board, board info: " + boardRequestParam);
-			jiraBoardConfigDTO = jiraFeignClient.getJiraBoardConfiguration(baseUrl, boardRequestParam.getBoardId(),
-					boardRequestParam.getToken());
+			JiraBoardConfigDTO jiraBoardConfigDTO = jiraFeignClient.getJiraBoardConfiguration(baseUrl,
+					boardRequestParam.getBoardId(), boardRequestParam.getToken());
 			log.info("Successfully get configuration for board: " + boardRequestParam.getBoardId() + "response: "
 					+ jiraBoardConfigDTO);
 
@@ -278,7 +273,8 @@ public class JiraService {
 				QUERY_COUNT, 0, jql, boardRequestParam.getToken());
 		log.info("Successfully get first-page done card information");
 
-		AllDoneCardsResponseDTO allDoneCardsResponseDTO = formatAllDoneCards(allDoneCardResponse);
+		List<TargetField> targetField = getTargetField(baseUrl, boardRequestParam);
+		AllDoneCardsResponseDTO allDoneCardsResponseDTO = formatAllDoneCards(allDoneCardResponse, targetField);
 
 		List<JiraCard> doneCards = new ArrayList<>(new HashSet<>(allDoneCardsResponseDTO.getIssues()));
 		int pages = (int) Math.ceil(Double.parseDouble(allDoneCardsResponseDTO.getTotal()) / QUERY_COUNT);
@@ -291,7 +287,7 @@ public class JiraService {
 		List<CompletableFuture<AllDoneCardsResponseDTO>> futures = range.stream()
 			.map(startFrom -> CompletableFuture.supplyAsync(
 					() -> (formatAllDoneCards(jiraFeignClient.getAllDoneCards(baseUrl, boardRequestParam.getBoardId(),
-							QUERY_COUNT, startFrom * QUERY_COUNT, jql, boardRequestParam.getToken()))),
+							QUERY_COUNT, startFrom * QUERY_COUNT, jql, boardRequestParam.getToken()), targetField)),
 					customTaskExecutor))
 			.toList();
 		log.info("Successfully get more done card information");
@@ -305,7 +301,7 @@ public class JiraService {
 
 	}
 
-	private AllDoneCardsResponseDTO formatAllDoneCards(String allDoneCardResponse) {
+	private AllDoneCardsResponseDTO formatAllDoneCards(String allDoneCardResponse, List<TargetField> targetFields) {
 		Gson gson = new Gson();
 		AllDoneCardsResponseDTO allDoneCardsResponseDTO = gson.fromJson(allDoneCardResponse,
 				AllDoneCardsResponseDTO.class);
@@ -319,6 +315,7 @@ public class JiraService {
 		ArrayList<Integer> storyPointList = new ArrayList<>();
 		Map<String, String> resultMap = targetFields.stream()
 			.collect(Collectors.toMap(TargetField::getKey, TargetField::getName));
+		CardCustomFieldKey cardCustomFieldKey = covertCustomFieldKey(targetFields);
 		for (JsonElement element : elements) {
 			JsonObject jsonElement = element.getAsJsonObject().get("fields").getAsJsonObject();
 			JsonElement storyPoints = jsonElement.getAsJsonObject().get(cardCustomFieldKey.getStoryPoints());
@@ -418,8 +415,6 @@ public class JiraService {
 			.distinct()
 			.toList();
 		log.info("Successfully get targetField:{}", targetFields);
-		cardCustomFieldKey = saveCustomFieldKey(targetFields);
-		this.targetFields = targetFields;
 		return targetFields;
 	}
 
@@ -594,7 +589,7 @@ public class JiraService {
 		return CardCycleTime.builder().name(cardId).steps(stepsDay).total(total).build();
 	}
 
-	private CardCustomFieldKey saveCustomFieldKey(List<TargetField> model) {
+	private CardCustomFieldKey covertCustomFieldKey(List<TargetField> model) {
 		CardCustomFieldKey cardCustomFieldKey = CardCustomFieldKey.builder().build();
 		for (TargetField value : model) {
 			String lowercaseName = value.getName().toLowerCase();

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -70,10 +70,11 @@ public class JiraService {
 	private final ThreadPoolTaskExecutor customTaskExecutor;
 
 	public static final int QUERY_COUNT = 100;
+
 	private static final String DONE_CARD_TAG = "done";
 
 	public static final List<String> FIELDS_IGNORE = List.of("summary", "description", "attachment", "duedate",
-		"issuelinks");
+			"issuelinks");
 
 	private final JiraFeignClient jiraFeignClient;
 

--- a/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
@@ -27,6 +27,7 @@ import static heartbeat.service.jira.JiraBoardConfigDTOFixture.STORY_POINTS_FORM
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -446,9 +447,6 @@ class JiraServiceTest {
 
 	@Test
 	void shouldGetCardsWhenCallGetStoryPointsAndCycleTime() throws JsonProcessingException {
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
-		StatusSelfDTO doneStatusSelf = DONE_STATUS_SELF_RESPONSE_BUILDER().build();
-		StatusSelfDTO doingStatusSelf = DOING_STATUS_SELF_RESPONSE_BUILDER().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		String token = "token";
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
@@ -463,21 +461,15 @@ class JiraServiceTest {
 			.replaceAll("storyPoints", "customfield_10016");
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		doReturn(jiraBoardConfigDTO).when(jiraFeignClient).getJiraBoardConfiguration(baseUrl, BOARD_ID, token);
-		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
-		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
 		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
 			.thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "1", token))
 			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "2", token))
 			.thenReturn(CARD_HISTORY_RESPONSE_BUILDER().build());
-		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
-			.thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
+		when(jiraFeignClient.getTargetField(baseUrl, "PLL", token)).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
 		when(boardUtil.getCardTimeForEachStep(any())).thenReturn(CYCLE_TIME_INFO_LIST());
-		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 
-		jiraService.getJiraConfiguration(boardTypeJira, boardRequestParam);
 		CardCollection cardCollection = jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
 				jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 
@@ -490,10 +482,7 @@ class JiraServiceTest {
 	@Test
 	void shouldReturnIllegalArgumentExceptionWhenHaveUnknownColumn() throws JsonProcessingException {
 		String token = "token";
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
 		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_HAVE_UNKNOWN_COLUMN_BUILD().build();
-		StatusSelfDTO doneStatusSelf = DONE_STATUS_SELF_RESPONSE_BUILDER().build();
-		StatusSelfDTO doingStatusSelf = DOING_STATUS_SELF_RESPONSE_BUILDER().build();
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = STORY_POINTS_FORM_ALL_DONE_CARD().build();
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
 		String jql = String.format(
@@ -504,9 +493,6 @@ class JiraServiceTest {
 			.replaceAll("storyPoints", "customfield_10016");
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		doReturn(jiraBoardConfigDTO).when(jiraFeignClient).getJiraBoardConfiguration(baseUrl, BOARD_ID, token);
-		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
-		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
 		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
 			.thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "1", token))
@@ -514,10 +500,8 @@ class JiraServiceTest {
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "2", token))
 			.thenReturn(CARD_HISTORY_RESPONSE_BUILDER_WITHOUT_STATUS().build());
 		when(boardUtil.getCardTimeForEachStep(any())).thenReturn(CYCLE_TIME_INFO_LIST());
-		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
-			.thenReturn(FIELD_RESPONSE_BUILDER().build());
+		when(jiraFeignClient.getTargetField(baseUrl, "PLL", token)).thenReturn(FIELD_RESPONSE_BUILDER().build());
 
-		jiraService.getJiraConfiguration(boardTypeJira, boardRequestParam);
 		assertThatThrownBy(() -> jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
 				jiraBoardSetting.getBoardColumns(), List.of("Zhang San")))
 			.isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
## Summary
- [Serialization of cacheable classes.](https://github.com/au-heartbeat/Heartbeat/pull/510/commits/8f94a27f789f2419da78881ebeb03b9d162f7818)
- Refactor and delete temporary cached values in JiraService.

## Before

_Description_

Here is the reason that why to Serializable the class.

The JVM is preventing Ehcache from accessing the subgraph beneath 'private final byte[] java.lang.String.value' - cache sizes may be underestimated as a result
java.lang.reflect.InaccessibleObjectException: Unable to make field private final byte[] java.lang.String.value accessible: module java.base does not "opens java.lang" to unnamed module \@5cc73178

![image](https://github.com/au-heartbeat/Heartbeat/assets/33213627/c879f5f0-62fc-4ef5-a262-802d35723e80)


**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
