### PR TITLE
ADM-566:[frontend] fix the next button can not be disabled bug

### DIFF
--- a/frontend/src/components/Metrics/MetricsStepper/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStepper/index.tsx
@@ -63,7 +63,7 @@ const MetricsStepper = () => {
 
   const isShowCrewsSetting = isShowBoard
   const isShowRealDone =
-    isShowBoard && selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length < 2
+    isShowBoard && selectedBoardColumns.filter((column) => column.value === METRICS_CONSTANTS.doneValue).length > 0
   const isShowDeploymentFrequency =
     requiredData.includes(REQUIRED_DATA.DEPLOYMENT_FREQUENCY) ||
     requiredData.includes(REQUIRED_DATA.CHANGE_FAILURE_RATE) ||


### PR DESCRIPTION
## Summary

The 'Next' button should be disabled.

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
