### PR TITLE
ADM-589 Add time duration display in UI and csv file name

### DIFF
--- a/frontend/__tests__/src/components/DateDisplay/CollectionDuration.test.tsx
+++ b/frontend/__tests__/src/components/DateDisplay/CollectionDuration.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react'
+import CollectionDuration from '@src/components/Common/CollectionDuration'
+import React from 'react'
+import { IMPORTED_NEW_CONFIG_FIXTURE, TIME_DISPLAY_TITTLE_END, TIME_DISPLAY_TITTLE_START } from '../../fixtures'
+
+describe('Collection Duration', () => {
+  const setup = () =>
+    render(
+      <CollectionDuration
+        startDate={IMPORTED_NEW_CONFIG_FIXTURE.dateRange.startDate}
+        endDate={IMPORTED_NEW_CONFIG_FIXTURE.dateRange.endDate}
+      />
+    )
+  it('should render the start and end text correctly', () => {
+    const { getByText } = setup()
+
+    expect(getByText(TIME_DISPLAY_TITTLE_START)).toBeInTheDocument()
+    expect(getByText(TIME_DISPLAY_TITTLE_END)).toBeInTheDocument()
+  })
+  it('should render the start and end time with correct format', () => {
+    const { getByText, getAllByText } = setup()
+
+    expect(getByText('16')).toBeInTheDocument()
+    expect(getAllByText('Mar 23')).toHaveLength(2)
+    expect(getByText('30')).toBeInTheDocument()
+  })
+})

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -185,9 +185,50 @@ export const MOCK_GENERATE_REPORT_REQUEST_PARAMS: ReportRequestDTO = {
     doneColumn: ['Done'],
   },
 }
+
+export const IMPORTED_NEW_CONFIG_FIXTURE = {
+  projectName: 'ConfigFileForImporting',
+  metrics: ['Velocity', 'Cycle time', 'Classification', 'Lead time for changes'],
+  dateRange: {
+    startDate: '2023-03-16T00:00:00.000+08:00',
+    endDate: '2023-03-30T23:59:59.999+08:00',
+  },
+  calendarType: 'Calendar with Chinese Holiday',
+  board: {
+    type: 'Classic Jira',
+    verifyToken: 'mockVerifyToken',
+    boardId: '1963',
+    token: 'mockToken',
+    site: 'mockSite',
+    email: 'test@test.com',
+    projectKey: 'PLL',
+  },
+  pipeline: 'mockToken',
+  pipelineTool: {
+    type: 'BuildKite',
+    token: 'mockToken',
+  },
+  sourceControl: {
+    type: 'GitHub',
+    token: '',
+  },
+  crews: ['lucy', 'hi hi', 'Yu Zhang'],
+  classification: ['type', 'Parent'],
+  cycleTime: [
+    {
+      'In Analysis': 'To do',
+    },
+    {
+      'Ready For Dev': 'Analysis',
+    },
+  ],
+}
+
 export const MOCK_EXPORT_CSV_REQUEST_PARAMS: CSVReportRequestDTO = {
   csvTimeStamp: 1613664000000,
   dataType: 'pipeline',
+  startDate: IMPORTED_NEW_CONFIG_FIXTURE.dateRange.startDate,
+  endDate: IMPORTED_NEW_CONFIG_FIXTURE.dateRange.endDate,
 }
 
 export const MOCK_IMPORT_FILE = {
@@ -542,44 +583,6 @@ export const EXPECTED_REPORT_VALUES = {
 export const CONFIG_PAGE_VERIFY_IMPORT_ERROR_MESSAGE =
   'Imported data is not perfectly matched. Please review carefully before going next!'
 
-export const IMPORTED_NEW_CONFIG_FIXTURE = {
-  projectName: 'ConfigFileForImporting',
-  metrics: ['Velocity', 'Cycle time', 'Classification', 'Lead time for changes'],
-  dateRange: {
-    startDate: '2023-03-16T00:00:00.000+08:00',
-    endDate: '2023-03-30T23:59:59.999+08:00',
-  },
-  calendarType: 'Calendar with Chinese Holiday',
-  board: {
-    type: 'Classic Jira',
-    verifyToken: 'mockVerifyToken',
-    boardId: '1963',
-    token: 'mockToken',
-    site: 'mockSite',
-    email: 'test@test.com',
-    projectKey: 'PLL',
-  },
-  pipeline: 'mockToken',
-  pipelineTool: {
-    type: 'BuildKite',
-    token: 'mockToken',
-  },
-  sourceControl: {
-    type: 'GitHub',
-    token: '',
-  },
-  crews: ['lucy', 'hi hi', 'Yu Zhang'],
-  classification: ['type', 'Parent'],
-  cycleTime: [
-    {
-      'In Analysis': 'To do',
-    },
-    {
-      'Ready For Dev': 'Analysis',
-    },
-  ],
-}
-
 export const BASIC_IMPORTED_OLD_CONFIG_FIXTURE = {
   projectName: 'ConfigFileForImporting',
   metrics: ['Velocity', 'Cycle time', 'Classification', 'Lead time for changes'],
@@ -653,3 +656,6 @@ export const NO_RESULT_DASH = '----'
 export const MOCK_AUTOCOMPLETE_LIST = ['Option 1', 'Option 2', 'Option 3']
 
 export const AUTOCOMPLETE_SELECT_ACTION = 'selectOption'
+
+export const TIME_DISPLAY_TITTLE_START = 'START'
+export const TIME_DISPLAY_TITTLE_END = 'END'

--- a/frontend/src/clients/report/CSVClient.ts
+++ b/frontend/src/clients/report/CSVClient.ts
@@ -4,14 +4,18 @@ import dayjs from 'dayjs'
 import { downloadCSV } from '@src/utils/util'
 
 export class CSVClient extends HttpClient {
-  parseTimeStampToHumanDate = (csvTimeStamp: number | undefined): string =>
-    dayjs(csvTimeStamp).format('YYYY-MM-DD-HH-mm-ss')
+  parseTimeStampToHumanDate = (csvTimeStamp: number | undefined): string => dayjs(csvTimeStamp).format('SSS')
+  parseCollectionDateToHumanDate = (date: string) => dayjs(date).format('YYYYMMDD')
 
   exportCSVData = async (params: CSVReportRequestDTO) => {
     await this.axiosInstance
       .get(`/reports/${params.dataType}/${params.csvTimeStamp}`, { responseType: 'blob' })
       .then((res) => {
-        const exportedFilename = `${params.dataType}-data-${this.parseTimeStampToHumanDate(params.csvTimeStamp)}.csv`
+        const exportedFilename = `${params.dataType}-${this.parseCollectionDateToHumanDate(
+          params.startDate
+        )}-to-${this.parseCollectionDateToHumanDate(params.endDate)}-${this.parseTimeStampToHumanDate(
+          params.csvTimeStamp
+        )}.csv`
         downloadCSV(exportedFilename, res.data)
       })
       .catch((e) => {

--- a/frontend/src/clients/report/dto/request.ts
+++ b/frontend/src/clients/report/dto/request.ts
@@ -51,4 +51,6 @@ export interface ReportRequestDTO {
 export interface CSVReportRequestDTO {
   dataType: string
   csvTimeStamp: number
+  startDate: string
+  endDate: string
 }

--- a/frontend/src/components/Common/CollectionDuration/index.tsx
+++ b/frontend/src/components/Common/CollectionDuration/index.tsx
@@ -1,13 +1,11 @@
 import {
   CollectionDateContainer,
-  StartColoredTopArea,
   GreyTransitionBox,
   TextBox,
-  EndColoredTopArea,
-  StartTitle,
-  EndTitle,
   DateText,
   MonthYearText,
+  DateTitle,
+  ColoredTopArea,
 } from '@src/components/Common/CollectionDuration/style'
 import dayjs from 'dayjs'
 
@@ -22,42 +20,47 @@ type DisplayedDateInfo = {
   day: string
 }
 
+type DateInformation = {
+  formattedDate: DisplayedDateInfo
+  dateTittle: string
+}
+
 const CollectionDuration = ({ startDate, endDate }: Props) => {
+  const toBeFormattedStartDate = dayjs(startDate)
+  const toBeFormattedEndDate = dayjs(endDate)
   const startDateInfo: DisplayedDateInfo = {
-    year: dayjs(startDate).format('YY'),
-    month: dayjs(startDate).format('MMM'),
-    day: dayjs(startDate).format('DD'),
+    year: toBeFormattedStartDate.format('YY'),
+    month: toBeFormattedStartDate.format('MMM'),
+    day: toBeFormattedStartDate.format('DD'),
   }
   const endDateInfo: DisplayedDateInfo = {
-    year: dayjs(endDate).format('YY'),
-    month: dayjs(endDate).format('MMM'),
-    day: dayjs(endDate).format('DD'),
+    year: toBeFormattedEndDate.format('YY'),
+    month: toBeFormattedEndDate.format('MMM'),
+    day: toBeFormattedEndDate.format('DD'),
+  }
+
+  const DateDisplay = (props: DateInformation) => {
+    const { dateTittle, formattedDate } = props
+    return (
+      <div>
+        <DateTitle isStart={dateTittle === 'START'}>{dateTittle}</DateTitle>
+        <ColoredTopArea isStart={dateTittle === 'START'} />
+        <TextBox>
+          <DateText>{formattedDate.day}</DateText>
+          <MonthYearText>
+            {formattedDate.month} {formattedDate.year}
+          </MonthYearText>
+        </TextBox>
+      </div>
+    )
   }
 
   return (
     <>
       <CollectionDateContainer>
-        <div>
-          <StartTitle>START</StartTitle>
-          <StartColoredTopArea />
-          <TextBox>
-            <DateText>{startDateInfo.day}</DateText>
-            <MonthYearText>
-              {startDateInfo.month} {startDateInfo.year}
-            </MonthYearText>
-          </TextBox>
-        </div>
+        <DateDisplay dateTittle='START' formattedDate={startDateInfo} />
         <GreyTransitionBox />
-        <div>
-          <EndTitle>END</EndTitle>
-          <EndColoredTopArea />
-          <TextBox>
-            <DateText>{endDateInfo.day}</DateText>
-            <MonthYearText>
-              {endDateInfo.month} {endDateInfo.year}
-            </MonthYearText>
-          </TextBox>
-        </div>
+        <DateDisplay dateTittle='END' formattedDate={endDateInfo} />
       </CollectionDateContainer>
     </>
   )

--- a/frontend/src/components/Common/CollectionDuration/index.tsx
+++ b/frontend/src/components/Common/CollectionDuration/index.tsx
@@ -1,0 +1,66 @@
+import {
+  CollectionDateContainer,
+  StartColoredTopArea,
+  GreyTransitionBox,
+  TextBox,
+  EndColoredTopArea,
+  StartTitle,
+  EndTitle,
+  DateText,
+  MonthYearText,
+} from '@src/components/Common/CollectionDuration/style'
+import dayjs from 'dayjs'
+
+type Props = {
+  startDate: string
+  endDate: string
+}
+
+type DisplayedDateInfo = {
+  year: string
+  month: string
+  day: string
+}
+
+const CollectionDuration = ({ startDate, endDate }: Props) => {
+  const startDateInfo: DisplayedDateInfo = {
+    year: dayjs(startDate).format('YY'),
+    month: dayjs(startDate).format('MMM'),
+    day: dayjs(startDate).format('DD'),
+  }
+  const endDateInfo: DisplayedDateInfo = {
+    year: dayjs(endDate).format('YY'),
+    month: dayjs(endDate).format('MMM'),
+    day: dayjs(endDate).format('DD'),
+  }
+
+  return (
+    <>
+      <CollectionDateContainer>
+        <div>
+          <StartTitle>START</StartTitle>
+          <StartColoredTopArea />
+          <TextBox>
+            <DateText>{startDateInfo.day}</DateText>
+            <MonthYearText>
+              {startDateInfo.month} {startDateInfo.year}
+            </MonthYearText>
+          </TextBox>
+        </div>
+        <GreyTransitionBox />
+        <div>
+          <EndTitle>END</EndTitle>
+          <EndColoredTopArea />
+          <TextBox>
+            <DateText>{endDateInfo.day}</DateText>
+            <MonthYearText>
+              {endDateInfo.month} {endDateInfo.year}
+            </MonthYearText>
+          </TextBox>
+        </div>
+      </CollectionDateContainer>
+    </>
+  )
+}
+
+export default CollectionDuration

--- a/frontend/src/components/Common/CollectionDuration/index.tsx
+++ b/frontend/src/components/Common/CollectionDuration/index.tsx
@@ -56,13 +56,11 @@ const CollectionDuration = ({ startDate, endDate }: Props) => {
   }
 
   return (
-    <>
-      <CollectionDateContainer>
-        <DateDisplay dateTittle='START' formattedDate={startDateInfo} />
-        <GreyTransitionBox />
-        <DateDisplay dateTittle='END' formattedDate={endDateInfo} />
-      </CollectionDateContainer>
-    </>
+    <CollectionDateContainer>
+      <DateDisplay dateTittle='START' formattedDate={startDateInfo} />
+      <GreyTransitionBox />
+      <DateDisplay dateTittle='END' formattedDate={endDateInfo} />
+    </CollectionDateContainer>
   )
 }
 

--- a/frontend/src/components/Common/CollectionDuration/style.tsx
+++ b/frontend/src/components/Common/CollectionDuration/style.tsx
@@ -5,7 +5,7 @@ import { theme } from '@src/theme'
 export const CollectionDateContainer = styled('div')({
   display: 'flex',
   alignItems: 'flex-end',
-  margin: '2rem auto 0',
+  margin: '0.5rem auto 0',
 })
 
 export const TextBox = styled(Paper)({

--- a/frontend/src/components/Common/CollectionDuration/style.tsx
+++ b/frontend/src/components/Common/CollectionDuration/style.tsx
@@ -5,12 +5,12 @@ import { theme } from '@src/theme'
 export const CollectionDateContainer = styled('div')({
   display: 'flex',
   alignItems: 'flex-end',
-  margin: '0.5rem auto 0',
+  margin: '0 auto 2rem',
 })
 
 export const TextBox = styled(Paper)({
-  width: '2.5rem',
-  height: '1.25rem',
+  width: '3rem',
+  height: '2rem',
   padding: '0.75rem',
   border: '0 solid #ccc',
   boxShadow: '0 0.125rem 0.5rem rgba(0, 0, 0, 0.2)',
@@ -24,7 +24,7 @@ export const TextBox = styled(Paper)({
 
 export const GreyTransitionBox = styled('div')({
   width: '10rem',
-  height: '2.8rem',
+  height: '3.5rem',
   backgroundColor: 'rgba(204, 204, 204, 0.28)',
   border: 0,
   borderRadius: 0,
@@ -49,11 +49,11 @@ export const DateTitle = styled('div')((props: { isStart: boolean }) => ({
 }))
 
 export const DateText = styled('div')({
-  fontSize: '1.25rem',
+  fontSize: '1.5rem',
   letterSpacing: '0.1rem',
 })
 
 export const MonthYearText = styled('div')({
   fontSize: '0.625rem',
-  marginBottom: '0.125rem',
+  marginBottom: '0.3rem',
 })

--- a/frontend/src/components/Common/CollectionDuration/style.tsx
+++ b/frontend/src/components/Common/CollectionDuration/style.tsx
@@ -25,7 +25,7 @@ export const TextBox = styled(Paper)({
 export const GreyTransitionBox = styled('div')({
   width: '10rem',
   height: '3.5rem',
-  backgroundColor: 'rgba(204, 204, 204, 0.28)',
+  backgroundColor: '#CCCCCC47',
   border: 0,
   borderRadius: 0,
 })

--- a/frontend/src/components/Common/CollectionDuration/style.tsx
+++ b/frontend/src/components/Common/CollectionDuration/style.tsx
@@ -1,0 +1,80 @@
+import { styled } from '@mui/material/styles'
+import { Paper } from '@mui/material'
+
+export const CollectionDateContainer = styled('div')`
+  display: flex;
+  align-items: flex-end;
+  margin: 2rem auto 0;
+`
+styled('strong')`
+  margin-left: 0.25rem;
+  font-size: 0.875rem;
+`
+export const TextBox = styled(Paper)`
+  width: 2.5rem;
+  height: 1.25rem;
+  padding: 0.75rem;
+  border: 0 solid #ccc;
+  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.2);
+  border-bottom-left-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`
+export const GreyTransitionBox = styled('div')`
+  width: 10rem;
+  height: 2.8rem;
+  background-color: rgba(204, 204, 204, 0.28);
+  border: 0;
+  border-radius: 0;
+`
+export const StartColoredTopArea = styled('div')`
+  width: 100%;
+  height: 0.625rem;
+  background-color: #b9c4cc;
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+`
+
+export const EndColoredTopArea = styled('div')`
+  width: 100%;
+  height: 10px;
+  background-color: #3498db;
+  border-top-left-radius: 0.375rem;
+  border-top-right-radius: 0.375rem;
+`
+
+export const StartTitle = styled('div')`
+  font-size: 0.625rem;
+  color: #b9c4cc;
+  font-family: Georgia, serif;
+  letter-spacing: 0.1em;
+  text-align: center;
+  padding: 0.25rem 0;
+  font-weight: bold;
+  margin-bottom: 0.125rem;
+`
+export const EndTitle = styled('div')`
+  font-size: 0.625rem;
+  color: #3498db;
+  text-align: center;
+  font-family: Georgia, serif;
+  letter-spacing: 0.1em;
+  padding: 0.25rem 0;
+  font-weight: bold;
+  margin-bottom: 0.125rem;
+`
+
+export const DateText = styled('div')`
+  font-size: 1.25rem;
+  letter-spacing: 0.1em;
+  font-family: monospace;
+`
+
+export const MonthYearText = styled('div')`
+  font-size: 0.625rem;
+  margin-bottom: 0.125rem;
+  font-family: monospace;
+`

--- a/frontend/src/components/Common/CollectionDuration/style.tsx
+++ b/frontend/src/components/Common/CollectionDuration/style.tsx
@@ -1,80 +1,59 @@
 import { styled } from '@mui/material/styles'
 import { Paper } from '@mui/material'
+import { theme } from '@src/theme'
 
-export const CollectionDateContainer = styled('div')`
-  display: flex;
-  align-items: flex-end;
-  margin: 2rem auto 0;
-`
-styled('strong')`
-  margin-left: 0.25rem;
-  font-size: 0.875rem;
-`
-export const TextBox = styled(Paper)`
-  width: 2.5rem;
-  height: 1.25rem;
-  padding: 0.75rem;
-  border: 0 solid #ccc;
-  box-shadow: 0 0.125rem 0.5rem rgba(0, 0, 0, 0.2);
-  border-bottom-left-radius: 0.375rem;
-  border-bottom-right-radius: 0.375rem;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-`
-export const GreyTransitionBox = styled('div')`
-  width: 10rem;
-  height: 2.8rem;
-  background-color: rgba(204, 204, 204, 0.28);
-  border: 0;
-  border-radius: 0;
-`
-export const StartColoredTopArea = styled('div')`
-  width: 100%;
-  height: 0.625rem;
-  background-color: #b9c4cc;
-  border-top-left-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-`
+export const CollectionDateContainer = styled('div')({
+  display: 'flex',
+  alignItems: 'flex-end',
+  margin: '2rem auto 0',
+})
 
-export const EndColoredTopArea = styled('div')`
-  width: 100%;
-  height: 10px;
-  background-color: #3498db;
-  border-top-left-radius: 0.375rem;
-  border-top-right-radius: 0.375rem;
-`
+export const TextBox = styled(Paper)({
+  width: '2.5rem',
+  height: '1.25rem',
+  padding: '0.75rem',
+  border: '0 solid #ccc',
+  boxShadow: '0 0.125rem 0.5rem rgba(0, 0, 0, 0.2)',
+  borderBottomLeftRadius: '0.375rem',
+  borderBottomRightRadius: '0.375rem',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+})
 
-export const StartTitle = styled('div')`
-  font-size: 0.625rem;
-  color: #b9c4cc;
-  font-family: Georgia, serif;
-  letter-spacing: 0.1em;
-  text-align: center;
-  padding: 0.25rem 0;
-  font-weight: bold;
-  margin-bottom: 0.125rem;
-`
-export const EndTitle = styled('div')`
-  font-size: 0.625rem;
-  color: #3498db;
-  text-align: center;
-  font-family: Georgia, serif;
-  letter-spacing: 0.1em;
-  padding: 0.25rem 0;
-  font-weight: bold;
-  margin-bottom: 0.125rem;
-`
+export const GreyTransitionBox = styled('div')({
+  width: '10rem',
+  height: '2.8rem',
+  backgroundColor: 'rgba(204, 204, 204, 0.28)',
+  border: 0,
+  borderRadius: 0,
+})
 
-export const DateText = styled('div')`
-  font-size: 1.25rem;
-  letter-spacing: 0.1em;
-  font-family: monospace;
-`
+export const ColoredTopArea = styled('div')((props: { isStart: boolean }) => ({
+  width: '100%',
+  height: '0.625rem',
+  backgroundColor: props.isStart ? theme.palette.info.light : theme.palette.info.dark,
+  borderTopLeftRadius: '0.375rem',
+  borderTopRightRadius: '0.375rem',
+}))
 
-export const MonthYearText = styled('div')`
-  font-size: 0.625rem;
-  margin-bottom: 0.125rem;
-  font-family: monospace;
-`
+export const DateTitle = styled('div')((props: { isStart: boolean }) => ({
+  fontSize: '0.625rem',
+  color: props.isStart ? theme.palette.info.light : theme.palette.info.dark,
+  textAlign: 'center',
+  letterSpacing: '0.1em',
+  padding: '0.25rem 0',
+  fontWeight: 'bold',
+  marginBottom: '0.125rem',
+}))
+
+export const DateText = styled('div')({
+  fontSize: '1.25rem',
+  letterSpacing: '0.1rem',
+})
+
+export const MonthYearText = styled('div')({
+  fontSize: '0.625rem',
+  marginBottom: '0.125rem',
+})

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -25,9 +25,9 @@ const MetricsStep = () => {
 
   return (
     <>
+      {startDate && endDate && <CollectionDuration startDate={startDate} endDate={endDate} />}
       <MetricSelectionWrapper>
         <MetricsSelectionTitle>Board configuration</MetricsSelectionTitle>
-        {startDate && endDate && <CollectionDuration startDate={startDate} endDate={endDate} />}
 
         {isShowCrewsAndRealDone && <Crews options={users} title={'Crews settings'} label={'Included Crews'} />}
 

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -3,10 +3,11 @@ import { useAppSelector } from '@src/hooks'
 import { RealDone } from '@src/components/Metrics/MetricsStep/RealDone'
 import { CycleTime } from '@src/components/Metrics/MetricsStep/CycleTime'
 import { Classification } from '@src/components/Metrics/MetricsStep/Classification'
-import { selectJiraColumns, selectMetrics, selectUsers } from '@src/context/config/configSlice'
+import { selectDateRange, selectJiraColumns, selectMetrics, selectUsers } from '@src/context/config/configSlice'
 import { DONE, REQUIRED_DATA } from '@src/constants'
 import { selectCycleTimeSettings, selectMetricsContent } from '@src/context/Metrics/metricsSlice'
 import { DeploymentFrequencySettings } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings'
+import CollectionDuration from '@src/components/Common/CollectionDuration'
 import { MetricSelectionWrapper, MetricsSelectionTitle } from '@src/components/Metrics/MetricsStep/style'
 
 const MetricsStep = () => {
@@ -15,6 +16,7 @@ const MetricsStep = () => {
   const jiraColumns = useAppSelector(selectJiraColumns)
   const targetFields = useAppSelector(selectMetricsContent).targetFields
   const cycleTimeSettings = useAppSelector(selectCycleTimeSettings)
+  const { startDate, endDate } = useAppSelector(selectDateRange)
   const isShowCrewsAndRealDone =
     requiredData.includes(REQUIRED_DATA.VELOCITY) ||
     requiredData.includes(REQUIRED_DATA.CYCLE_TIME) ||
@@ -25,7 +27,9 @@ const MetricsStep = () => {
     <>
       <MetricSelectionWrapper>
         <MetricsSelectionTitle>Board configuration</MetricsSelectionTitle>
-        {isShowCrewsAndRealDone && <Crews options={users} title={'Crews settings'} label={'Included Crews'} />}
+        {startDate && endDate && <CollectionDuration startDate={startDate} endDate={endDate} />}
+
+      {isShowCrewsAndRealDone && <Crews options={users} title={'Crews settings'} label={'Included Crews'} />}
 
         {requiredData.includes(REQUIRED_DATA.CYCLE_TIME) && <CycleTime title={'Cycle time settings'} />}
 

--- a/frontend/src/components/Metrics/MetricsStep/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/index.tsx
@@ -29,7 +29,7 @@ const MetricsStep = () => {
         <MetricsSelectionTitle>Board configuration</MetricsSelectionTitle>
         {startDate && endDate && <CollectionDuration startDate={startDate} endDate={endDate} />}
 
-      {isShowCrewsAndRealDone && <Crews options={users} title={'Crews settings'} label={'Included Crews'} />}
+        {isShowCrewsAndRealDone && <Crews options={users} title={'Crews settings'} label={'Included Crews'} />}
 
         {requiredData.includes(REQUIRED_DATA.CYCLE_TIME) && <CycleTime title={'Cycle time settings'} />}
 

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -25,6 +25,7 @@ import { useAppDispatch } from '@src/hooks/useAppDispatch'
 import { ButtonGroupStyle, ErrorNotificationContainer, ExportButton } from '@src/components/Metrics/ReportStep/style'
 import { ErrorNotification } from '@src/components/ErrorNotification'
 import { useNavigate } from 'react-router-dom'
+import CollectionDuration from '@src/components/Common/CollectionDuration'
 
 const ReportStep = () => {
   const dispatch = useAppDispatch()
@@ -69,6 +70,7 @@ const ReportStep = () => {
   const { metrics, calendarType, dateRange } = configData.basic
   const { board, pipelineTool, sourceControl } = configData
   const { token, type, site, projectKey, boardId, email } = board.config
+  const { startDate, endDate } = dateRange
   const requiredData = useAppSelector(selectMetrics)
   const isShowExportBoardButton =
     requiredData.includes(REQUIRED_DATA.VELOCITY) ||
@@ -115,8 +117,8 @@ const ReportStep = () => {
   const encodeToken = `Basic ${btoa(msg)}`
   const getReportRequestBody = (): ReportRequestDTO => ({
     metrics: metrics,
-    startTime: dayjs(dateRange.startDate).valueOf().toString(),
-    endTime: dayjs(dateRange.endDate).valueOf().toString(),
+    startTime: dayjs(startDate).valueOf().toString(),
+    endTime: dayjs(endDate).valueOf().toString(),
     considerHoliday: calendarType === CHINA_CALENDAR,
     buildKiteSetting: {
       pipelineCrews,
@@ -144,9 +146,11 @@ const ReportStep = () => {
     csvTimeStamp: csvTimeStamp,
   })
 
-  const getExportCSV = (dataType: string): CSVReportRequestDTO => ({
+  const getExportCSV = (dataType: string, startDate: string | null, endDate: string | null): CSVReportRequestDTO => ({
     dataType: dataType,
     csvTimeStamp: csvTimeStamp,
+    startDate: startDate ?? '',
+    endDate: endDate ?? '',
   })
 
   const fetchReportData: () => Promise<
@@ -196,8 +200,8 @@ const ReportStep = () => {
     })
   }, [fetchReportData])
 
-  const handleDownload = (dataType: string) => {
-    fetchExportData(getExportCSV(dataType))
+  const handleDownload = (dataType: string, startDate: string | null, endDate: string | null) => {
+    fetchExportData(getExportCSV(dataType, startDate, endDate))
   }
 
   const handleBack = () => {
@@ -212,6 +216,7 @@ const ReportStep = () => {
         navigate(ERROR_PAGE_ROUTE)
       ) : (
         <>
+          {startDate && endDate && <CollectionDuration startDate={startDate} endDate={endDate} />}
           {reportErrorMsg && (
             <ErrorNotificationContainer>
               <ErrorNotification message={reportErrorMsg} />
@@ -269,10 +274,12 @@ const ReportStep = () => {
               Previous
             </BackButton>
             {isShowExportBoardButton && (
-              <ExportButton onClick={() => handleDownload('board')}>Export board data</ExportButton>
+              <ExportButton onClick={() => handleDownload('board', startDate, endDate)}>Export board data</ExportButton>
             )}
             {isShowExportPipelineButton && (
-              <ExportButton onClick={() => handleDownload('pipeline')}>Export pipeline data</ExportButton>
+              <ExportButton onClick={() => handleDownload('pipeline', startDate, endDate)}>
+                Export pipeline data
+              </ExportButton>
             )}
           </ButtonGroupStyle>
         </>

--- a/frontend/src/theme.ts
+++ b/frontend/src/theme.ts
@@ -40,6 +40,10 @@ export const theme = createTheme({
     primary: {
       main: indigo[FIVE_HUNDRED],
     },
+    info: {
+      main: '#3498db',
+      light: '#b9c4cc',
+    },
   },
   main: {
     backgroundColor: indigo[FIVE_HUNDRED],


### PR DESCRIPTION
## Summary

- Add the collection duration display in both `metrics` and `report` page.
- Add the collection duration info in the exported csv file name.

## Before

<img width="1783" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/64305563/693b562d-a6d3-42cd-a992-ac7b1dcf30e5">


## After

<img width="1229" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/64305563/cf27dc33-bd4c-4fbd-8aaa-e8470ef8b766">



## Note

_Null_
