### PR TITLE
ADM-645:[backend]test: add test for supporting column multi-status to get correct cycleTime

### DIFF
--- a/backend/src/main/java/heartbeat/service/report/calculator/CycleTimeCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/CycleTimeCalculator.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -113,7 +112,7 @@ public class CycleTimeCalculator {
 			.map(Map.Entry::getKey)
 			.toList();
 		List<CycleTimeForSelectedStepItem> cycleTimeForSelectedStepsList = new ArrayList<>();
-		double totalTime = 0;
+		double totalTime = 0.0;
 		for (Map.Entry<String, Double> entry : aggregatedMap.entrySet()) {
 			String key = entry.getKey();
 			double value = BigDecimal.valueOf(entry.getValue()).setScale(2, RoundingMode.HALF_UP).doubleValue();

--- a/backend/src/test/java/heartbeat/service/report/CycleTimeCalculatorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/CycleTimeCalculatorTest.java
@@ -15,7 +15,10 @@ import org.mockito.quality.Strictness;
 import java.util.List;
 
 import static heartbeat.service.report.CycleTimeFixture.JIRA_BOARD_COLUMNS_SETTING;
+import static heartbeat.service.report.CycleTimeFixture.JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_STATUSES;
+import static heartbeat.service.report.CycleTimeFixture.JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_SWIM_LANES;
 import static heartbeat.service.report.CycleTimeFixture.MOCK_CARD_COLLECTION;
+import static heartbeat.service.report.CycleTimeFixture.MOCK_CARD_COLLECTION_COLUMN_WITH_MULTIPLE_STATUSES;
 import static heartbeat.service.report.CycleTimeFixture.MOCK_CARD_COLLECTION_WITH_ZERO_VALUE;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +30,7 @@ class CycleTimeCalculatorTest {
 	CycleTimeCalculator cycleTimeCalculator;
 
 	@Test
-	public void shouldReturnAllDoneCardsCycleTimeWhenCallCalculateCycleTime() {
+	void shouldReturnAllDoneCardsCycleTimeWhenCallCalculateCycleTime() {
 		CardCollection cardCollection = MOCK_CARD_COLLECTION();
 		List<RequestJiraBoardColumnSetting> boardColumns = JIRA_BOARD_COLUMNS_SETTING();
 
@@ -54,7 +57,6 @@ class CycleTimeCalculatorTest {
 						.averageTimeForCards(1.30)
 						.totalTime(2.60)
 						.build()))
-
 			.build();
 
 		CycleTime cycleTimeActual = cycleTimeCalculator.calculateCycleTime(cardCollection, boardColumns);
@@ -63,7 +65,7 @@ class CycleTimeCalculatorTest {
 	}
 
 	@Test
-	public void shouldReturnAllDoneCardsCycleTimeWhenCallCalculateCycleTimeWithZeroValue() {
+	void shouldReturnAllDoneCardsCycleTimeWhenCallCalculateCycleTimeWithZeroValue() {
 		CardCollection cardCollection = MOCK_CARD_COLLECTION_WITH_ZERO_VALUE();
 		List<RequestJiraBoardColumnSetting> boardColumns = JIRA_BOARD_COLUMNS_SETTING();
 
@@ -90,7 +92,76 @@ class CycleTimeCalculatorTest {
 						.averageTimeForCards(0.0)
 						.totalTime(1.3)
 						.build()))
+			.build();
 
+		CycleTime cycleTimeActual = cycleTimeCalculator.calculateCycleTime(cardCollection, boardColumns);
+
+		assertThat(cycleTimeActual).isEqualTo(cycleTimeExpect);
+	}
+
+	@Test
+	void shouldCalculateAllTheStatusesTogetherWhenCycleTimeColumnHasMultipleStatuses() {
+		CardCollection cardCollection = MOCK_CARD_COLLECTION_COLUMN_WITH_MULTIPLE_STATUSES();
+		List<RequestJiraBoardColumnSetting> boardColumns = JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_STATUSES();
+
+		CycleTime cycleTimeExpect = CycleTime.builder()
+			.totalTimeForCards(6.9)
+			.averageCycleTimePerSP(3.45)
+			.averageCycleTimePerCard(6.9)
+			.swimlaneList(List.of(
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("In Dev")
+						.averageTimeForSP(1.3)
+						.averageTimeForCards(2.6)
+						.totalTime(2.6)
+						.build(),
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("Block")
+						.averageTimeForSP(1.5)
+						.averageTimeForCards(3.0)
+						.totalTime(3.0)
+						.build(),
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("Testing")
+						.averageTimeForSP(0.65)
+						.averageTimeForCards(1.3)
+						.totalTime(1.3)
+						.build()))
+			.build();
+
+		CycleTime cycleTimeActual = cycleTimeCalculator.calculateCycleTime(cardCollection, boardColumns);
+
+		assertThat(cycleTimeActual).isEqualTo(cycleTimeExpect);
+	}
+
+	@Test
+	void shouldCalculateAllTheSwimLanesTogetherWhenCycleTimeMetricHasMultipleSwimLanes() {
+		CardCollection cardCollection = MOCK_CARD_COLLECTION_COLUMN_WITH_MULTIPLE_STATUSES();
+		List<RequestJiraBoardColumnSetting> boardColumns = JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_SWIM_LANES();
+
+		CycleTime cycleTimeExpect = CycleTime.builder()
+			.totalTimeForCards(5.5)
+			.averageCycleTimePerSP(2.75)
+			.averageCycleTimePerCard(5.5)
+			.swimlaneList(List.of(
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("In Dev")
+						.averageTimeForSP(1.6)
+						.averageTimeForCards(3.2)
+						.totalTime(3.2)
+						.build(),
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("Block")
+						.averageTimeForSP(0.5)
+						.averageTimeForCards(1.0)
+						.totalTime(1.0)
+						.build(),
+					CycleTimeForSelectedStepItem.builder()
+						.optionalItemName("Testing")
+						.averageTimeForSP(0.65)
+						.averageTimeForCards(1.3)
+						.totalTime(1.3)
+						.build()))
 			.build();
 
 		CycleTime cycleTimeActual = cycleTimeCalculator.calculateCycleTime(cardCollection, boardColumns);

--- a/backend/src/test/java/heartbeat/service/report/CycleTimeFixture.java
+++ b/backend/src/test/java/heartbeat/service/report/CycleTimeFixture.java
@@ -32,10 +32,39 @@ public class CycleTimeFixture {
 		return CardCollection.builder().storyPointSum(0).cardsNumber(0).jiraCardDTOList(jiraCardList).build();
 	}
 
+	public static CardCollection MOCK_CARD_COLLECTION_COLUMN_WITH_MULTIPLE_STATUSES() {
+		List<CycleTimeInfo> cycleTimeInfoList = List.of(CycleTimeInfo.builder().column("IN DOING").day(1.4).build(),
+				CycleTimeInfo.builder().column("DOING").day(1.2).build(),
+				CycleTimeInfo.builder().column("BLOCKED").day(2.0).build(),
+				CycleTimeInfo.builder().column("FLAG").day(1.0).build(),
+				CycleTimeInfo.builder().column("TESTING").day(1.3).build(),
+				CycleTimeInfo.builder().column("DONE").day(9.0).build());
+		List<JiraCardDTO> jiraCardList = List.of(JiraCardDTO.builder().cycleTime(cycleTimeInfoList).build());
+
+		return CardCollection.builder().storyPointSum(2.0).cardsNumber(1).jiraCardDTOList(jiraCardList).build();
+	}
+
 	public static List<RequestJiraBoardColumnSetting> JIRA_BOARD_COLUMNS_SETTING() {
 		return List.of(RequestJiraBoardColumnSetting.builder().name("TODO").value("To do").build(),
 				RequestJiraBoardColumnSetting.builder().name("Doing").value("In Dev").build(),
 				RequestJiraBoardColumnSetting.builder().name("Blocked").value("Block").build(),
+				RequestJiraBoardColumnSetting.builder().name("Testing").value("Testing").build(),
+				RequestJiraBoardColumnSetting.builder().name("Done").value("Done").build());
+	}
+
+	public static List<RequestJiraBoardColumnSetting> JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_STATUSES() {
+		return List.of(RequestJiraBoardColumnSetting.builder().name("TODO").value("To do").build(),
+				RequestJiraBoardColumnSetting.builder().name("Doing").value("In Dev").build(),
+				RequestJiraBoardColumnSetting.builder().name("In Doing").value("In Dev").build(),
+				RequestJiraBoardColumnSetting.builder().name("Blocked").value("Block").build(),
+				RequestJiraBoardColumnSetting.builder().name("Testing").value("Testing").build(),
+				RequestJiraBoardColumnSetting.builder().name("Done").value("Done").build());
+	}
+
+	public static List<RequestJiraBoardColumnSetting> JIRA_BOARD_COLUMNS_SETTING_WITH_MULTIPLE_SWIM_LANES() {
+		return List.of(RequestJiraBoardColumnSetting.builder().name("TODO").value("To do").build(),
+				RequestJiraBoardColumnSetting.builder().name("Doing").value("In Dev").build(),
+				RequestJiraBoardColumnSetting.builder().name("Blocked").value("In Dev").build(),
 				RequestJiraBoardColumnSetting.builder().name("Testing").value("Testing").build(),
 				RequestJiraBoardColumnSetting.builder().name("Done").value("Done").build());
 	}


### PR DESCRIPTION
… get correct cycleTime

## Summary

To support column multi-status to get correct cycleTime, we don't need to change the function code. So I just add 2 tests to cover the business scenarios.

1. should sum all the statuses when a state have multiple statues
For example: The Doing state has 2 statues.

> In Doing -> Doing

> Doing -> Doing

2. should sum all the statues when multiple swimlane mapping to the same metric
For example: The **In Dev** has 2 swimlanes.

> Doing -> In Dev

> Testing -> In Dev

## Note

_Null_
