### PR TITLE
Adm 445 [backend] MTTR calculation in Pipeline

### DIFF
--- a/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AvgMeanTimeToRecovery {
 
-	private double avgMeanTimeToRecovery;
+	private final String name ="Average";
+	private double timeToRecovery;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
@@ -11,7 +11,8 @@ import lombok.NoArgsConstructor;
 @Builder
 public class AvgMeanTimeToRecovery {
 
-	private final String name ="Average";
+	private final String name = "Average";
+
 	private double timeToRecovery;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
@@ -1,0 +1,16 @@
+package heartbeat.controller.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AvgMeanTimeToRecovery {
+
+	private double avgMeanTimeToRecovery;
+
+}

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/AvgMeanTimeToRecovery.java
@@ -1,5 +1,6 @@
 package heartbeat.controller.report.dto.response;
 
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,6 +14,6 @@ public class AvgMeanTimeToRecovery {
 
 	private final String name = "Average";
 
-	private double timeToRecovery;
+	private BigDecimal timeToRecovery;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecovery.java
@@ -1,0 +1,20 @@
+package heartbeat.controller.report.dto.response;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MeanTimeToRecovery {
+
+	private AvgMeanTimeToRecovery avgMeanTimeToRecovery;
+
+	private List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines;
+
+}

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecovery.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecovery.java
@@ -1,6 +1,5 @@
 package heartbeat.controller.report.dto.response;
 
-import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
@@ -1,0 +1,20 @@
+package heartbeat.controller.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MeanTimeToRecoveryOfPipeline {
+
+	private String pipelineName;
+
+	private String pipelineStep;
+
+	private double meanTimeToRecovery;
+
+}

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
@@ -1,6 +1,7 @@
 package heartbeat.controller.report.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -18,6 +19,6 @@ public class MeanTimeToRecoveryOfPipeline {
 	@JsonProperty("step")
 	private String pipelineStep;
 
-	private double timeToRecovery;
+	private BigDecimal timeToRecovery;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MeanTimeToRecoveryOfPipeline.java
@@ -1,5 +1,6 @@
 package heartbeat.controller.report.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -11,10 +12,12 @@ import lombok.NoArgsConstructor;
 @Builder
 public class MeanTimeToRecoveryOfPipeline {
 
+	@JsonProperty("name")
 	private String pipelineName;
 
+	@JsonProperty("step")
 	private String pipelineStep;
 
-	private double meanTimeToRecovery;
+	private double timeToRecovery;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/ReportResponse.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/ReportResponse.java
@@ -23,6 +23,8 @@ public class ReportResponse {
 
 	private ChangeFailureRate changeFailureRate;
 
+	private MeanTimeToRecovery meanTimeToRecovery;
+
 	private LeadTimeForChanges leadTimeForChanges;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/TotalTimeAndRecoveryTimes.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/TotalTimeAndRecoveryTimes.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TotalTimeAndRecoveryTimes {
 
-	private double totalTimeToRecovery;
+	private long totalTimeToRecovery;
 
 	private int recoveryTimes;
 

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/TotalTimeAndRecoveryTimes.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/TotalTimeAndRecoveryTimes.java
@@ -1,0 +1,18 @@
+package heartbeat.controller.report.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TotalTimeAndRecoveryTimes {
+
+	private double totalTimeToRecovery;
+
+	private int recoveryTimes;
+
+}

--- a/backend/src/main/java/heartbeat/service/pipeline/buildkite/BuildKiteService.java
+++ b/backend/src/main/java/heartbeat/service/pipeline/buildkite/BuildKiteService.java
@@ -227,9 +227,9 @@ public class BuildKiteService {
 		if (deploymentEnvironment.getOrgId() == null) {
 			throw new NotFoundException(HttpStatus.NOT_FOUND.value(), "miss orgId argument");
 		}
-		List<DeployInfo> passedBuilds = this.getBuildsByState(buildInfos, deploymentEnvironment, "passed", startTime,
+		List<DeployInfo> passedBuilds = getBuildsByState(buildInfos, deploymentEnvironment, "passed", startTime,
 				endTime);
-		List<DeployInfo> failedBuilds = this.getBuildsByState(buildInfos, deploymentEnvironment, "failed", startTime,
+		List<DeployInfo> failedBuilds = getBuildsByState(buildInfos, deploymentEnvironment, "failed", startTime,
 				endTime);
 
 		return DeployTimes.builder()

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -61,6 +61,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.stereotype.Service;
 
@@ -222,6 +223,11 @@ public class GenerateReporterService {
 
 		if (lowMetrics.stream().anyMatch(this.buildKiteMetrics::contains)) {
 			FetchedData.BuildKiteData buildKiteData = fetchBuildKiteInfo(request);
+			val cachedBuildKiteData = fetchedData.getBuildKiteData();
+			if (cachedBuildKiteData != null) {
+				val pipelineLeadTimes = cachedBuildKiteData.getPipelineLeadTimes();
+				buildKiteData.setPipelineLeadTimes(pipelineLeadTimes);
+			}
 			fetchedData.setBuildKiteData(buildKiteData);
 		}
 

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -255,10 +255,12 @@ public class GenerateReporterService {
 			.build();
 		CardCollection nonDoneCardCollection = fetchNonDoneCardCollection(request);
 		CardCollection cardCollection = fetchCardCollection(request);
+
 		CardCollectionInfo collectionInfo = CardCollectionInfo.builder()
 			.cardCollection(cardCollection)
 			.nonDoneCardCollection(nonDoneCardCollection)
 			.build();
+
 		URI baseUrl = urlGenerator.getUri(boardRequestParam.getSite());
 
 		JiraBoardConfigDTO jiraBoardConfigDTO = jiraService.getJiraBoardConfig(baseUrl, boardRequestParam.getBoardId(),
@@ -461,8 +463,8 @@ public class GenerateReporterService {
 		FetchedData.BuildKiteData buildKiteData = fetchBuildKiteData(request.getStartTime(), request.getEndTime(),
 				request.getCodebaseSetting().getLeadTime(), request.getBuildKiteSetting().getToken());
 		Map<String, String> repoMap = getRepoMap(request.getCodebaseSetting());
-		List<PipelineLeadTime> pipelineLeadTimes = gitHubService.fetchPipelinesLeadTime(buildKiteData.getDeployTimesList(), repoMap,
-				request.getCodebaseSetting().getToken());
+		List<PipelineLeadTime> pipelineLeadTimes = gitHubService.fetchPipelinesLeadTime(
+				buildKiteData.getDeployTimesList(), repoMap, request.getCodebaseSetting().getToken());
 		return BuildKiteData.builder()
 			.pipelineLeadTimes(pipelineLeadTimes)
 			.buildInfosList(buildKiteData.getBuildInfosList())

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -59,12 +59,7 @@ public class MeanToRecoveryCalculator {
 	}
 
 	private BigDecimal stripTrailingZeros(BigDecimal timeToRecovery) {
-		if (timeToRecovery.scale() <= 0) {
-			return timeToRecovery.setScale(0, RoundingMode.DOWN);
-		}
-		else {
-			return timeToRecovery.stripTrailingZeros();
-		}
+		return timeToRecovery.stripTrailingZeros();
 	}
 
 	private TotalTimeAndRecoveryTimes getTotalRecoveryTimeAndRecoveryTimes(DeployTimes deploy) {

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -10,6 +10,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +24,9 @@ import org.springframework.stereotype.Component;
 public class MeanToRecoveryCalculator {
 
 	public MeanTimeToRecovery calculate(List<DeployTimes> deployTimes) {
+		if (deployTimes.isEmpty()) {
+			return new MeanTimeToRecovery(new AvgMeanTimeToRecovery(BigDecimal.ZERO), Collections.emptyList());
+		}
 		List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines = deployTimes.stream()
 			.map(this::convertToMeanTimeToRecoveryOfPipeline)
 			.collect(Collectors.toList());

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -8,22 +8,17 @@ import heartbeat.controller.report.dto.response.MeanTimeToRecoveryOfPipeline;
 import heartbeat.controller.report.dto.response.TotalTimeAndRecoveryTimes;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
-import lombok.val;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
 @Component
-@Log4j2
 public class MeanToRecoveryCalculator {
 
 	public MeanTimeToRecovery calculate(List<DeployTimes> deployTimes) {
-		log.info("Guoqing test deploy: {}", deployTimes);
 		List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines = deployTimes.stream()
 			.map(this::convertToMeanTimeToRecoveryOfPipeline)
 			.collect(Collectors.toList());
@@ -39,7 +34,6 @@ public class MeanToRecoveryCalculator {
 	}
 
 	private MeanTimeToRecoveryOfPipeline convertToMeanTimeToRecoveryOfPipeline(DeployTimes deploy) {
-		log.info("Guoqing test deploy22: {}", deploy);
 		if (deploy.getFailed().isEmpty()) {
 			return new MeanTimeToRecoveryOfPipeline(deploy.getPipelineName(), deploy.getPipelineStep(), 0);
 		}

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -14,7 +14,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor
@@ -27,7 +26,7 @@ public class MeanToRecoveryCalculator {
 			.collect(Collectors.toList());
 
 		double avgMeanTimeToRecovery = meanTimeRecoveryPipelines.stream()
-			.mapToDouble(MeanTimeToRecoveryOfPipeline::getMeanTimeToRecovery)
+			.mapToDouble(MeanTimeToRecoveryOfPipeline::getTimeToRecovery)
 			.average()
 			.orElse(0);
 		AvgMeanTimeToRecovery avgMeanTimeToRecoveryObj = new AvgMeanTimeToRecovery(

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -37,7 +37,7 @@ public class MeanToRecoveryCalculator {
 	}
 
 	private double getFormattedTime(double time) {
-		BigDecimal decimal = new BigDecimal(time);
+		BigDecimal decimal = new BigDecimal(String.valueOf(time));
 		return decimal.setScale(1, RoundingMode.HALF_UP).doubleValue();
 	}
 

--- a/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/MeanToRecoveryCalculator.java
@@ -1,0 +1,78 @@
+package heartbeat.service.report.calculator;
+
+import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
+import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
+import heartbeat.controller.report.dto.response.AvgMeanTimeToRecovery;
+import heartbeat.controller.report.dto.response.MeanTimeToRecovery;
+import heartbeat.controller.report.dto.response.MeanTimeToRecoveryOfPipeline;
+import heartbeat.controller.report.dto.response.TotalTimeAndRecoveryTimes;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import lombok.val;
+import org.springframework.stereotype.Component;
+
+@RequiredArgsConstructor
+@Component
+@Log4j2
+public class MeanToRecoveryCalculator {
+
+	public MeanTimeToRecovery calculate(List<DeployTimes> deployTimes) {
+		log.info("Guoqing test deploy: {}", deployTimes);
+		List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines = deployTimes.stream()
+			.map(this::convertToMeanTimeToRecoveryOfPipeline)
+			.collect(Collectors.toList());
+
+		double avgMeanTimeToRecovery = meanTimeRecoveryPipelines.stream()
+			.mapToDouble(MeanTimeToRecoveryOfPipeline::getMeanTimeToRecovery)
+			.average()
+			.orElse(0);
+
+		AvgMeanTimeToRecovery avgMeanTimeToRecoveryObj = new AvgMeanTimeToRecovery(avgMeanTimeToRecovery);
+
+		return new MeanTimeToRecovery(avgMeanTimeToRecoveryObj, meanTimeRecoveryPipelines);
+	}
+
+	private MeanTimeToRecoveryOfPipeline convertToMeanTimeToRecoveryOfPipeline(DeployTimes deploy) {
+		log.info("Guoqing test deploy22: {}", deploy);
+		if (deploy.getFailed().isEmpty()) {
+			return new MeanTimeToRecoveryOfPipeline(deploy.getPipelineName(), deploy.getPipelineStep(), 0);
+		}
+		else {
+			TotalTimeAndRecoveryTimes result = getTotalRecoveryTimeAndRecoveryTimes(deploy);
+			double meanTimeToRecovery = result.getTotalTimeToRecovery() / result.getRecoveryTimes();
+			return new MeanTimeToRecoveryOfPipeline(deploy.getPipelineName(), deploy.getPipelineStep(),
+					meanTimeToRecovery);
+		}
+	}
+
+	private TotalTimeAndRecoveryTimes getTotalRecoveryTimeAndRecoveryTimes(DeployTimes deploy) {
+		List<DeployInfo> sortedJobs = new ArrayList<>(deploy.getFailed());
+		sortedJobs.addAll(deploy.getPassed());
+		sortedJobs.sort(Comparator.comparing(DeployInfo::getPipelineCreateTime));
+
+		long totalTimeToRecovery = 0;
+		long failedJobCreateTime = 0;
+		int recoveryTimes = 0;
+
+		for (DeployInfo job : sortedJobs) {
+			long pipelineCreateTime = Instant.parse(job.getPipelineCreateTime()).toEpochMilli();
+			if ("passed".equals(job.getState()) && failedJobCreateTime != 0) {
+				totalTimeToRecovery += pipelineCreateTime - failedJobCreateTime;
+				failedJobCreateTime = 0;
+				recoveryTimes++;
+			}
+			if ("failed".equals(job.getState()) && failedJobCreateTime == 0) {
+				failedJobCreateTime = pipelineCreateTime;
+			}
+		}
+
+		return new TotalTimeAndRecoveryTimes(totalTimeToRecovery, recoveryTimes);
+	}
+
+}

--- a/backend/src/main/java/heartbeat/service/report/calculator/model/FetchedData.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/model/FetchedData.java
@@ -14,8 +14,6 @@ public class FetchedData {
 
 	private CardCollectionInfo cardCollectionInfo;
 
-	private List<PipelineLeadTime> pipelineLeadTimes;
-
 	private BuildKiteData buildKiteData;
 
 	@Data
@@ -31,6 +29,8 @@ public class FetchedData {
 	@Data
 	@Builder
 	public static class BuildKiteData {
+
+		private List<PipelineLeadTime> pipelineLeadTimes;
 
 		private List<DeployTimes> deployTimesList;
 

--- a/backend/src/main/java/heartbeat/service/report/calculator/model/FetchedData.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/model/FetchedData.java
@@ -1,0 +1,43 @@
+package heartbeat.service.report.calculator.model;
+
+import heartbeat.client.dto.codebase.github.PipelineLeadTime;
+import heartbeat.client.dto.pipeline.buildkite.BuildKiteBuildInfo;
+import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
+import heartbeat.controller.board.dto.response.CardCollection;
+import java.util.List;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class FetchedData {
+
+	private CardCollectionInfo cardCollectionInfo;
+
+	private List<PipelineLeadTime> pipelineLeadTimes;
+
+	private BuildKiteData buildKiteData;
+
+	@Data
+	@Builder
+	public static class CardCollectionInfo {
+
+		private CardCollection cardCollection;
+
+		private CardCollection nonDoneCardCollection;
+
+	}
+
+	@Data
+	@Builder
+	public static class BuildKiteData {
+
+		private List<DeployTimes> deployTimesList;
+
+		private List<Map.Entry<String, List<BuildKiteBuildInfo>>> buildInfosList;
+
+		private List<Map.Entry<String, List<BuildKiteBuildInfo>>> leadTimeBuildInfosList;
+
+	}
+
+}

--- a/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
@@ -62,7 +62,7 @@ class MeanToRecoveryCalculatorTest {
 		MeanTimeToRecoveryOfPipeline deploy2Result = meanTimeRecoveryPipelines.get(1);
 		Assertions.assertEquals("Pipeline 2", deploy2Result.getPipelineName());
 		Assertions.assertEquals("Step 2", deploy2Result.getPipelineStep());
-		Assertions.assertEquals(0, deploy2Result.getTimeToRecovery().compareTo(BigDecimal.valueOf(120000.0)));
+		Assertions.assertEquals(0, deploy2Result.getTimeToRecovery().compareTo(BigDecimal.valueOf(120000)));
 
 		MeanTimeToRecoveryOfPipeline deploy3Result = meanTimeRecoveryPipelines.get(2);
 		Assertions.assertEquals("Pipeline 3", deploy3Result.getPipelineName());

--- a/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
@@ -6,6 +6,7 @@ import heartbeat.controller.report.dto.response.AvgMeanTimeToRecovery;
 import heartbeat.controller.report.dto.response.MeanTimeToRecovery;
 import heartbeat.controller.report.dto.response.MeanTimeToRecoveryOfPipeline;
 import heartbeat.service.report.calculator.MeanToRecoveryCalculator;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -28,7 +29,7 @@ class MeanToRecoveryCalculatorTest {
 
 		MeanTimeToRecovery result = calculator.calculate(deployTimes);
 
-		Assertions.assertEquals(0, result.getAvgMeanTimeToRecovery().getAvgMeanTimeToRecovery());
+		Assertions.assertEquals(BigDecimal.ZERO, result.getAvgMeanTimeToRecovery().getTimeToRecovery());
 		Assertions.assertTrue(result.getMeanTimeRecoveryPipelines().isEmpty());
 	}
 
@@ -48,7 +49,7 @@ class MeanToRecoveryCalculatorTest {
 		MeanTimeToRecovery result = calculator.calculate(deployTimesList);
 
 		AvgMeanTimeToRecovery avgMeanTimeToRecovery = result.getAvgMeanTimeToRecovery();
-		Assertions.assertEquals(100000.0, avgMeanTimeToRecovery.getAvgMeanTimeToRecovery());
+		Assertions.assertEquals(0, avgMeanTimeToRecovery.getTimeToRecovery().compareTo(BigDecimal.valueOf(100000)));
 
 		List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines = result.getMeanTimeRecoveryPipelines();
 		Assertions.assertEquals(3, meanTimeRecoveryPipelines.size());
@@ -56,17 +57,17 @@ class MeanToRecoveryCalculatorTest {
 		MeanTimeToRecoveryOfPipeline deploy1Result = meanTimeRecoveryPipelines.get(0);
 		Assertions.assertEquals("Pipeline 1", deploy1Result.getPipelineName());
 		Assertions.assertEquals("Step 1", deploy1Result.getPipelineStep());
-		Assertions.assertEquals(180000.0, deploy1Result.getTimeToRecovery());
+		Assertions.assertEquals(0, deploy1Result.getTimeToRecovery().compareTo(BigDecimal.valueOf(180000)));
 
 		MeanTimeToRecoveryOfPipeline deploy2Result = meanTimeRecoveryPipelines.get(1);
 		Assertions.assertEquals("Pipeline 2", deploy2Result.getPipelineName());
 		Assertions.assertEquals("Step 2", deploy2Result.getPipelineStep());
-		Assertions.assertEquals(120000.0, deploy2Result.getTimeToRecovery());
+		Assertions.assertEquals(0, deploy2Result.getTimeToRecovery().compareTo(BigDecimal.valueOf(120000.0)));
 
 		MeanTimeToRecoveryOfPipeline deploy3Result = meanTimeRecoveryPipelines.get(2);
 		Assertions.assertEquals("Pipeline 3", deploy3Result.getPipelineName());
 		Assertions.assertEquals("Step 3", deploy3Result.getPipelineStep());
-		Assertions.assertEquals(0.0, deploy3Result.getTimeToRecovery());
+		Assertions.assertEquals(BigDecimal.ZERO, deploy3Result.getTimeToRecovery());
 	}
 
 	private DeployTimes createDeployTimes(String pipelineName, String pipelineStep, int failedCount, int passedCount) {

--- a/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
@@ -1,0 +1,105 @@
+package heartbeat.service.report;
+
+import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
+import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
+import heartbeat.controller.report.dto.response.AvgMeanTimeToRecovery;
+import heartbeat.controller.report.dto.response.MeanTimeToRecovery;
+import heartbeat.controller.report.dto.response.MeanTimeToRecoveryOfPipeline;
+import heartbeat.service.report.calculator.MeanToRecoveryCalculator;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MeanToRecoveryCalculatorTest {
+
+	@InjectMocks
+	private MeanToRecoveryCalculator calculator;
+
+	@Test
+	public void shouldReturnZeroAvgMeanTimeToRecoveryWhenDeployTimesIsEmpty() {
+		List<DeployTimes> deployTimes = new ArrayList<>();
+
+		MeanTimeToRecovery result = calculator.calculate(deployTimes);
+
+		Assertions.assertEquals(0, result.getAvgMeanTimeToRecovery().getAvgMeanTimeToRecovery());
+		Assertions.assertTrue(result.getMeanTimeRecoveryPipelines().isEmpty());
+	}
+
+	@Test
+	void shouldCalculateMeanTimeToRecoveryWhenDeployTimesIsNotEmpty() {
+		DeployTimes deploy1 = createDeployTimes("Pipeline 1", "Step 1", 2, 3);
+
+		DeployTimes deploy2 = createDeployTimes("Pipeline 2", "Step 2", 1, 2);
+
+		DeployTimes deploy3 = createDeployTimes("Pipeline 3", "Step 3", 0, 3);
+
+		List<DeployTimes> deployTimesList = new ArrayList<>();
+		deployTimesList.add(deploy1);
+		deployTimesList.add(deploy2);
+		deployTimesList.add(deploy3);
+
+		MeanTimeToRecovery result = calculator.calculate(deployTimesList);
+
+		AvgMeanTimeToRecovery avgMeanTimeToRecovery = result.getAvgMeanTimeToRecovery();
+		Assertions.assertEquals(100000.0, avgMeanTimeToRecovery.getAvgMeanTimeToRecovery());
+
+		List<MeanTimeToRecoveryOfPipeline> meanTimeRecoveryPipelines = result.getMeanTimeRecoveryPipelines();
+		Assertions.assertEquals(3, meanTimeRecoveryPipelines.size());
+
+		MeanTimeToRecoveryOfPipeline deploy1Result = meanTimeRecoveryPipelines.get(0);
+		Assertions.assertEquals("Pipeline 1", deploy1Result.getPipelineName());
+		Assertions.assertEquals("Step 1", deploy1Result.getPipelineStep());
+		Assertions.assertEquals(180000.0, deploy1Result.getMeanTimeToRecovery());
+
+		MeanTimeToRecoveryOfPipeline deploy2Result = meanTimeRecoveryPipelines.get(1);
+		Assertions.assertEquals("Pipeline 2", deploy2Result.getPipelineName());
+		Assertions.assertEquals("Step 2", deploy2Result.getPipelineStep());
+		Assertions.assertEquals(120000.0, deploy2Result.getMeanTimeToRecovery());
+
+		MeanTimeToRecoveryOfPipeline deploy3Result = meanTimeRecoveryPipelines.get(2);
+		Assertions.assertEquals("Pipeline 3", deploy3Result.getPipelineName());
+		Assertions.assertEquals("Step 3", deploy3Result.getPipelineStep());
+		Assertions.assertEquals(0.0, deploy3Result.getMeanTimeToRecovery());
+	}
+
+	private DeployTimes createDeployTimes(String pipelineName, String pipelineStep, int failedCount, int passedCount) {
+		DeployTimes deployTimes = new DeployTimes();
+		deployTimes.setPipelineName(pipelineName);
+		deployTimes.setPipelineStep(pipelineStep);
+
+		List<DeployInfo> failed = new ArrayList<>();
+		List<DeployInfo> passed = new ArrayList<>();
+
+		Instant baseTimestamp = Instant.parse("2023-06-25T18:28:54.981Z");
+		long interval = 60 * 1000L;
+
+		for (int i = 1; i <= failedCount; i++) {
+			DeployInfo failedJob = new DeployInfo();
+			failedJob.setState("failed");
+			failedJob
+				.setPipelineCreateTime(DateTimeFormatter.ISO_INSTANT.format(baseTimestamp.minusMillis(i * interval)));
+			failed.add(failedJob);
+		}
+
+		for (int i = 1; i <= passedCount; i++) {
+			DeployInfo passedJob = new DeployInfo();
+			passedJob.setState("passed");
+			passedJob
+				.setPipelineCreateTime(DateTimeFormatter.ISO_INSTANT.format(baseTimestamp.plusMillis(i * interval)));
+			passed.add(passedJob);
+		}
+
+		deployTimes.setFailed(failed);
+		deployTimes.setPassed(passed);
+
+		return deployTimes;
+	}
+
+}

--- a/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/MeanToRecoveryCalculatorTest.java
@@ -56,17 +56,17 @@ class MeanToRecoveryCalculatorTest {
 		MeanTimeToRecoveryOfPipeline deploy1Result = meanTimeRecoveryPipelines.get(0);
 		Assertions.assertEquals("Pipeline 1", deploy1Result.getPipelineName());
 		Assertions.assertEquals("Step 1", deploy1Result.getPipelineStep());
-		Assertions.assertEquals(180000.0, deploy1Result.getMeanTimeToRecovery());
+		Assertions.assertEquals(180000.0, deploy1Result.getTimeToRecovery());
 
 		MeanTimeToRecoveryOfPipeline deploy2Result = meanTimeRecoveryPipelines.get(1);
 		Assertions.assertEquals("Pipeline 2", deploy2Result.getPipelineName());
 		Assertions.assertEquals("Step 2", deploy2Result.getPipelineStep());
-		Assertions.assertEquals(120000.0, deploy2Result.getMeanTimeToRecovery());
+		Assertions.assertEquals(120000.0, deploy2Result.getTimeToRecovery());
 
 		MeanTimeToRecoveryOfPipeline deploy3Result = meanTimeRecoveryPipelines.get(2);
 		Assertions.assertEquals("Pipeline 3", deploy3Result.getPipelineName());
 		Assertions.assertEquals("Step 3", deploy3Result.getPipelineStep());
-		Assertions.assertEquals(0.0, deploy3Result.getMeanTimeToRecovery());
+		Assertions.assertEquals(0.0, deploy3Result.getTimeToRecovery());
 	}
 
 	private DeployTimes createDeployTimes(String pipelineName, String pipelineStep, int failedCount, int passedCount) {

--- a/backend/src/test/java/heartbeat/service/report/calculator/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/MeanToRecoveryCalculatorTest.java
@@ -1,5 +1,0 @@
-package heartbeat.service.report.calculator;
-
-class MeanToRecoveryCalculatorTest {
-
-}

--- a/backend/src/test/java/heartbeat/service/report/calculator/MeanToRecoveryCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/MeanToRecoveryCalculatorTest.java
@@ -1,0 +1,5 @@
+package heartbeat.service.report.calculator;
+
+class MeanToRecoveryCalculatorTest {
+
+}


### PR DESCRIPTION
## Summary
- [format the recovery time to strip the trailing zeros.](https://github.com/au-heartbeat/Heartbeat/pull/516/commits/7e02cac07979ee8f3c5f9db1a114d479209ea605)
- calculate the value of mean time to recovery.
- Refactor and delete temporary cached values in GenerateReporterService.
...

## Before

_Description_

**Screenshots**
**new:** 
![image](https://github.com/au-heartbeat/Heartbeat/assets/33213627/2a80ecb9-ded6-473f-a864-da99d01f622c)
**old:**
![image](https://github.com/au-heartbeat/Heartbeat/assets/33213627/4daf8866-ab2f-4447-bb54-20825d16fefa)


## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
