### PR TITLE
ADM-611:[frontend]feat: clean encoded jira token for empty token

### DIFF
--- a/backend/src/main/java/heartbeat/controller/source/dto/SourceControlDTO.java
+++ b/backend/src/main/java/heartbeat/controller/source/dto/SourceControlDTO.java
@@ -20,8 +20,7 @@ public class SourceControlDTO {
 
 	@Valid
 	@NotBlank(message = "Token cannot be empty.")
-	@Pattern(regexp = "^(ghp|gho|ghu|ghs|ghr)_([a-zA-Z0-9]{36})$",
-		message = "token's pattern is incorrect")
+	@Pattern(regexp = "^(ghp|gho|ghu|ghs|ghr)_([a-zA-Z0-9]{36})$", message = "token's pattern is incorrect")
 	private String token;
 
 }

--- a/backend/src/test/java/heartbeat/controller/source/GithubControllerTest.java
+++ b/backend/src/test/java/heartbeat/controller/source/GithubControllerTest.java
@@ -72,7 +72,9 @@ class GithubControllerTest {
 	void shouldReturnBadRequestWhenRequestParamPatternIsIncorrect() throws Exception {
 		SourceControlDTO sourceControlDTO = SourceControlDTO.builder().token("12345").build();
 
-		final var response = mockMvc.perform(post("/source-control").content(new ObjectMapper().writeValueAsString(sourceControlDTO)).contentType(MediaType.APPLICATION_JSON))
+		final var response = mockMvc
+			.perform(post("/source-control").content(new ObjectMapper().writeValueAsString(sourceControlDTO))
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isBadRequest())
 			.andReturn()
 			.getResponse();

--- a/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/MetricsStepper/MetricsStepper.test.tsx
@@ -81,6 +81,7 @@ jest.mock('@src/emojis/emoji', () => ({
 
 jest.mock('@src/utils/util', () => ({
   exportToJsonFile: jest.fn(),
+  getJiraBoardToken: jest.fn(),
   transformToCleanedBuildKiteEmoji: jest.fn(),
 }))
 

--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -45,6 +45,7 @@ jest.mock('@src/emojis/emoji', () => ({
 
 jest.mock('@src/utils/util', () => ({
   transformToCleanedBuildKiteEmoji: jest.fn(),
+  getJiraBoardToken: jest.fn(),
 }))
 
 let store = null

--- a/frontend/__tests__/src/utils/Util.test.tsx
+++ b/frontend/__tests__/src/utils/Util.test.tsx
@@ -1,4 +1,4 @@
-import { exportToJsonFile, transformToCleanedBuildKiteEmoji } from '@src/utils/util'
+import { exportToJsonFile, getJiraBoardToken, transformToCleanedBuildKiteEmoji } from '@src/utils/util'
 import { CleanedBuildKiteEmoji, OriginBuildKiteEmoji } from '@src/emojis/emoji'
 
 describe('exportToJsonFile function', () => {
@@ -29,5 +29,26 @@ describe('transformToCleanedBuildKiteEmoji function', () => {
     const [result] = transformToCleanedBuildKiteEmoji([mockOriginEmoji])
 
     expect(result).toEqual(expectedCleanedEmoji)
+  })
+})
+
+describe('getJiraToken function', () => {
+  it('should return an valid string when token is not empty string', () => {
+    const email = 'test@example.com'
+    const token = 'myToken'
+
+    const jiraToken = getJiraBoardToken(token, email)
+    const encodedMsg = `Basic ${btoa(`${email}:${token}`)}`
+
+    expect(jiraToken).toBe(encodedMsg)
+  })
+
+  it('should return an empty string when token is missing', () => {
+    const email = 'test@example.com'
+    const token = ''
+
+    const jiraToken = getJiraBoardToken(token, email)
+
+    expect(jiraToken).toBe('')
   })
 })

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -26,6 +26,7 @@ import { ButtonGroupStyle, ErrorNotificationContainer, ExportButton } from '@src
 import { ErrorNotification } from '@src/components/ErrorNotification'
 import { useNavigate } from 'react-router-dom'
 import CollectionDuration from '@src/components/Common/CollectionDuration'
+import { getJiraBoardToken } from '@src/utils/util'
 
 const ReportStep = () => {
   const dispatch = useAppDispatch()
@@ -113,9 +114,8 @@ const ReportStep = () => {
     }[]
   }
 
-  const msg = `${email}:${token}`
-  const encodeToken = `Basic ${btoa(msg)}`
   const filteredCycleTime = cycleTimeSettings.filter((item) => item.value != '----')
+  const jiraToken = getJiraBoardToken(token, email)
   const getReportRequestBody = (): ReportRequestDTO => ({
     metrics: metrics,
     startTime: dayjs(startDate).valueOf().toString(),
@@ -132,7 +132,7 @@ const ReportStep = () => {
       leadTime: getPipelineConfig(leadTimeForChanges),
     },
     jiraBoardSetting: {
-      token: encodeToken,
+      token: jiraToken,
       type: type.toLowerCase().replace(' ', '-'),
       site,
       projectKey,

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -27,3 +27,12 @@ export const transformToCleanedBuildKiteEmoji = (input: OriginBuildKiteEmoji[]):
     image,
     aliases: [...new Set([...aliases, name])],
   }))
+
+export const getJiraBoardToken = (token: string, email: string) => {
+  if (token) {
+    const encodedMsg = btoa(`${email}:${token}`)
+    return `Basic ${encodedMsg}`
+  } else {
+    return ''
+  }
+}


### PR DESCRIPTION
## Summary

Make the jira board token to be an empty string when use don't need the jira board information