### PR TITLE
ADM-519 [frontend] One uniform error handling page

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ConfigStep/Board.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/Board.test.tsx
@@ -18,6 +18,7 @@ import { rest } from 'msw'
 import { HttpStatusCode } from 'axios'
 import { navigateMock } from '../../../../setupTests'
 import { ERROR_PAGE_ROUTE } from '@src/constants'
+import userEvent from '@testing-library/user-event'
 
 export const fillBoardFieldsInformation = () => {
   const fields = ['Board Id', 'Email', 'Project Key', 'Site', 'Token']
@@ -198,13 +199,13 @@ describe('Board', () => {
     const { getByText, getByRole } = setup()
     fillBoardFieldsInformation()
 
-    fireEvent.click(getByRole('button', { name: VERIFY }))
+    await userEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
       expect(getByText('Sorry there is no card has been done, please change your collection date!')).toBeInTheDocument()
     })
 
-    fireEvent.click(getByRole('button', { name: 'Ok' }))
+    await userEvent.click(getByRole('button', { name: 'Ok' }))
     expect(getByText('Sorry there is no card has been done, please change your collection date!')).not.toBeVisible()
   })
 
@@ -217,7 +218,7 @@ describe('Board', () => {
     const { getByText, getByRole } = setup()
     fillBoardFieldsInformation()
 
-    fireEvent.click(getByRole('button', { name: VERIFY }))
+    await userEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
       expect(
@@ -233,7 +234,7 @@ describe('Board', () => {
     const { getByRole } = setup()
     fillBoardFieldsInformation()
 
-    fireEvent.click(getByRole('button', { name: VERIFY }))
+    await userEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith(ERROR_PAGE_ROUTE)

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/SourceControl.test.tsx
@@ -20,6 +20,7 @@ import { rest } from 'msw'
 import { HttpStatusCode } from 'axios'
 import { navigateMock } from '../../../../setupTests'
 import { ERROR_PAGE_ROUTE } from '@src/constants'
+import userEvent from '@testing-library/user-event'
 
 export const fillSourceControlFieldsInformation = () => {
   const mockInfo = 'ghpghoghughsghr_1A2b1A2b1A2b1A2b1A2b1A2b1A2b1A2b1A2b'
@@ -155,7 +156,7 @@ describe('SourceControl', () => {
 
     fillSourceControlFieldsInformation()
 
-    fireEvent.click(getByRole('button', { name: VERIFY }))
+    await userEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
       expect(
@@ -172,7 +173,7 @@ describe('SourceControl', () => {
     const { getByRole } = setup()
     fillSourceControlFieldsInformation()
 
-    fireEvent.click(getByRole('button', { name: VERIFY }))
+    await userEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
       expect(navigateMock).toHaveBeenCalledWith(ERROR_PAGE_ROUTE)


### PR DESCRIPTION
## Summary
Build a uniform error page which includes icon, message, retry hyper link

Route to error page when it captured server errors in frontend

## Before
If error code is 5xx, it will pop out of the popup window.

## After
If error code is 5xx, it will throw an error page.