### PR TITLE
ADM-550 [Fox][frontend] - Real down reset issue

### DIFF
--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@src/context/Metrics/metricsSlice'
 import { useAppSelector } from '@src/hooks'
 import { WarningNotification } from '@src/components/Common/WarningNotification'
+import { DONE } from '@src/constants'
 
 interface cycleTimeProps {
   title: string
@@ -21,6 +22,7 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
   const { cycleTimeSettings } = useAppSelector(selectMetricsContent)
   const warningMessage = useAppSelector(selectCycleTimeWarningMessage)
   const [cycleTimeOptions, setCycleTimeOptions] = useState(cycleTimeSettings)
+  const [saveDone, setSaveDone] = useState<string[]>([])
 
   const saveCycleTimeOptions = (name: string, value: string) => {
     setCycleTimeOptions(
@@ -33,7 +35,13 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
           : item
       )
     )
-    dispatch(saveDoneColumn([]))
+    if (value === DONE) {
+      setSaveDone([...saveDone, name])
+      dispatch(saveDoneColumn([]))
+    } else if (saveDone.includes(name)) {
+      setSaveDone(saveDone.filter((e) => e !== name))
+      dispatch(saveDoneColumn([]))
+    }
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Only when the Cycle time component marks one column as done, the Real down component will be reset.

## Before

Whenever the Cycle time component updates, the Real down component resets.

**Screenshots**
<img width="670" alt="Screenshot 2023-08-08 at 17 52 10" src="https://github.com/au-heartbeat/Heartbeat/assets/126433704/b4cf4702-773b-4ec3-9ec3-103409c2ec38">

## After

_Description_
Only when the Cycle time component marks one column as done, the Real down component will be reset.

**Screenshots**
Options change to Done, will reset:
<img width="651" alt="Screenshot 2023-08-08 at 17 50 28" src="https://github.com/au-heartbeat/Heartbeat/assets/126433704/ed0c1c29-be99-46dd-ac38-418f42d17cbb">
Done change to other options, will reset:
<img width="663" alt="Screenshot 2023-08-08 at 17 51 08" src="https://github.com/au-heartbeat/Heartbeat/assets/126433704/3e818416-024e-4685-a7c4-aa6e5a265673">
Options except Done change to other options, will not reset:
<img width="664" alt="Screenshot 2023-08-08 at 17 51 35" src="https://github.com/au-heartbeat/Heartbeat/assets/126433704/ae73d0b0-1b0f-494f-a5b3-2f1f9dfb232a">


## Note

_Null_
