### PR TITLE
ADM-471: [frontend] Error handling enhancement for frontend

### DIFF
--- a/frontend/__tests__/src/client/BoardClient.test.ts
+++ b/frontend/__tests__/src/client/BoardClient.test.ts
@@ -36,7 +36,7 @@ describe('verify board request', () => {
 
     const result = await boardClient.getVerifyBoard(MOCK_BOARD_VERIFY_REQUEST_PARAMS)
 
-    expect(result.isNoDoneCard).toEqual(true)
+    expect(result.haveDoneCard).toEqual(false)
     expect(result.isBoardVerify).toEqual(false)
   })
 

--- a/frontend/__tests__/src/client/MetricsClient.test.ts
+++ b/frontend/__tests__/src/client/MetricsClient.test.ts
@@ -20,7 +20,7 @@ describe('get steps from metrics response', () => {
 
     const result = await metricsClient.getSteps(params, buildId, organizationId, pipelineType, token)
 
-    expect(result).toEqual({ response: ['step1'], isNoStep: false })
+    expect(result).toEqual({ response: ['step1'], haveStep: true })
   })
 
   it('should throw error when getSteps response status 500', async () => {
@@ -55,6 +55,6 @@ describe('get steps from metrics response', () => {
 
     const result = await metricsClient.getSteps(params, buildId, organizationId, pipelineType, token)
 
-    expect(result).toEqual({ response: [], isNoStep: true })
+    expect(result).toEqual({ response: [], haveStep: false })
   })
 })

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -143,7 +143,7 @@ describe('PipelineMetricSelection', () => {
     expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
   })
   it('should show no steps warning message when getSteps succeed but get no steps', async () => {
-    metricsClient.getSteps = jest.fn().mockReturnValue({ response: [], isNoStep: true })
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: [], haveStep: false })
     const { getByText, getByRole } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: '' },
       false,
@@ -164,7 +164,7 @@ describe('PipelineMetricSelection', () => {
   })
 
   it('should show steps selection when getSteps succeed ', async () => {
-    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], isNoStep: false })
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], haveStep: true })
     const { getByRole, getByText } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: '' },
       false,
@@ -183,7 +183,7 @@ describe('PipelineMetricSelection', () => {
   })
 
   it('should show duplicated message given duplicated id', async () => {
-    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], isNoStep: false })
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], haveStep: true })
     const { getByText } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: 'step1' },
       false,

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -143,7 +143,7 @@ describe('PipelineMetricSelection', () => {
     expect(mockUpdatePipeline).toHaveBeenCalledTimes(2)
   })
   it('should show no steps warning message when getSteps succeed but get no steps', async () => {
-    metricsClient.getSteps = jest.fn().mockImplementation(() => [])
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: [], isNoStep: true })
     const { getByText, getByRole } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: '' },
       false,
@@ -164,7 +164,7 @@ describe('PipelineMetricSelection', () => {
   })
 
   it('should show steps selection when getSteps succeed ', async () => {
-    metricsClient.getSteps = jest.fn().mockImplementation(() => ['steps'])
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], isNoStep: false })
     const { getByRole, getByText } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: '' },
       false,
@@ -183,7 +183,7 @@ describe('PipelineMetricSelection', () => {
   })
 
   it('should show duplicated message given duplicated id', async () => {
-    metricsClient.getSteps = jest.fn().mockImplementation(() => ['steps'])
+    metricsClient.getSteps = jest.fn().mockReturnValue({ response: ['steps'], isNoStep: false })
     const { getByText } = await setup(
       { id: 0, organization: 'mockOrgName', pipelineName: 'mockName', step: 'step1' },
       false,

--- a/frontend/__tests__/src/context/metricsSlice.test.ts
+++ b/frontend/__tests__/src/context/metricsSlice.test.ts
@@ -22,8 +22,7 @@ import saveMetricsSettingReducer, {
   updateTreatFlagCardAsBlock,
 } from '@src/context/Metrics/metricsSlice'
 import { store } from '@src/store'
-import { PIPELINE_SETTING_TYPES } from '../fixtures'
-import { CLASSIFICATION_WARNING_MESSAGE } from '../fixtures'
+import { CLASSIFICATION_WARNING_MESSAGE, PIPELINE_SETTING_TYPES } from '../fixtures'
 import { ORGANIZATION_WARNING_MESSAGE, PIPELINE_NAME_WARNING_MESSAGE, REAL_DONE_WARNING_MESSAGE } from '@src/constants'
 import { setupStore } from '../utils/setupStoreUtil'
 
@@ -516,7 +515,14 @@ describe('saveMetricsSetting reducer', () => {
         { id: 0, organization: 'mockOrganization1', pipelineName: 'mockPipelineName1', step: '' },
         { id: 1, organization: 'mockOrganization1', pipelineName: 'mockPipelineName2', step: '' },
       ],
-      leadTimeForChanges: [{ id: 0, organization: 'mockOrganization1', pipelineName: 'mockPipelineName1', step: '' }],
+      leadTimeForChanges: [
+        {
+          id: 0,
+          organization: 'mockOrganization1',
+          pipelineName: 'mockPipelineName1',
+          step: '',
+        },
+      ],
       importedData: {
         ...initState.importedData,
         importedDeployment: mockImportedDeployment,
@@ -574,7 +580,14 @@ describe('saveMetricsSetting reducer', () => {
         id: 1,
         steps: mockSteps,
         type: PIPELINE_SETTING_TYPES.LEAD_TIME_FOR_CHANGES_TYPE,
-        expectedSettings: [{ id: 0, organization: 'mockOrganization1', pipelineName: 'mockPipelineName1', step: '' }],
+        expectedSettings: [
+          {
+            id: 0,
+            organization: 'mockOrganization1',
+            pipelineName: 'mockPipelineName1',
+            step: '',
+          },
+        ],
         expectedWarning: [{ id: 0, organization: null, pipelineName: null, step: null }],
       },
     ]
@@ -918,10 +931,18 @@ describe('saveMetricsSetting reducer', () => {
       await store.dispatch(updateMetricsImportedData(mockImportData))
       await store.dispatch(updatePipelineSettings({ pipelineList: mockPipelineList, isProjectCreated: false }))
       await store.dispatch(
-        updatePipelineStep({ steps: mockSteps, id: 0, type: PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE })
+        updatePipelineStep({
+          steps: mockSteps,
+          id: 0,
+          type: PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE,
+        })
       )
       await store.dispatch(
-        updatePipelineStep({ steps: mockSteps, id: 1, type: PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE })
+        updatePipelineStep({
+          steps: mockSteps,
+          id: 1,
+          type: PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE,
+        })
       )
       await store.dispatch(
         updatePipelineStep({ steps: mockSteps, id: 0, type: PIPELINE_SETTING_TYPES.LEAD_TIME_FOR_CHANGES_TYPE })

--- a/frontend/src/clients/MetricsClient.ts
+++ b/frontend/src/clients/MetricsClient.ts
@@ -11,7 +11,7 @@ export interface getStepsParams {
 
 export class MetricsClient extends HttpClient {
   steps: string[] = []
-  isNoStep = false
+  haveStep = true
 
   getSteps = async (
     params: getStepsParams,
@@ -21,7 +21,7 @@ export class MetricsClient extends HttpClient {
     token: string
   ) => {
     this.steps = []
-    this.isNoStep = false
+    this.haveStep = true
     const result = await this.axiosInstance.get(
       `/pipelines/${pipelineType}/${organizationId}/pipelines/${buildId}/steps`,
       {
@@ -31,10 +31,10 @@ export class MetricsClient extends HttpClient {
         params,
       }
     )
-    result.status === HttpStatusCode.NoContent ? (this.isNoStep = true) : (this.steps = result.data.steps)
+    result.status === HttpStatusCode.NoContent ? (this.haveStep = false) : (this.steps = result.data.steps)
     return {
       response: this.steps,
-      isNoStep: this.isNoStep,
+      haveStep: this.haveStep,
     }
   }
 }

--- a/frontend/src/clients/MetricsClient.ts
+++ b/frontend/src/clients/MetricsClient.ts
@@ -1,4 +1,5 @@
 import { HttpClient } from '@src/clients/Httpclient'
+import { HttpStatusCode } from 'axios'
 
 export interface getStepsParams {
   pipelineName: string
@@ -10,6 +11,7 @@ export interface getStepsParams {
 
 export class MetricsClient extends HttpClient {
   steps: string[] = []
+  isNoStep = false
 
   getSteps = async (
     params: getStepsParams,
@@ -18,20 +20,22 @@ export class MetricsClient extends HttpClient {
     pipelineType: string,
     token: string
   ) => {
-    await this.axiosInstance
-      .get(`/pipelines/${pipelineType}/${organizationId}/pipelines/${buildId}/steps`, {
+    this.steps = []
+    this.isNoStep = false
+    const result = await this.axiosInstance.get(
+      `/pipelines/${pipelineType}/${organizationId}/pipelines/${buildId}/steps`,
+      {
         headers: {
           Authorization: `${token}`,
         },
         params,
-      })
-      .then((res) => {
-        this.steps = res.data.steps
-      })
-      .catch((e) => {
-        throw e
-      })
-    return this.steps
+      }
+    )
+    result.status === HttpStatusCode.NoContent ? (this.isNoStep = true) : (this.steps = result.data.steps)
+    return {
+      response: this.steps,
+      isNoStep: this.isNoStep,
+    }
   }
 }
 

--- a/frontend/src/clients/board/BoardClient.ts
+++ b/frontend/src/clients/board/BoardClient.ts
@@ -8,6 +8,9 @@ export class BoardClient extends HttpClient {
   response = {}
 
   getVerifyBoard = async (params: BoardRequestDTO) => {
+    this.isBoardVerify = false
+    this.isNoDoneCard = false
+    this.response = {}
     try {
       const boardType = params.type === 'Classic Jira' ? 'classic-jira' : params.type.toLowerCase()
       const result = await this.axiosInstance.get(`/boards/${boardType}`, { params })

--- a/frontend/src/clients/board/BoardClient.ts
+++ b/frontend/src/clients/board/BoardClient.ts
@@ -4,12 +4,12 @@ import { BoardRequestDTO } from '@src/clients/board/dto/request'
 
 export class BoardClient extends HttpClient {
   isBoardVerify = false
-  isNoDoneCard = false
+  haveDoneCard = true
   response = {}
 
   getVerifyBoard = async (params: BoardRequestDTO) => {
     this.isBoardVerify = false
-    this.isNoDoneCard = false
+    this.haveDoneCard = true
     this.response = {}
     try {
       const boardType = params.type === 'Classic Jira' ? 'classic-jira' : params.type.toLowerCase()
@@ -24,13 +24,13 @@ export class BoardClient extends HttpClient {
     return {
       response: this.response,
       isBoardVerify: this.isBoardVerify,
-      isNoDoneCard: this.isNoDoneCard,
+      haveDoneCard: this.haveDoneCard,
     }
   }
 
   handleBoardNoDoneCard = () => {
     this.isBoardVerify = false
-    this.isNoDoneCard = true
+    this.haveDoneCard = false
   }
 
   handleBoardVerifySucceed = (res: object) => {

--- a/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
@@ -15,10 +15,10 @@ import {
   selectBoard,
   selectDateRange,
   selectIsBoardVerified,
+  selectIsProjectCreated,
   updateBoard,
   updateBoardVerifyState,
   updateJiraVerifyResponse,
-  selectIsProjectCreated,
 } from '@src/context/config/configSlice'
 import { useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect'
 import { ErrorNotification } from '@src/components/ErrorNotification'
@@ -178,7 +178,7 @@ export const Board = () => {
         dispatch(updateBoardVerifyState(res.isBoardVerify))
         dispatch(updateJiraVerifyResponse(res.response))
         res.isBoardVerify && dispatch(updateMetricsState({ ...res.response, isProjectCreated }))
-        setIsNoDoneCard(res.isNoDoneCard)
+        setIsNoDoneCard(!res.haveDoneCard)
       }
     })
   }

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -68,8 +68,8 @@ export const PipelineMetricSelection = ({
     getSteps(params, organizationId, buildId, pipelineType, token).then((res) => {
       const steps = res?.response ?? []
       dispatch(updatePipelineToolVerifyResponseSteps({ organization, pipelineName: _pipelineName, steps }))
-      !res?.isNoStep && dispatch(updatePipelineStep({ steps, id, type }))
-      res && setIsShowNoStepWarning(res.isNoStep)
+      res?.haveStep && dispatch(updatePipelineStep({ steps, id, type }))
+      res && setIsShowNoStepWarning(!res.haveStep)
     })
   }
 

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -66,10 +66,10 @@ export const PipelineMetricSelection = ({
       _pipelineName
     )
     getSteps(params, organizationId, buildId, pipelineType, token).then((res) => {
-      const steps = res ? Object.values(res) : []
+      const steps = res?.response ?? []
       dispatch(updatePipelineToolVerifyResponseSteps({ organization, pipelineName: _pipelineName, steps }))
-      !!steps.length && dispatch(updatePipelineStep({ steps, id, type }))
-      res && setIsShowNoStepWarning(!steps.length)
+      !res?.isNoStep && dispatch(updatePipelineStep({ steps, id, type }))
+      res && setIsShowNoStepWarning(res.isNoStep)
     })
   }
 

--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -315,9 +315,7 @@ export const metricsSlice = createSlice({
       const { importedDeployment, importedLeadTime } = state.importedData
       const updatedImportedPipeline =
         type === PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE ? importedDeployment : importedLeadTime
-      const updatedImportedPipelineStep = !updatedImportedPipeline.length
-        ? ''
-        : updatedImportedPipeline.filter((pipeline) => pipeline.id === id)[0]?.step ?? ''
+      const updatedImportedPipelineStep = updatedImportedPipeline.find((pipeline) => pipeline.id === id)?.step ?? ''
       const validStep = steps.includes(updatedImportedPipelineStep) ? updatedImportedPipelineStep : ''
       const stepWarningMessage = steps.includes(updatedImportedPipelineStep) ? null : STEP_WARNING_MESSAGE
 
@@ -332,17 +330,14 @@ export const metricsSlice = createSlice({
         )
 
       const getStepWarningMessage = (pipelines: IPipelineWarningMessageConfig[]) => {
-        if (pipelines.length > 0) {
-          return pipelines.map((pipeline) =>
-            pipeline.id === id
-              ? {
-                  ...pipeline,
-                  step: stepWarningMessage,
-                }
-              : pipeline
-          )
-        }
-        return []
+        return pipelines.map((pipeline) =>
+          pipeline?.id === id
+            ? {
+                ...pipeline,
+                step: stepWarningMessage,
+              }
+            : pipeline
+        )
       }
 
       type === PIPELINE_SETTING_TYPES.DEPLOYMENT_FREQUENCY_SETTINGS_TYPE

--- a/frontend/src/hooks/useGetMetricsStepsEffect.ts
+++ b/frontend/src/hooks/useGetMetricsStepsEffect.ts
@@ -9,7 +9,13 @@ export interface useGetMetricsStepsEffectInterface {
     buildId: string,
     pipelineType: string,
     token: string
-  ) => Promise<string[] | undefined>
+  ) => Promise<
+    | {
+        isNoStep: boolean
+        response: string[]
+      }
+    | undefined
+  >
   isLoading: boolean
   errorMessage: string
 }

--- a/frontend/src/hooks/useGetMetricsStepsEffect.ts
+++ b/frontend/src/hooks/useGetMetricsStepsEffect.ts
@@ -11,7 +11,7 @@ export interface useGetMetricsStepsEffectInterface {
     token: string
   ) => Promise<
     | {
-        isNoStep: boolean
+        haveStep: boolean
         response: string[]
       }
     | undefined

--- a/frontend/src/hooks/useVerifyBoardEffect.ts
+++ b/frontend/src/hooks/useVerifyBoardEffect.ts
@@ -7,7 +7,7 @@ export interface useVerifyBoardStateInterface {
   verifyJira: (params: BoardRequestDTO) => Promise<
     | {
         isBoardVerify: boolean
-        isNoDoneCard: boolean
+        haveDoneCard: boolean
         response: object
       }
     | undefined


### PR DESCRIPTION
## Summary

- Handle `204` for get pipeline steps.
- Fix no done cards warning cannot reset issue. 

**Before**

1. Select a time range without a done card.
2. A warning display like `Sorry there is no card has been done, please change your collection date!` and Board Verify failed.
3. Then select a time range with done cards.
4. A warning still display, but Board verify succeed.

<img width="1153" alt="Screenshot 2023-07-10 at 16 48 32" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/4cbaabb5-3139-433d-8cbf-baa0ae621f8d">


**After**
1. Select a time range without a done card.
2. A warning display like `Sorry there is no card has been done, please change your collection date!` and Board Verify failed.
3. Then select a time range with done cards.
4. A warning not display, and Board verify succeed.

<img width="1105" alt="Screenshot 2023-07-10 at 16 50 30" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/eb7d038e-b9fc-4643-bbd6-ec24f64e4c5e">

