### PR TITLE
ADm-546: [frontend] Performance optimization

### DIFF
--- a/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ConfigStep/ConfigStep.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, Matcher, render, waitFor, within } from '@testing-library/react'
-import { ConfigStep } from '@src/components/Metrics/ConfigStep'
+import ConfigStep from '@src/components/Metrics/ConfigStep'
 import {
   CHINA_CALENDAR,
   CONFIG_TITLE,

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react'
-import { MetricsStep } from '@src/components/Metrics/MetricsStep'
+import MetricsStep from '@src/components/Metrics/MetricsStep'
 import { Provider } from 'react-redux'
 import { setupStore } from '../../../utils/setupStoreUtil'
 

--- a/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStep/MetricsStep.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { act, render } from '@testing-library/react'
 import MetricsStep from '@src/components/Metrics/MetricsStep'
 import { Provider } from 'react-redux'
 import { setupStore } from '../../../utils/setupStoreUtil'

--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -85,11 +85,11 @@ Object.defineProperty(window, 'location', { value: mockLocation })
 
 let store = setupStore()
 const fillConfigPageData = async () => {
-  const projectNameInput = screen.getByRole('textbox', { name: PROJECT_NAME_LABEL })
-  await userEvent.type(projectNameInput, TEST_PROJECT_NAME)
-
-  const startDateInput = screen.getByRole('textbox', { name: START_DATE_LABEL }) as HTMLInputElement
+  const projectNameInput = await screen.findByRole('textbox', { name: PROJECT_NAME_LABEL })
+  fireEvent.change(projectNameInput, { target: { value: TEST_PROJECT_NAME } })
+  const startDateInput = (await screen.findByRole('textbox', { name: START_DATE_LABEL })) as HTMLInputElement
   fireEvent.change(startDateInput, { target: { value: INPUT_DATE_VALUE } })
+
   await act(async () => {
     await store.dispatch(updateMetrics([VELOCITY, LEAD_TIME_FOR_CHANGES]))
     await store.dispatch(updateBoardVerifyState(true))

--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -256,7 +256,7 @@ describe('MetricsStepper', () => {
     const { getByText } = setup()
 
     await fillConfigPageData()
-    await userEvent.click(getByText(NEXT))
+    fireEvent.click(getByText(NEXT))
 
     expect(getByText(METRICS)).toHaveStyle(`color:${stepperColor}`)
   })

--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, waitFor } from '@testing-library/react'
-import { ReportStep } from '@src/components/Metrics/ReportStep'
+import ReportStep from '@src/components/Metrics/ReportStep'
 import {
   BACK,
   ERROR_PAGE_ROUTE,

--- a/frontend/src/components/Metrics/ConfigStep/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@src/context/config/configSlice'
 import { WarningNotification } from '@src/components/Common/WarningNotification'
 
-export const ConfigStep = () => {
+const ConfigStep = () => {
   const dispatch = useAppDispatch()
   const projectName = useAppSelector(selectProjectName)
   const calendarType = useAppSelector(selectCalendarType)
@@ -61,3 +61,5 @@ export const ConfigStep = () => {
     </ConfigStepWrapper>
   )
 }
+
+export default ConfigStep

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -9,7 +9,7 @@ import { selectMetricsContent } from '@src/context/Metrics/metricsSlice'
 import { DeploymentFrequencySettings } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings'
 import { LeadTimeForChanges } from '@src/components/Metrics/MetricsStep/LeadTimeForChanges'
 
-export const MetricsStep = () => {
+const MetricsStep = () => {
   const requiredData = useAppSelector(selectMetrics)
   const users = useAppSelector(selectUsers)
   const jiraColumns = useAppSelector(selectJiraColumns)
@@ -39,3 +39,5 @@ export const MetricsStep = () => {
     </>
   )
 }
+
+export default MetricsStep

--- a/frontend/src/components/Metrics/MetricsStepper/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStepper/index.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect, useState } from 'react'
+import React, { lazy, Suspense, useEffect, useState } from 'react'
 import {
   BackButton,
   ButtonContainer,
@@ -188,9 +188,9 @@ const MetricsStepper = () => {
     setIsDialogShowing(false)
   }
 
-  const ConfigStep = React.lazy(() => import('@src/components/Metrics/ConfigStep'))
-  const MetricsStep = React.lazy(() => import('@src/components/Metrics/MetricsStep'))
-  const ReportStep = React.lazy(() => import('@src/components/Metrics/ReportStep'))
+  const ConfigStep = lazy(() => import('@src/components/Metrics/ConfigStep'))
+  const MetricsStep = lazy(() => import('@src/components/Metrics/MetricsStep'))
+  const ReportStep = lazy(() => import('@src/components/Metrics/ReportStep'))
 
   return (
     <>

--- a/frontend/src/components/Metrics/MetricsStepper/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStepper/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { Suspense, useEffect, useState } from 'react'
 import {
   BackButton,
   ButtonContainer,
@@ -12,7 +12,6 @@ import {
 } from './style'
 import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch'
 import { backStep, nextStep, selectStepNumber, updateTimeStamp } from '@src/context/stepper/StepperSlice'
-import { ConfigStep } from '@src/components/Metrics/ConfigStep'
 import {
   HOME_PAGE_ROUTE,
   METRICS_CONSTANTS,
@@ -21,12 +20,10 @@ import {
   SAVE_CONFIG_TIPS,
   STEPS,
 } from '@src/constants'
-import { MetricsStep } from '@src/components/Metrics/MetricsStep'
 import { ConfirmDialog } from '@src/components/Metrics/MetricsStepper/ConfirmDialog'
 import { useNavigate } from 'react-router-dom'
 import { selectConfig, selectMetrics } from '@src/context/config/configSlice'
 import { useMetricsStepValidationCheckContext } from '@src/hooks/useMetricsStepValidationCheckContext'
-import { ReportStep } from '@src/components/Metrics/ReportStep'
 import { Tooltip } from '@mui/material'
 import { exportToJsonFile } from '@src/utils/util'
 import {
@@ -191,6 +188,10 @@ const MetricsStepper = () => {
     setIsDialogShowing(false)
   }
 
+  const ConfigStep = React.lazy(() => import('@src/components/Metrics/ConfigStep'))
+  const MetricsStep = React.lazy(() => import('@src/components/Metrics/MetricsStep'))
+  const ReportStep = React.lazy(() => import('@src/components/Metrics/ReportStep'))
+
   return (
     <>
       <StyledStepper activeStep={activeStep}>
@@ -201,9 +202,11 @@ const MetricsStepper = () => {
         ))}
       </StyledStepper>
       <MetricsStepperContent>
-        {activeStep === 0 && <ConfigStep />}
-        {activeStep === 1 && <MetricsStep />}
-        {activeStep === 2 && <ReportStep />}
+        <Suspense>
+          {activeStep === 0 && <ConfigStep />}
+          {activeStep === 1 && <MetricsStep />}
+          {activeStep === 2 && <ReportStep />}
+        </Suspense>
       </MetricsStepperContent>
       <ButtonContainer>
         {activeStep !== 2 && (

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -26,7 +26,7 @@ import { ButtonGroupStyle, ErrorNotificationContainer, ExportButton } from '@src
 import { ErrorNotification } from '@src/components/ErrorNotification'
 import { useNavigate } from 'react-router-dom'
 
-export const ReportStep = () => {
+const ReportStep = () => {
   const dispatch = useAppDispatch()
   const navigate = useNavigate()
   const { generateReport, isLoading, isServerError, errorMessage: reportErrorMsg } = useGenerateReportEffect()
@@ -265,3 +265,5 @@ export const ReportStep = () => {
     </>
   )
 }
+
+export default ReportStep


### PR DESCRIPTION
## Summary

Use lazy load to improve the performance of Metrics module.

## Before
There are 90 requests when we import config.
![image](https://github.com/au-heartbeat/Heartbeat/assets/108106853/66467c41-930f-41b6-ba6e-d9e734465368)

## After
There are 45 requests when we import config.
![image](https://github.com/au-heartbeat/Heartbeat/assets/108106853/3b77aafe-77b3-43a5-a447-4ddca2cd733b)

