### PR TITLE
ADM-537:[frontend] Modify error message when no card.

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ConfigStep/Board.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/Board.test.tsx
@@ -6,6 +6,7 @@ import {
   CONFIG_TITLE,
   ERROR_MESSAGE_COLOR,
   MOCK_BOARD_URL_FOR_JIRA,
+  NO_CARD_ERROR_MESSAGE,
   RESET,
   VERIFY,
   VERIFY_ERROR_MESSAGE,
@@ -191,7 +192,7 @@ describe('Board', () => {
     })
   })
 
-  it('should check noDoneCardPop show and disappear when board verify response status is 204', async () => {
+  it('should check noCardPop show and disappear when board verify response status is 204', async () => {
     server.use(rest.get(MOCK_BOARD_URL_FOR_JIRA, (req, res, ctx) => res(ctx.status(HttpStatusCode.NoContent))))
     const { getByText, getByRole } = setup()
     fillBoardFieldsInformation()
@@ -199,11 +200,11 @@ describe('Board', () => {
     fireEvent.click(getByRole('button', { name: VERIFY }))
 
     await waitFor(() => {
-      expect(getByText('Sorry there is no card has been done, please change your collection date!')).toBeInTheDocument()
+      expect(getByText(NO_CARD_ERROR_MESSAGE)).toBeInTheDocument()
     })
 
     fireEvent.click(getByRole('button', { name: 'Ok' }))
-    expect(getByText('Sorry there is no card has been done, please change your collection date!')).not.toBeVisible()
+    expect(getByText(NO_CARD_ERROR_MESSAGE)).not.toBeVisible()
   })
 
   it('should check error notification show and disappear when board verify response status is 401', async () => {

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/NoCardPop.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/NoCardPop.test.tsx
@@ -1,19 +1,19 @@
 import { fireEvent, render } from '@testing-library/react'
-import { NoDoneCardPop } from '@src/components/Metrics/ConfigStep/NoDoneCardPop'
+import { NoCardPop } from '@src/components/Metrics/ConfigStep/NoDoneCardPop'
+import { NO_CARD_ERROR_MESSAGE } from '../../../fixtures'
 
-const NO_CARD_MESSAGE = 'Sorry there is no card has been done, please change your collection date!'
 const OK = 'Ok'
 describe('NoCardPop', () => {
-  it('should show NoDoneCardPop component given isOpen param is true', () => {
-    const { getByText, getByRole } = render(<NoDoneCardPop isOpen={true} onClose={jest.fn()} />)
+  it('should show NoCardPop component given isOpen param is true', () => {
+    const { getByText, getByRole } = render(<NoCardPop isOpen={true} onClose={jest.fn()} />)
 
-    expect(getByText(NO_CARD_MESSAGE)).toBeInTheDocument()
+    expect(getByText(NO_CARD_ERROR_MESSAGE)).toBeInTheDocument()
     expect(getByRole('button', { name: OK })).toBeInTheDocument()
   })
 
   it('should call onClose function when click Ok button given isOpen param is true', () => {
     const handleClose = jest.fn()
-    const { getByRole } = render(<NoDoneCardPop isOpen={true} onClose={handleClose} />)
+    const { getByRole } = render(<NoCardPop isOpen={true} onClose={handleClose} />)
     const okButton = getByRole('button', { name: OK })
 
     fireEvent.click(okButton)

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -634,3 +634,6 @@ export const ERROR_PAGE_MESSAGE =
   'Something on internet is not quite right. Perhaps head back to our homepage and try again.'
 
 export const RETRY_BUTTON = 'Go to homepage'
+
+export const NO_CARD_ERROR_MESSAGE =
+  'Sorry there is no card within selected date range, please change your collection date!'

--- a/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/Board/index.tsx
@@ -22,7 +22,7 @@ import {
 } from '@src/context/config/configSlice'
 import { useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect'
 import { ErrorNotification } from '@src/components/ErrorNotification'
-import { NoDoneCardPop } from '@src/components/Metrics/ConfigStep/NoDoneCardPop'
+import { NoCardPop } from '@src/components/Metrics/ConfigStep/NoDoneCardPop'
 import { Loading } from '@src/components/Loading'
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons'
 import {
@@ -202,7 +202,7 @@ export const Board = () => {
 
   return (
     <StyledSection>
-      <NoDoneCardPop isOpen={isShowNoDoneCard} onClose={() => setIsNoDoneCard(false)} />
+      <NoCardPop isOpen={isShowNoDoneCard} onClose={() => setIsNoDoneCard(false)} />
       {errorMessage && <ErrorNotification message={errorMessage} />}
       {isLoading && <Loading />}
       <StyledTitle>{CONFIG_TITLE.BOARD}</StyledTitle>

--- a/frontend/src/components/Metrics/ConfigStep/NoDoneCardPop/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/NoDoneCardPop/index.tsx
@@ -5,11 +5,14 @@ interface NoDoneCardPopProps {
   isOpen: boolean
   onClose: () => void
 }
-export const NoDoneCardPop = (props: NoDoneCardPopProps) => {
+
+export const NoCardPop = (props: NoDoneCardPopProps) => {
   const { isOpen, onClose } = props
   return (
     <StyledDialog open={isOpen}>
-      <DialogContent>Sorry there is no card has been done, please change your collection date!</DialogContent>
+      <DialogContent>
+        Sorry there is no card within selected date range, please change your collection date!
+      </DialogContent>
       <OkButton onClick={onClose}>Ok</OkButton>
     </StyledDialog>
   )


### PR DESCRIPTION
## Summary

- Modify error message when no card.

## Before

Board verify only return done cards.
Crews setting only consider the users who has been assigned to the done cards.
When this is no done card, it will show error message.

**Screenshots**
<img width="1728" alt="Screenshot 2023-08-04 at 11 30 55 (2)" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/c1a5d53f-c6dc-4dc9-a988-16c76a85b365">


## After

Board verify only return done cards.
Crews setting include the all users who has been assigned to one card.
When this is no card, it will show error message.

**Screenshots**
<img width="1728" alt="Screenshot 2023-08-04 at 11 32 34 (2)" src="https://github.com/au-heartbeat/Heartbeat/assets/112382375/36ad0dba-1c37-41a2-aee2-dd33c4baf24c">

