### PR TITLE
ADM 551: [frontend] Adjust AUTO To date when user select From date

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
@@ -51,7 +51,7 @@ describe('DateRangePicker', () => {
     expectDate(endDateInput)
   })
 
-  it('should Auto-fill endDate which is after startDate 14 days when fill right startDate ', () => {
+  it('should Auto-fill endDate which is after startDate 13 days when fill right startDate ', () => {
     const { getByRole } = setup()
     const endDate = TODAY.add(13, 'day')
     const startDateInput = getByRole('textbox', { name: START_DATE_LABEL }) as HTMLInputElement

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
@@ -53,7 +53,7 @@ describe('DateRangePicker', () => {
 
   it('should Auto-fill endDate which is after startDate 13 days when fill right startDate ', () => {
     const { getByRole } = setup()
-    const endDate = TODAY.add(14, 'day')
+    const endDate = TODAY.add(13, 'day')
     const startDateInput = getByRole('textbox', { name: START_DATE_LABEL }) as HTMLInputElement
     const endDateInput = getByRole('textbox', { name: END_DATE_LABEL }) as HTMLInputElement
 

--- a/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/DateRangePicker.test.tsx
@@ -53,7 +53,7 @@ describe('DateRangePicker', () => {
 
   it('should Auto-fill endDate which is after startDate 14 days when fill right startDate ', () => {
     const { getByRole } = setup()
-    const endDate = TODAY.add(14, 'day')
+    const endDate = TODAY.add(13, 'day')
     const startDateInput = getByRole('textbox', { name: START_DATE_LABEL }) as HTMLInputElement
     const endDateInput = getByRole('textbox', { name: END_DATE_LABEL }) as HTMLInputElement
 

--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -321,7 +321,7 @@ describe('MetricsStepper', () => {
       board: { boardId: '', email: '', projectKey: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',
       dateRange: {
-        endDate: dayjs().endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        endDate: dayjs().endOf('date').add(13, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
         startDate: dayjs().startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       },
       metrics: ['Velocity', 'Lead time for changes'],
@@ -350,7 +350,7 @@ describe('MetricsStepper', () => {
       board: { boardId: '', email: '', projectKey: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',
       dateRange: {
-        endDate: dayjs().endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+        endDate: dayjs().endOf('date').add(13, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
         startDate: dayjs().startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
       },
       metrics: ['Velocity', 'Lead time for changes'],

--- a/frontend/src/components/Metrics/ConfigStep/DateRangePicker/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/DateRangePicker/index.tsx
@@ -32,7 +32,7 @@ export const DateRangePicker = () => {
       dispatch(
         updateDateRange({
           startDate: value.startOf('date').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
-          endDate: value.endOf('date').add(14, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
+          endDate: value.endOf('date').add(13, 'day').format('YYYY-MM-DDTHH:mm:ss.SSSZ'),
         })
       )
     }


### PR DESCRIPTION
## Summary

Justify the time interval automatically generated on the config page and its related tests.