### PR TITLE
ADM-540: [backend]Cycle time for undone cards

### DIFF
--- a/backend/src/main/java/heartbeat/client/JiraFeignClient.java
+++ b/backend/src/main/java/heartbeat/client/JiraFeignClient.java
@@ -28,7 +28,7 @@ public interface JiraFeignClient {
 			@RequestHeader String authorization);
 
 	@GetMapping(path = "/rest/agile/1.0/board/{boardId}/issue?maxResults={queryCount}&startAt={startAt}&jql={jql}")
-	String getAllDoneCards(URI baseUrl, @PathVariable String boardId, @PathVariable int queryCount,
+	String getAllCards(URI baseUrl, @PathVariable String boardId, @PathVariable int queryCount,
 			@PathVariable int startAt, @PathVariable String jql, @RequestHeader String authorization);
 
 	@Cacheable(cacheNames = "jiraActivityfeed", key = "#jiraCardKey")

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -129,7 +129,7 @@ public class JiraService {
 		}
 	}
 
-	public CardCollection getStoryPointsAndCycleTime(StoryPointsAndCycleTimeRequest request,
+	public CardCollection getStoryPointsAndCycleTimeForDoneCards(StoryPointsAndCycleTimeRequest request,
 			List<RequestJiraBoardColumnSetting> boardColumns, List<String> users) {
 		BoardType boardType = BoardType.fromValue(request.getType());
 		URI baseUrl = urlGenerator.getUri(request.getSite());
@@ -145,8 +145,9 @@ public class JiraService {
 		JiraCardWithFields jiraCardWithFields = getAllDoneCards(boardType, baseUrl, request.getStatus(),
 				boardRequestParam);
 		List<JiraCard> allDoneCards = jiraCardWithFields.getJiraCards();
+
 		List<JiraCardDTO> matchedCards = getMatchedCards(request, boardColumns, users, baseUrl, allDoneCards,
-				jiraCardWithFields.getTargetFields());
+				jiraCardWithFields.getTargetFields(), false);
 		int storyPointSum = matchedCards.stream()
 			.mapToInt(card -> card.getBaseInfo().getFields().getStoryPoints())
 			.sum();
@@ -428,48 +429,6 @@ public class JiraService {
 			.collect(Collectors.toList());
 	}
 
-	private List<JiraCardDTO> getMatchedCards(StoryPointsAndCycleTimeRequest request,
-			List<RequestJiraBoardColumnSetting> boardColumns, List<String> users, URI baseUrl,
-			List<JiraCard> allDoneCards, List<TargetField> targetFields) {
-		CardCustomFieldKey cardCustomFieldKey = covertCustomFieldKey(targetFields);
-		String keyFlagged = cardCustomFieldKey.getFlagged();
-		List<JiraCardDTO> matchedCards = new ArrayList<>();
-		List<CompletableFuture<JiraCard>> futures = allDoneCards.stream()
-			.map(jiraCard -> CompletableFuture.supplyAsync(() -> {
-				CardHistoryResponseDTO jiraCardHistory = jiraFeignClient.getJiraCardHistory(baseUrl, jiraCard.getKey(),
-						request.getToken());
-				if (isDoneCardByHistory(jiraCardHistory)) {
-					return jiraCard;
-				}
-				else {
-					return null;
-				}
-			}))
-			.toList();
-		List<JiraCard> jiraCards = futures.stream().map(CompletableFuture::join).filter(Objects::nonNull).toList();
-
-		jiraCards.forEach(doneCard -> {
-			CycleTimeInfoDTO cycleTimeInfoDTO = getCycleTime(baseUrl, doneCard.getKey(), request.getToken(),
-					request.isTreatFlagCardAsBlock(), keyFlagged);
-			List<String> assigneeSet = new ArrayList<>(getAssigneeSet(baseUrl, doneCard, request.getToken()));
-			if (doneCard.getFields().getAssignee() != null
-					&& doneCard.getFields().getAssignee().getDisplayName() != null) {
-				assigneeSet.add(doneCard.getFields().getAssignee().getDisplayName());
-			}
-			if (users.stream().anyMatch(assigneeSet::contains)) {
-				JiraCardDTO jiraCardDTO = JiraCardDTO.builder()
-					.baseInfo(doneCard)
-					.cycleTime(cycleTimeInfoDTO.getCycleTimeInfos())
-					.originCycleTime(cycleTimeInfoDTO.getOriginCycleTimeInfos())
-					.cardCycleTime(calculateCardCycleTime(doneCard.getKey(), cycleTimeInfoDTO.getCycleTimeInfos(),
-							boardColumns))
-					.build();
-				matchedCards.add(jiraCardDTO);
-			}
-		});
-		return matchedCards;
-	}
-
 	private boolean isDoneCardByHistory(CardHistoryResponseDTO jiraCardHistory) {
 		HistoryDetail detail = jiraCardHistory.getItems()
 			.stream()
@@ -607,7 +566,8 @@ public class JiraService {
 		return cardCustomFieldKey;
 	}
 
-	public CardCollection getStoryPointsAndCycleTimeForNonDoneCards(StoryPointsAndCycleTimeRequest request) {
+	public CardCollection getStoryPointsAndCycleTimeForNonDoneCards(StoryPointsAndCycleTimeRequest request,
+			List<RequestJiraBoardColumnSetting> boardColumns, List<String> users) {
 		URI baseUrl = urlGenerator.getUri(request.getSite());
 		BoardRequestParam boardRequestParam = BoardRequestParam.builder()
 			.boardId(request.getBoardId())
@@ -618,15 +578,17 @@ public class JiraService {
 			.endTime(request.getEndTime())
 			.build();
 
-		List<JiraCard> allNonDoneCards = getAllNonDoneCardsForActiveSprint(baseUrl, request.getStatus(),
-				boardRequestParam)
-			.getJiraCards();
+		JiraCardWithFields jiraCardWithFields = getAllNonDoneCardsForActiveSprint(baseUrl, request.getStatus(),
+				boardRequestParam);
+
+		List<JiraCard> allNonDoneCards = jiraCardWithFields.getJiraCards();
 		if (allNonDoneCards.isEmpty()) {
 			allNonDoneCards = getAllNonDoneCardsForKanBan(baseUrl, request.getStatus(), boardRequestParam)
 				.getJiraCards();
 		}
 
-		List<JiraCardDTO> matchedNonCards = getMatchedNonCards(allNonDoneCards);
+		List<JiraCardDTO> matchedNonCards = getMatchedCards(request, boardColumns, users, baseUrl, allNonDoneCards,
+				jiraCardWithFields.getTargetFields(), true);
 		int storyPointSum = matchedNonCards.stream()
 			.mapToInt(card -> card.getBaseInfo().getFields().getStoryPoints())
 			.sum();
@@ -638,14 +600,62 @@ public class JiraService {
 			.build();
 	}
 
-	private List<JiraCardDTO> getMatchedNonCards(List<JiraCard> allNonDoneCards) {
-		List<JiraCardDTO> matchedNonCards = new ArrayList<>();
-		allNonDoneCards.forEach(doneCard -> {
+	private List<JiraCardDTO> getMatchedCards(StoryPointsAndCycleTimeRequest request,
+			List<RequestJiraBoardColumnSetting> boardColumns, List<String> users, URI baseUrl, List<JiraCard> allCards,
+			List<TargetField> targetFields, Boolean isNonDone) {
 
-			JiraCardDTO jiraCardDTO = JiraCardDTO.builder().baseInfo(doneCard).build();
-			matchedNonCards.add(jiraCardDTO);
+		List<JiraCard> filteredCards = isNonDone ? allCards : filterDoneCards(baseUrl, request, allCards);
+
+		List<JiraCardDTO> matchedCards = new ArrayList<>();
+		CardCustomFieldKey cardCustomFieldKey = covertCustomFieldKey(targetFields);
+		String keyFlagged = cardCustomFieldKey.getFlagged();
+
+		filteredCards.forEach(card -> {
+			CycleTimeInfoDTO cycleTimeInfoDTO = getCycleTime(baseUrl, card.getKey(), request.getToken(),
+					request.isTreatFlagCardAsBlock(), keyFlagged);
+
+			List<String> assigneeSet = getAssigneeSetWithDisplayName(baseUrl, card, request.getToken());
+			if (users.stream().anyMatch(assigneeSet::contains)) {
+				CardCycleTime cardCycleTime = calculateCardCycleTime(card.getKey(),
+						cycleTimeInfoDTO.getCycleTimeInfos(), boardColumns);
+
+				if (isNonDone) {
+					cardCycleTime.setTotal(0.0);
+				}
+
+				JiraCardDTO jiraCardDTO = buildJiraCardDTO(card, cycleTimeInfoDTO, cardCycleTime);
+				matchedCards.add(jiraCardDTO);
+			}
 		});
-		return matchedNonCards;
+
+		return matchedCards;
+	}
+
+	private List<JiraCard> filterDoneCards(URI baseUrl, StoryPointsAndCycleTimeRequest request,
+			List<JiraCard> allCards) {
+		return allCards.stream().map(card -> CompletableFuture.supplyAsync(() -> {
+			CardHistoryResponseDTO jiraCardHistory = jiraFeignClient.getJiraCardHistory(baseUrl, card.getKey(),
+					request.getToken());
+			return isDoneCardByHistory(jiraCardHistory) ? card : null;
+		})).map(CompletableFuture::join).filter(Objects::nonNull).toList();
+	}
+
+	private List<String> getAssigneeSetWithDisplayName(URI baseUrl, JiraCard card, String token) {
+		List<String> assigneeSet = new ArrayList<>(getAssigneeSet(baseUrl, card, token));
+		if (card.getFields().getAssignee() != null && card.getFields().getAssignee().getDisplayName() != null) {
+			assigneeSet.add(card.getFields().getAssignee().getDisplayName());
+		}
+		return assigneeSet;
+	}
+
+	private JiraCardDTO buildJiraCardDTO(JiraCard card, CycleTimeInfoDTO cycleTimeInfoDTO,
+			CardCycleTime cardCycleTime) {
+		return JiraCardDTO.builder()
+			.baseInfo(card)
+			.cycleTime(cycleTimeInfoDTO.getCycleTimeInfos())
+			.originCycleTime(cycleTimeInfoDTO.getOriginCycleTimeInfos())
+			.cardCycleTime(cardCycleTime)
+			.build();
 	}
 
 	private JiraCardWithFields getAllNonDoneCardsForActiveSprint(URI baseUrl, List<String> status,
@@ -676,8 +686,8 @@ public class JiraService {
 	private JiraCardWithFields getCardList(URI baseUrl, BoardRequestParam boardRequestParam, String jql,
 			String cardType) {
 		log.info("Start to get first-page xxx card information form kanban, param {}", cardType);
-		String allCardResponse = jiraFeignClient.getAllDoneCards(baseUrl, boardRequestParam.getBoardId(), QUERY_COUNT,
-				0, jql, boardRequestParam.getToken());
+		String allCardResponse = jiraFeignClient.getAllCards(baseUrl, boardRequestParam.getBoardId(), QUERY_COUNT, 0,
+				jql, boardRequestParam.getToken());
 		if (allCardResponse.isEmpty()) {
 			return JiraCardWithFields.builder().jiraCards(Collections.emptyList()).build();
 		}
@@ -696,7 +706,7 @@ public class JiraService {
 		List<Integer> range = IntStream.rangeClosed(1, pages - 1).boxed().toList();
 		List<CompletableFuture<AllDoneCardsResponseDTO>> futures = range.stream()
 			.map(startFrom -> CompletableFuture.supplyAsync(
-					() -> (formatAllDoneCards(jiraFeignClient.getAllDoneCards(baseUrl, boardRequestParam.getBoardId(),
+					() -> (formatAllDoneCards(jiraFeignClient.getAllCards(baseUrl, boardRequestParam.getBoardId(),
 							QUERY_COUNT, startFrom * QUERY_COUNT, jql, boardRequestParam.getToken()), targetField)),
 					customTaskExecutor))
 			.toList();

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -581,14 +581,12 @@ public class JiraService {
 		JiraCardWithFields jiraCardWithFields = getAllNonDoneCardsForActiveSprint(baseUrl, request.getStatus(),
 				boardRequestParam);
 
-		List<JiraCard> allNonDoneCards = jiraCardWithFields.getJiraCards();
-		if (allNonDoneCards.isEmpty()) {
-			allNonDoneCards = getAllNonDoneCardsForKanBan(baseUrl, request.getStatus(), boardRequestParam)
-				.getJiraCards();
+		if (jiraCardWithFields.getJiraCards().isEmpty()) {
+			jiraCardWithFields = getAllNonDoneCardsForKanBan(baseUrl, request.getStatus(), boardRequestParam);
 		}
 
-		List<JiraCardDTO> matchedNonCards = getMatchedCards(request, boardColumns, users, baseUrl, allNonDoneCards,
-				jiraCardWithFields.getTargetFields(), true);
+		List<JiraCardDTO> matchedNonCards = getMatchedCards(request, boardColumns, users, baseUrl,
+				jiraCardWithFields.getJiraCards(), jiraCardWithFields.getTargetFields(), true);
 		int storyPointSum = matchedNonCards.stream()
 			.mapToInt(card -> card.getBaseInfo().getFields().getStoryPoints())
 			.sum();

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -255,11 +255,11 @@ public class GenerateReporterService {
 		return fetchedData;
 	}
 
-	private CardCollection fetchCardCollection(GenerateReportRequest request) {
+	private CardCollection fetchDoneCardCollection(GenerateReportRequest request) {
 		JiraBoardSetting jiraBoardSetting = request.getJiraBoardSetting();
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = getStoryPointsAndCycleTimeRequest(
 				jiraBoardSetting, request.getStartTime(), request.getEndTime());
-		return jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
+		return jiraService.getStoryPointsAndCycleTimeForDoneCards(storyPointsAndCycleTimeRequest,
 				jiraBoardSetting.getBoardColumns(), jiraBoardSetting.getUsers());
 	}
 
@@ -267,7 +267,8 @@ public class GenerateReporterService {
 		JiraBoardSetting jiraBoardSetting = request.getJiraBoardSetting();
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = getStoryPointsAndCycleTimeRequest(
 				jiraBoardSetting, request.getStartTime(), request.getEndTime());
-		return jiraService.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest);
+		return jiraService.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest,
+				jiraBoardSetting.getBoardColumns(), jiraBoardSetting.getUsers());
 	}
 
 	private CardCollectionInfo fetchDataFromKanban(GenerateReportRequest request) {
@@ -281,7 +282,7 @@ public class GenerateReporterService {
 			.endTime(request.getEndTime())
 			.build();
 		CardCollection nonDoneCardCollection = fetchNonDoneCardCollection(request);
-		CardCollection cardCollection = fetchCardCollection(request);
+		CardCollection cardCollection = fetchDoneCardCollection(request);
 
 		CardCollectionInfo collectionInfo = CardCollectionInfo.builder()
 			.cardCollection(cardCollection)

--- a/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
@@ -140,7 +140,7 @@ class JiraServiceTest {
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
 			.thenReturn(CARD_HISTORY_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
@@ -179,8 +179,8 @@ class JiraServiceTest {
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 100, jql, token)).thenReturn(allDoneCards);
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 100, jql, token)).thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "1", token))
 			.thenReturn(CARD_HISTORY_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
@@ -224,7 +224,7 @@ class JiraServiceTest {
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_3, token)).thenReturn(completeStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
 			.thenReturn(CARD_HISTORY_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
@@ -278,7 +278,7 @@ class JiraServiceTest {
 		doReturn(jiraBoardConfigDTO).when(jiraFeignClient).getJiraBoardConfiguration(baseUrl, BOARD_ID, token);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token))
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token))
 			.thenReturn(objectMapper.writeValueAsString(ONE_PAGE_NO_DONE_CARDS_RESPONSE_BUILDER().build()));
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
 			.thenReturn(FIELD_RESPONSE_BUILDER().build());
@@ -338,7 +338,7 @@ class JiraServiceTest {
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_1, token)).thenReturn(doneStatusSelf);
 		when(jiraFeignClient.getColumnStatusCategory(baseUrl, COLUM_SELF_ID_2, token)).thenReturn(doingStatusSelf);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, token)).thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
 			.thenReturn(new CardHistoryResponseDTO(Collections.emptyList()));
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", token))
@@ -458,7 +458,7 @@ class JiraServiceTest {
 			.replaceAll("storyPoints", "customfield_10016");
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
 			.thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "1", token))
 			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
@@ -467,8 +467,8 @@ class JiraServiceTest {
 		when(jiraFeignClient.getTargetField(baseUrl, "PLL", token)).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
 		when(boardUtil.getCardTimeForEachStep(any())).thenReturn(CYCLE_TIME_INFO_LIST());
 
-		CardCollection cardCollection = jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
-				jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
+		CardCollection cardCollection = jiraService.getStoryPointsAndCycleTimeForDoneCards(
+				storyPointsAndCycleTimeRequest, jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 
 		assertThat(cardCollection.getStoryPointSum()).isEqualTo(0);
 		assertThat(cardCollection.getCardsNumber()).isEqualTo(1);
@@ -482,13 +482,13 @@ class JiraServiceTest {
 		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_BUILD().build();
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(any(), any(), anyInt(), anyInt(), any(), any())).thenReturn(
+		when(jiraFeignClient.getAllCards(any(), any(), anyInt(), anyInt(), any(), any())).thenReturn(
 				"{\"total\":1,\"issues\":[{\"expand\":\"expand\",\"id\":\"1\",\"self\":\"https:xxxx/issue/1\",\"key\":\"ADM-455\",\"fields\":{\"customfield_10020\":[{\"id\":16,\"name\":\"Tool Sprint 11\",\"state\":\"closed\",\"boardId\":2,\"goal\":\"goals\",\"startDate\":\"2023-05-15T03:09:23.000Z\",\"endDate\":\"2023-05-28T16:00:00.000Z\",\"completeDate\":\"2023-05-29T03:51:24.898Z\"}],\"customfield_10021\":[{\"self\":\"https:xxxx/10019\",\"value\":\"Impediment\",\"id\":\"10019\"}],\"customfield_10016\":1,\"assignee\":{\"displayName\":\"Zhang San\"}}}]}");
 		when(jiraFeignClient.getTargetField(any(), any(), any())).thenReturn(FIELD_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
 			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 
-		CardCollection doneCards = jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
+		CardCollection doneCards = jiraService.getStoryPointsAndCycleTimeForDoneCards(storyPointsAndCycleTimeRequest,
 				jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 		assertThat(doneCards.getStoryPointSum()).isEqualTo(1);
 		assertThat(doneCards.getCardsNumber()).isEqualTo(1);
@@ -517,7 +517,7 @@ class JiraServiceTest {
 			.replaceAll("storyPoints", "customfield_10016");
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jql, boardRequestParam.getToken()))
 			.thenReturn(allDoneCards);
 		when(jiraFeignClient.getJiraCardHistory(baseUrl, "1", token))
 			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
@@ -526,7 +526,7 @@ class JiraServiceTest {
 		when(boardUtil.getCardTimeForEachStep(any())).thenReturn(CYCLE_TIME_INFO_LIST());
 		when(jiraFeignClient.getTargetField(baseUrl, "PLL", token)).thenReturn(FIELD_RESPONSE_BUILDER().build());
 
-		assertThatThrownBy(() -> jiraService.getStoryPointsAndCycleTime(storyPointsAndCycleTimeRequest,
+		assertThatThrownBy(() -> jiraService.getStoryPointsAndCycleTimeForDoneCards(storyPointsAndCycleTimeRequest,
 				jiraBoardSetting.getBoardColumns(), List.of("Zhang San")))
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessageContaining("Type does not find!");
@@ -535,16 +535,19 @@ class JiraServiceTest {
 	@Test
 	public void shouldReturnCardsWhenCallGetStoryPointsAndCycleTimeForNonDoneCardsForActiveSprint()
 			throws JsonProcessingException {
+		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_BUILD().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = STORY_POINTS_FORM_ALL_DONE_CARD().build();
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(any(), any(), anyInt(), anyInt(), any(), any()))
+		when(jiraFeignClient.getAllCards(any(), any(), anyInt(), anyInt(), any(), any()))
 			.thenReturn(objectMapper.writeValueAsString(ALL_NON_DONE_CARDS_RESPONSE_FOR_STORY_POINT_BUILDER().build()));
+		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
+			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 		when(jiraFeignClient.getTargetField(any(), any(), any())).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
 
-		CardCollection nonDoneCards = jiraService
-			.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest);
+		CardCollection nonDoneCards = jiraService.getStoryPointsAndCycleTimeForNonDoneCards(
+				storyPointsAndCycleTimeRequest, jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 		assertThat(nonDoneCards.getStoryPointSum()).isEqualTo(0);
 		assertThat(nonDoneCards.getCardsNumber()).isEqualTo(3);
 	}
@@ -552,17 +555,20 @@ class JiraServiceTest {
 	@Test
 	public void shouldReturnCardsWhenCallGetStoryPointsAndCycleTimeForNonDoneCardsForActiveSprintWithStatusIsEmpty()
 			throws JsonProcessingException {
+		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_BUILD().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = STORY_POINTS_FORM_ALL_DONE_CARD_WITH_EMPTY_STATUS()
 			.build();
 
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(any(), any(), anyInt(), anyInt(), any(), any()))
+		when(jiraFeignClient.getAllCards(any(), any(), anyInt(), anyInt(), any(), any()))
 			.thenReturn(objectMapper.writeValueAsString(ALL_NON_DONE_CARDS_RESPONSE_FOR_STORY_POINT_BUILDER().build()));
 		when(jiraFeignClient.getTargetField(any(), any(), any())).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
+		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
+			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 
-		CardCollection nonDoneCards = jiraService
-			.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest);
+		CardCollection nonDoneCards = jiraService.getStoryPointsAndCycleTimeForNonDoneCards(
+				storyPointsAndCycleTimeRequest, jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 
 		assertThat(nonDoneCards.getStoryPointSum()).isEqualTo(0);
 		assertThat(nonDoneCards.getCardsNumber()).isEqualTo(3);
@@ -571,6 +577,7 @@ class JiraServiceTest {
 	@Test
 	public void shouldReturnCardsWhenCallGetStoryPointsAndCycleTimeForNonDoneCardsForKanban()
 			throws JsonProcessingException {
+		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_BUILD().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = STORY_POINTS_FORM_ALL_DONE_CARD().build();
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
@@ -578,18 +585,20 @@ class JiraServiceTest {
 				+ "')";
 		String jqlForActiveSprint = "sprint in openSprints() AND status not in ('"
 				+ String.join("','", storyPointsAndCycleTimeRequest.getStatus()) + "')";
+
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForActiveSprint,
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForActiveSprint,
 				boardRequestParam.getToken()))
 			.thenReturn("");
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForKanban,
-				boardRequestParam.getToken()))
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForKanban, boardRequestParam.getToken()))
 			.thenReturn(objectMapper.writeValueAsString(ALL_NON_DONE_CARDS_RESPONSE_FOR_STORY_POINT_BUILDER().build()));
 
 		when(jiraFeignClient.getTargetField(any(), any(), any())).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
+		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
+			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 
-		CardCollection nonDoneCards = jiraService
-			.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest);
+		CardCollection nonDoneCards = jiraService.getStoryPointsAndCycleTimeForNonDoneCards(
+				storyPointsAndCycleTimeRequest, jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 
 		assertThat(nonDoneCards.getStoryPointSum()).isEqualTo(0);
 		assertThat(nonDoneCards.getCardsNumber()).isEqualTo(3);
@@ -598,24 +607,26 @@ class JiraServiceTest {
 	@Test
 	public void shouldReturnCardsWhenCallGetStoryPointsAndCycleTimeForNonDoneCardsForKanbanWithStatusIsEmpty()
 			throws JsonProcessingException {
+		JiraBoardSetting jiraBoardSetting = JIRA_BOARD_SETTING_BUILD().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		StoryPointsAndCycleTimeRequest storyPointsAndCycleTimeRequest = STORY_POINTS_FORM_ALL_DONE_CARD_WITH_EMPTY_STATUS()
 			.build();
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
 		String jqlForKanban = "";
 		String jqlForActiveSprint = "sprint in openSprints() ";
+
 		when(urlGenerator.getUri(any())).thenReturn(baseUrl);
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForActiveSprint,
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForActiveSprint,
 				boardRequestParam.getToken()))
 			.thenReturn("");
-		when(jiraFeignClient.getAllDoneCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForKanban,
-				boardRequestParam.getToken()))
+		when(jiraFeignClient.getAllCards(baseUrl, BOARD_ID, QUERY_COUNT, 0, jqlForKanban, boardRequestParam.getToken()))
 			.thenReturn(objectMapper.writeValueAsString(ALL_NON_DONE_CARDS_RESPONSE_FOR_STORY_POINT_BUILDER().build()));
-
 		when(jiraFeignClient.getTargetField(any(), any(), any())).thenReturn(ALL_FIELD_RESPONSE_BUILDER().build());
+		when(jiraFeignClient.getJiraCardHistory(any(), any(), any()))
+			.thenReturn(CARD_HISTORY_MULTI_RESPONSE_BUILDER().build());
 
-		CardCollection nonDoneCards = jiraService
-			.getStoryPointsAndCycleTimeForNonDoneCards(storyPointsAndCycleTimeRequest);
+		CardCollection nonDoneCards = jiraService.getStoryPointsAndCycleTimeForNonDoneCards(
+				storyPointsAndCycleTimeRequest, jiraBoardSetting.getBoardColumns(), List.of("Zhang San"));
 
 		assertThat(nonDoneCards.getStoryPointSum()).isEqualTo(0);
 		assertThat(nonDoneCards.getCardsNumber()).isEqualTo(3);

--- a/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
@@ -155,16 +155,18 @@ class GenerateReporterServiceTest {
 		URI mockUrl = URI.create(SITE_ATLASSIAN_NET);
 
 		Velocity velocity = Velocity.builder().velocityForSP(0).velocityForCards(0).build();
-		when(jiraService.getStoryPointsAndCycleTime(any(), any(), any())).thenReturn(CardCollection.builder()
-			.storyPointSum(0)
-			.cardsNumber(0)
-			.jiraCardDTOList(Collections.emptyList())
-			.build());
-		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any())).thenReturn(CardCollection.builder()
-			.storyPointSum(0)
-			.cardsNumber(0)
-			.jiraCardDTOList(Collections.emptyList())
-			.build());
+		when(jiraService.getStoryPointsAndCycleTimeForDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(0)
+				.cardsNumber(0)
+				.jiraCardDTOList(Collections.emptyList())
+				.build());
+		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(0)
+				.cardsNumber(0)
+				.jiraCardDTOList(Collections.emptyList())
+				.build());
 		when(jiraService.getJiraColumns(any(), any(), any())).thenReturn(JiraColumnResult.builder()
 			.jiraColumnResponse(Collections.emptyList())
 			.doneColumns(Collections.emptyList())
@@ -203,7 +205,8 @@ class GenerateReporterServiceTest {
 			.pairList((List.of(ClassificationNameValuePair.builder().name("shawn").value(1.0D).build())))
 			.build();
 
-		when(jiraService.getStoryPointsAndCycleTime(any(), any(), any())).thenReturn(CardCollection.builder()
+		when(jiraService.getStoryPointsAndCycleTimeForDoneCards(any(), any(), any())).thenReturn(CardCollection
+			.builder()
 			.storyPointSum(0)
 			.cardsNumber(0)
 			.jiraCardDTOList(List.of(JiraCardDTO.builder()
@@ -218,16 +221,18 @@ class GenerateReporterServiceTest {
 			.build();
 
 		when(classificationCalculator.calculate(any(), any())).thenReturn(List.of(mockClassification));
-		when(jiraService.getStoryPointsAndCycleTime(any(), any(), any())).thenReturn(CardCollection.builder()
-			.storyPointSum(0)
-			.cardsNumber(0)
-			.jiraCardDTOList(Collections.emptyList())
-			.build());
-		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any())).thenReturn(CardCollection.builder()
-			.storyPointSum(0)
-			.cardsNumber(0)
-			.jiraCardDTOList(Collections.emptyList())
-			.build());
+		when(jiraService.getStoryPointsAndCycleTimeForDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(0)
+				.cardsNumber(0)
+				.jiraCardDTOList(Collections.emptyList())
+				.build());
+		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(0)
+				.cardsNumber(0)
+				.jiraCardDTOList(Collections.emptyList())
+				.build());
 		when(jiraService.getJiraColumns(any(), any(), any())).thenReturn(JiraColumnResult.builder()
 			.jiraColumnResponse(Collections.emptyList())
 			.doneColumns(Collections.emptyList())
@@ -347,12 +352,13 @@ class GenerateReporterServiceTest {
 			.endTime("123")
 			.build();
 
-		when(jiraService.getStoryPointsAndCycleTime(any(), any(), any())).thenReturn(cardCollection);
-		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any())).thenReturn(CardCollection.builder()
-			.storyPointSum(0)
-			.cardsNumber(0)
-			.jiraCardDTOList(Collections.emptyList())
-			.build());
+		when(jiraService.getStoryPointsAndCycleTimeForDoneCards(any(), any(), any())).thenReturn(cardCollection);
+		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(0)
+				.cardsNumber(0)
+				.jiraCardDTOList(Collections.emptyList())
+				.build());
 		when(jiraService.getJiraColumns(any(), any(), any())).thenReturn(JiraColumnResult.builder()
 			.jiraColumnResponse(Collections.emptyList())
 			.doneColumns(Collections.emptyList())
@@ -608,16 +614,18 @@ class GenerateReporterServiceTest {
 
 		URI mockUrl = URI.create(SITE_ATLASSIAN_NET);
 
-		when(jiraService.getStoryPointsAndCycleTime(any(), any(), any())).thenReturn(CardCollection.builder()
-			.storyPointSum(2)
-			.cardsNumber(1)
-			.jiraCardDTOList(BoardCsvFixture.MOCK_DONE_CARD_LIST())
-			.build());
-		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any())).thenReturn(CardCollection.builder()
-			.storyPointSum(2)
-			.cardsNumber(1)
-			.jiraCardDTOList(BoardCsvFixture.MOCK_NON_DONE_CARD_LIST())
-			.build());
+		when(jiraService.getStoryPointsAndCycleTimeForDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(2)
+				.cardsNumber(1)
+				.jiraCardDTOList(BoardCsvFixture.MOCK_DONE_CARD_LIST())
+				.build());
+		when(jiraService.getStoryPointsAndCycleTimeForNonDoneCards(any(), any(), any()))
+			.thenReturn(CardCollection.builder()
+				.storyPointSum(2)
+				.cardsNumber(1)
+				.jiraCardDTOList(BoardCsvFixture.MOCK_NON_DONE_CARD_LIST())
+				.build());
 		when(jiraService.getJiraColumns(any(), any(), any())).thenReturn(JiraColumnResult.builder()
 			.jiraColumnResponse(BoardCsvFixture.MOCK_JIRA_COLUMN_LIST())
 			.doneColumns(Collections.emptyList())


### PR DESCRIPTION
Summary
When export board CSV, only calculate cycle time for dong cards.

Before
<img width="1711" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/108106853/7f066b20-7fea-47fc-8ed5-fe7b5723226b">
After
<img width="1718" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/108106853/02482eca-00b8-4055-ba1a-37adee572ca6">
