### PR TITLE
ADM-560:[frontend] fix warning message when there are two in real don…

### DIFF
--- a/frontend/src/context/Metrics/metricsSlice.tsx
+++ b/frontend/src/context/Metrics/metricsSlice.tsx
@@ -251,14 +251,13 @@ export const metricsSlice = createSlice({
         state.classificationWarningMessage = null
       }
 
+      state.cycleTimeSettings = setCycleTimeSettings(jiraColumns, importedCycleTime.importedCycleTimeSettings)
       if (!isProjectCreated && !!importedDoneStatus.length) {
         setSelectDoneColumns(jiraColumns, state.cycleTimeSettings, importedDoneStatus).length <
         importedDoneStatus.length
           ? (state.realDoneWarningMessage = REAL_DONE_WARNING_MESSAGE)
           : (state.realDoneWarningMessage = null)
       }
-
-      state.cycleTimeSettings = setCycleTimeSettings(jiraColumns, importedCycleTime.importedCycleTimeSettings)
       state.doneColumn = isProjectCreated
         ? []
         : setSelectDoneColumns(jiraColumns, state.cycleTimeSettings, importedDoneStatus)


### PR DESCRIPTION
## Summary

When people import config, if there are two columns marked 'done' and two columns in real down, user can see the prompt message. Should fix it that user should not see the prompt message in this case.

## Before

![image](https://github.com/au-heartbeat/Heartbeat/assets/108106853/5c70c62c-744e-45be-af50-bbb436dcea03)

## After

![image](https://github.com/au-heartbeat/Heartbeat/assets/108106853/15f96a02-8c15-49cf-a3c3-f206565688bc)
