### PR TITLE
ADM-496 [frontend] Export board CSV

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -1,6 +1,12 @@
 import { act, render, waitFor } from '@testing-library/react'
 import { ReportStep } from '@src/components/Metrics/ReportStep'
-import { BACK, EXPECTED_REPORT_VALUES, EXPORT_PIPELINE_DATA, REQUIRED_DATA_LIST } from '../../../fixtures'
+import {
+  BACK,
+  EXPECTED_REPORT_VALUES,
+  EXPORT_BOARD_DATA,
+  EXPORT_PIPELINE_DATA,
+  REQUIRED_DATA_LIST,
+} from '../../../fixtures'
 import { setupStore } from '../../../utils/setupStoreUtil'
 import { Provider } from 'react-redux'
 import { updateDeploymentFrequencySettings } from '@src/context/Metrics/metricsSlice'
@@ -122,6 +128,32 @@ describe('Report Step', () => {
     const { getByText } = await act(() => setup([REQUIRED_DATA_LIST[4]]))
 
     await userEvent.click(getByText(EXPORT_PIPELINE_DATA))
+
+    expect(getByText('failed export csv')).toBeInTheDocument()
+  })
+
+  it('should not show export board button when not select board metrics', async () => {
+    const { queryByText } = await act(() => setup([REQUIRED_DATA_LIST[4]]))
+
+    const exportPipelineButton = queryByText(EXPORT_BOARD_DATA)
+
+    expect(exportPipelineButton).not.toBeInTheDocument()
+  })
+
+  it.each([[REQUIRED_DATA_LIST[1]], [REQUIRED_DATA_LIST[2]], [REQUIRED_DATA_LIST[3]]])(
+    'should show export board button when select %s',
+    async (requiredData) => {
+      const { getByText } = await act(() => setup([requiredData]))
+      const exportPipelineButton = getByText(EXPORT_BOARD_DATA)
+
+      expect(exportPipelineButton).toBeInTheDocument()
+    }
+  )
+
+  it('should show errorMessage when click export board button given csv not exist', async () => {
+    const { getByText } = await act(() => setup([REQUIRED_DATA_LIST[1]]))
+
+    await userEvent.click(getByText(EXPORT_BOARD_DATA))
 
     expect(getByText('failed export csv')).toBeInTheDocument()
   })

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -22,6 +22,8 @@ export const RESET = 'Reset'
 
 export const EXPORT_PIPELINE_DATA = 'Export pipeline data'
 
+export const EXPORT_BOARD_DATA = 'Export board data'
+
 export const VERIFIED = 'Verified'
 
 export const TOKEN_ERROR_MESSAGE = ['Token is invalid', 'Token is required']

--- a/frontend/cypress/e2e/createANewProject.cy.ts
+++ b/frontend/cypress/e2e/createANewProject.cy.ts
@@ -165,6 +165,13 @@ const checkPipelineCSV = () => {
   })
 }
 
+const checkBoardCSV = () => {
+  cy.wait(2000)
+  return cy.task('readDir', 'cypress/downloads').then((files) => {
+    expect(files).to.match(new RegExp(/board-data-.*\.csv/))
+  })
+}
+
 const checkFieldsExist = (fields: string[]) => {
   fields.forEach((item) => {
     cy.contains(item).should('exist')
@@ -256,6 +263,12 @@ describe('Create a new project', () => {
     reportPage.exportPipelineData()
 
     checkPipelineCSV()
+
+    reportPage.exportBoardDataButton().should('be.enabled')
+
+    reportPage.exportBoardData()
+
+    checkBoardCSV()
   })
 
   it('Should have data in metrics page when back from report page', () => {

--- a/frontend/cypress/pages/metrics/report.ts
+++ b/frontend/cypress/pages/metrics/report.ts
@@ -4,6 +4,7 @@ class Report {
   readonly deploymentFrequencyTitle = () => cy.contains('Deployment frequency')
   readonly backButton = () => cy.contains('Back')
   readonly exportPipelineDataButton = () => cy.contains('Export pipeline data')
+  readonly exportBoardDataButton = () => cy.contains('Export board data')
 
   backToMetricsStep() {
     this.backButton().click()
@@ -11,6 +12,10 @@ class Report {
 
   exportPipelineData() {
     this.exportPipelineDataButton().click()
+  }
+
+  exportBoardData() {
+    this.exportBoardDataButton().click()
   }
 }
 

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -124,8 +124,8 @@ export const ReportStep = () => {
     csvTimeStamp: csvTimeStamp,
   })
 
-  const getExportPipelineCSV = (): CSVReportRequestDTO => ({
-    dataType: 'pipeline',
+  const getExportCSV = (dataType: string): CSVReportRequestDTO => ({
+    dataType: dataType,
     csvTimeStamp: csvTimeStamp,
   })
 
@@ -169,8 +169,8 @@ export const ReportStep = () => {
     })
   }, [fetchReportData])
 
-  const handleDownload = () => {
-    fetchExportData(getExportPipelineCSV())
+  const handleDownload = (dataType: string) => {
+    fetchExportData(getExportCSV(dataType))
   }
 
   const handleBack = () => {
@@ -224,8 +224,12 @@ export const ReportStep = () => {
           )}
           <ButtonGroupStyle>
             <BackButton onClick={handleBack}>Back</BackButton>
-            {isShowExportBoardButton && <ExportButton>Export board data</ExportButton>}
-            {isShowExportPipelineButton && <ExportButton onClick={handleDownload}>Export pipeline data</ExportButton>}
+            {isShowExportBoardButton && (
+              <ExportButton onClick={() => handleDownload('board')}>Export board data</ExportButton>
+            )}
+            {isShowExportPipelineButton && (
+              <ExportButton onClick={() => handleDownload('pipeline')}>Export pipeline data</ExportButton>
+            )}
           </ButtonGroupStyle>
         </>
       )}


### PR DESCRIPTION
## Summary

- Export board CSV

## After

<img width="943" alt="Screenshot 2023-06-29 at 10 50 30" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/e787ab6a-c766-47f2-b7f6-7a517bf41631">

