### PR TITLE
ADM-537:[frontend] Support multiple Done columns

### DIFF
--- a/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/CycleTime.test.tsx
@@ -132,8 +132,8 @@ describe('CycleTime', () => {
   })
 
   describe('Error message ', () => {
-    it('should show error message when select more than one Done option', async () => {
-      const { getAllByRole, getByRole, getByText } = setup()
+    it('should not show error message when select more than one Done option', async () => {
+      const { getAllByRole, getByRole, queryByText } = setup()
       const columnsArray = getAllByRole('button', { name: 'Doing' })
       await userEvent.click(columnsArray[0])
       const listBoxZero = within(getByRole('listbox'))
@@ -144,7 +144,7 @@ describe('CycleTime', () => {
       const mockOptionOneDone = listBoxOne.getByRole('option', { name: 'Done' })
       await userEvent.click(mockOptionOneDone)
 
-      await waitFor(() => expect(getByText(errorMessage)).toBeInTheDocument())
+      expect(queryByText(errorMessage)).not.toBeInTheDocument()
     })
 
     it('should not show error message when select less than one Done option', async () => {

--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react'
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle'
 import FlagCard from '@src/components/Metrics/MetricsStep/CycleTime/FlagCard'
 import { FormSelectPart } from '@src/components/Metrics/MetricsStep/CycleTime/FormSelectPart'
-import { ErrorDone } from '@src/components/Metrics/MetricsStep/CycleTime/style'
 import { useAppDispatch } from '@src/hooks/useAppDispatch'
 import {
   saveCycleTimeSettings,
@@ -19,26 +18,25 @@ interface cycleTimeProps {
 
 export const CycleTime = ({ title }: cycleTimeProps) => {
   const dispatch = useAppDispatch()
-  const [isError, setIsError] = useState(false)
   const { cycleTimeSettings } = useAppSelector(selectMetricsContent)
   const warningMessage = useAppSelector(selectCycleTimeWarningMessage)
   const [cycleTimeOptions, setCycleTimeOptions] = useState(cycleTimeSettings)
 
   const saveCycleTimeOptions = (name: string, value: string) => {
     setCycleTimeOptions(
-      cycleTimeOptions.map((item) => {
-        if (item.name === name) {
-          item = JSON.parse(JSON.stringify(item))
-          item.value = value
-        }
-        return item
-      })
+      cycleTimeOptions.map((item) =>
+        item.name === name
+          ? {
+              ...item,
+              value,
+            }
+          : item
+      )
     )
     dispatch(saveDoneColumn([]))
   }
 
   useEffect(() => {
-    setIsError(cycleTimeOptions.filter((item) => item.value === 'Done').length > 1)
     dispatch(saveCycleTimeSettings(cycleTimeOptions))
   }, [cycleTimeOptions, dispatch])
 
@@ -46,11 +44,6 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
     <>
       <MetricsSettingTitle title={title} />
       {warningMessage && <WarningNotification message={warningMessage} />}
-      {isError && (
-        <ErrorDone>
-          <span>Only one column can be selected as &quot;Done&quot;</span>
-        </ErrorDone>
-      )}
       <FormSelectPart selectedOptions={cycleTimeOptions} saveCycleTimeOptions={saveCycleTimeOptions} />
       <FlagCard />
     </>

--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/style.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/style.tsx
@@ -1,6 +1,5 @@
 import { styled } from '@mui/material/styles'
 import { Checkbox } from '@mui/material'
-import { theme } from '@src/theme'
 
 export const FlagCardItem = styled('div')({
   display: 'flex',
@@ -12,9 +11,4 @@ export const ItemText = styled('div')({
 
 export const ItemCheckbox = styled(Checkbox)({
   paddingLeft: '0',
-})
-
-export const ErrorDone = styled('div')({
-  color: theme.components?.errorMessage.color,
-  paddingBottom: theme.components?.errorMessage.paddingBottom,
 })

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -4,8 +4,8 @@ import { RealDone } from '@src/components/Metrics/MetricsStep/RealDone'
 import { CycleTime } from '@src/components/Metrics/MetricsStep/CycleTime'
 import { Classification } from '@src/components/Metrics/MetricsStep/Classification'
 import { selectJiraColumns, selectMetrics, selectUsers } from '@src/context/config/configSlice'
-import { METRICS_CONSTANTS, REQUIRED_DATA } from '@src/constants'
-import { selectCycleTimeSettings, selectMetricsContent } from '@src/context/Metrics/metricsSlice'
+import { REQUIRED_DATA } from '@src/constants'
+import { selectMetricsContent } from '@src/context/Metrics/metricsSlice'
 import { DeploymentFrequencySettings } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings'
 import { LeadTimeForChanges } from '@src/components/Metrics/MetricsStep/LeadTimeForChanges'
 
@@ -14,7 +14,6 @@ export const MetricsStep = () => {
   const users = useAppSelector(selectUsers)
   const jiraColumns = useAppSelector(selectJiraColumns)
   const targetFields = useAppSelector(selectMetricsContent).targetFields
-  const selectedCycleTimeSettings = useAppSelector(selectCycleTimeSettings)
   const isShowCrewsAndRealDone =
     requiredData.includes(REQUIRED_DATA.VELOCITY) ||
     requiredData.includes(REQUIRED_DATA.CYCLE_TIME) ||
@@ -26,10 +25,7 @@ export const MetricsStep = () => {
 
       {requiredData.includes(REQUIRED_DATA.CYCLE_TIME) && <CycleTime title={'Cycle time settings'} />}
 
-      {isShowCrewsAndRealDone &&
-        selectedCycleTimeSettings.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2 && (
-          <RealDone columns={jiraColumns} title={'Real done'} label={'Consider as Done'} />
-        )}
+      {isShowCrewsAndRealDone && <RealDone columns={jiraColumns} title={'Real done'} label={'Consider as Done'} />}
 
       {requiredData.includes(REQUIRED_DATA.CLASSIFICATION) && (
         <Classification targetFields={targetFields} title={'Classification setting'} label={'Distinguished By'} />


### PR DESCRIPTION

## Summary

- Remove limitation of supporting one column marked as done.

## Screenshots

| Before | After | 
|--------|--------|
| <img width="1220" alt="Screenshot 2023-08-03 at 13 49 25" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/73f3f64c-5331-43aa-beb7-977fd4d8daff"> | <img width="1161" alt="Screenshot 2023-08-03 at 13 52 54" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/b7336237-773f-499a-95be-47fd7728201f"> | 
| <img width="337" alt="Screenshot 2023-08-03 at 13 51 23" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/66256899-7be9-411b-a5de-47ed26379932"> | <img width="294" alt="Screenshot 2023-08-03 at 13 54 07" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/d2d659f9-7797-4817-a513-91b7d6e77574"> | 


