### PR TITLE
Adm 640: [Frontend] Keep polling from generate report callback to fetch the result

### DIFF
--- a/frontend/__tests__/src/client/ReportClient.test.ts
+++ b/frontend/__tests__/src/client/ReportClient.test.ts
@@ -1,19 +1,35 @@
 import { setupServer } from 'msw/node'
 import { rest } from 'msw'
-import { MOCK_GENERATE_REPORT_REQUEST_PARAMS, MOCK_REPORT_URL, VERIFY_ERROR_MESSAGE } from '../fixtures'
+import {
+  MOCK_GENERATE_REPORT_REQUEST_PARAMS,
+  MOCK_REPORT_RESPONSE,
+  MOCK_RETRIEVE_REPORT_RESPONSE,
+  VERIFY_ERROR_MESSAGE,
+} from '../fixtures'
 import { HttpStatusCode } from 'axios'
 import { reportClient } from '@src/clients/report/ReportClient'
 
-const server = setupServer(rest.post(MOCK_REPORT_URL, (req, res, ctx) => res(ctx.status(HttpStatusCode.Ok))))
+const MOCK_REPORT_URL = 'http://localhost/api/v1/reports'
+const server = setupServer(
+  rest.post(MOCK_REPORT_URL, (req, res, ctx) => res(ctx.status(HttpStatusCode.Ok))),
+  rest.get(MOCK_REPORT_URL, (req, res, ctx) => res(ctx.status(HttpStatusCode.Ok)))
+)
 
 describe('report client', () => {
   beforeAll(() => server.listen())
+  afterEach(() => server.resetHandlers())
   afterAll(() => server.close())
 
-  it('should get response when generate report request status 200', async () => {
-    const result = await reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
-
-    expect(result.response).not.toBeNull()
+  it('should get response when generate report request status 202', async () => {
+    const excepted = {
+      response: MOCK_RETRIEVE_REPORT_RESPONSE,
+    }
+    server.use(
+      rest.post(MOCK_REPORT_URL, (req, res, ctx) =>
+        res(ctx.status(HttpStatusCode.Accepted), ctx.json(MOCK_RETRIEVE_REPORT_RESPONSE))
+      )
+    )
+    await expect(reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)).resolves.toStrictEqual(excepted)
   })
 
   it('should throw error when generate report response status 500', async () => {
@@ -48,5 +64,35 @@ describe('report client', () => {
     await expect(async () => {
       await reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     }).rejects.toThrow(VERIFY_ERROR_MESSAGE.BAD_REQUEST)
+  })
+
+  it('should throw error when calling pollingReport given response status 500', () => {
+    server.use(
+      rest.get(MOCK_REPORT_URL, (req, res, ctx) =>
+        res(
+          ctx.status(HttpStatusCode.InternalServerError),
+          ctx.json({
+            hintInfo: VERIFY_ERROR_MESSAGE.INTERNAL_SERVER_ERROR,
+          })
+        )
+      )
+    )
+
+    expect(async () => {
+      await reportClient.pollingReport(MOCK_REPORT_URL)
+    }).rejects.toThrow(VERIFY_ERROR_MESSAGE.INTERNAL_SERVER_ERROR)
+  })
+
+  it('should return status and response when calling pollingReport given response status 201', async () => {
+    const excepted = {
+      status: HttpStatusCode.Created,
+      response: MOCK_REPORT_RESPONSE,
+    }
+    server.use(
+      rest.get(MOCK_REPORT_URL, (req, res, ctx) =>
+        res(ctx.status(HttpStatusCode.Created), ctx.json(MOCK_REPORT_RESPONSE))
+      )
+    )
+    await expect(reportClient.pollingReport(MOCK_REPORT_URL)).resolves.toEqual(excepted)
   })
 })

--- a/frontend/__tests__/src/client/ReportClient.test.ts
+++ b/frontend/__tests__/src/client/ReportClient.test.ts
@@ -11,7 +11,7 @@ describe('report client', () => {
   afterAll(() => server.close())
 
   it('should get response when generate report request status 200', async () => {
-    const result = await reportClient.report(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+    const result = await reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
 
     expect(result.response).not.toBeNull()
   })
@@ -29,7 +29,7 @@ describe('report client', () => {
     )
 
     await expect(async () => {
-      await reportClient.report(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      await reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     }).rejects.toThrow(VERIFY_ERROR_MESSAGE.INTERNAL_SERVER_ERROR)
   })
 
@@ -46,7 +46,7 @@ describe('report client', () => {
     )
 
     await expect(async () => {
-      await reportClient.report(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      await reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     }).rejects.toThrow(VERIFY_ERROR_MESSAGE.BAD_REQUEST)
   })
 })

--- a/frontend/__tests__/src/client/ReportClient.test.ts
+++ b/frontend/__tests__/src/client/ReportClient.test.ts
@@ -29,6 +29,7 @@ describe('report client', () => {
         res(ctx.status(HttpStatusCode.Accepted), ctx.json(MOCK_RETRIEVE_REPORT_RESPONSE))
       )
     )
+
     await expect(reportClient.retrieveReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)).resolves.toStrictEqual(excepted)
   })
 
@@ -93,6 +94,7 @@ describe('report client', () => {
         res(ctx.status(HttpStatusCode.Created), ctx.json(MOCK_REPORT_RESPONSE))
       )
     )
+
     await expect(reportClient.pollingReport(MOCK_REPORT_URL)).resolves.toEqual(excepted)
   })
 })

--- a/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/components/Metrics/ReportStep/ReportStep.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, renderHook, waitFor } from '@testing-library/react'
+import { render, renderHook } from '@testing-library/react'
 import ReportStep from '@src/components/Metrics/ReportStep'
 import {
   BACK,
@@ -21,19 +21,12 @@ import {
 import userEvent from '@testing-library/user-event'
 import { backStep } from '@src/context/stepper/StepperSlice'
 import { navigateMock } from '../../../../setupTests'
-import mocked = jest.mocked
 import { useGenerateReportEffect } from '@src/hooks/useGenerateReportEffect'
 import { useNotificationLayoutEffect } from '@src/hooks/useNotificationLayoutEffect'
 import { HEADER_NOTIFICATION_MESSAGE } from '@src/constants'
 import React from 'react'
+import { useExportCsvEffect } from '@src/hooks/useExportCsvEffect'
 
-jest.mock('@src/hooks/useGenerateReportEffect', () => ({
-  useGenerateReportEffect: jest.fn().mockReturnValue({
-    generateReport: jest.fn(() => Promise.resolve(EXPECTED_REPORT_VALUES)),
-    isLoading: false,
-    isServerError: false,
-  }),
-}))
 jest.mock('@src/context/stepper/StepperSlice', () => ({
   ...jest.requireActual('@src/context/stepper/StepperSlice'),
   backStep: jest.fn().mockReturnValue({ type: 'BACK_STEP' }),
@@ -43,7 +36,17 @@ jest.mock('@src/hooks/useExportCsvEffect', () => ({
   useExportCsvEffect: jest.fn().mockReturnValue({
     fetchExportData: jest.fn(),
     errorMessage: 'failed export csv',
+    isExpired: false,
+  }),
+}))
+
+jest.mock('@src/hooks/useGenerateReportEffect', () => ({
+  useGenerateReportEffect: jest.fn().mockReturnValue({
+    startPollingReports: jest.fn(),
+    stopPollingReports: jest.fn(),
+    isLoading: false,
     isServerError: false,
+    errorMessage: '',
   }),
 }))
 
@@ -58,28 +61,41 @@ jest.mock('@src/utils/util', () => ({
 }))
 
 let store = null
-
 describe('Report Step', () => {
-  const { result } = renderHook(() => useNotificationLayoutEffect())
-
-  const setup = async (params: [string]) => {
+  const { result: notificationHook } = renderHook(() => useNotificationLayoutEffect())
+  const { result: reportHook } = renderHook(() => useGenerateReportEffect())
+  beforeEach(() => {
+    resetReportHook()
+  })
+  afterAll(() => {
+    jest.clearAllMocks()
+  })
+  const resetReportHook = async () => {
+    reportHook.current.startPollingReports = jest.fn()
+    reportHook.current.stopPollingReports = jest.fn()
+    reportHook.current.isLoading = false
+    reportHook.current.isServerError = false
+    reportHook.current.errorMessage = ''
+    reportHook.current.reports = EXPECTED_REPORT_VALUES
+  }
+  const setup = (params: [string]) => {
     store = setupStore()
-    await store.dispatch(
+    store.dispatch(
       updateJiraVerifyResponse({
         jiraColumns: MOCK_JIRA_VERIFY_RESPONSE.jiraColumns,
         targetFields: MOCK_JIRA_VERIFY_RESPONSE.targetFields,
         users: MOCK_JIRA_VERIFY_RESPONSE.users,
       })
     )
-    await store.dispatch(updateMetrics(params))
-    await store.dispatch(
+    store.dispatch(updateMetrics(params))
+    store.dispatch(
       updateDeploymentFrequencySettings({ updateId: 0, label: 'organization', value: 'mock organization' })
     )
-    await store.dispatch(
+    store.dispatch(
       updateDeploymentFrequencySettings({ updateId: 0, label: 'pipelineName', value: 'mock pipeline name' })
     )
-    await store.dispatch(updateDeploymentFrequencySettings({ updateId: 0, label: 'step', value: 'mock step1' }))
-    await store.dispatch(
+    store.dispatch(updateDeploymentFrequencySettings({ updateId: 0, label: 'step', value: 'mock step1' }))
+    store.dispatch(
       updatePipelineToolVerifyResponse({
         pipelineList: [
           {
@@ -95,7 +111,7 @@ describe('Report Step', () => {
     )
     return render(
       <Provider store={store}>
-        <ReportStep {...result.current} />
+        <ReportStep {...notificationHook.current} />
       </Provider>
     )
   }
@@ -104,155 +120,116 @@ describe('Report Step', () => {
     jest.clearAllMocks()
   })
 
-  it('should render report page', async () => {
-    const { getByText } = await act(() => setup(['']))
+  it('should render report page', () => {
+    const { getByText } = setup([''])
 
-    await waitFor(() => {
-      expect(getByText(REQUIRED_DATA_LIST[1])).toBeInTheDocument()
-      expect(getByText(REQUIRED_DATA_LIST[2])).toBeInTheDocument()
-    })
+    expect(getByText(REQUIRED_DATA_LIST[1])).toBeInTheDocument()
+    expect(getByText(REQUIRED_DATA_LIST[2])).toBeInTheDocument()
   })
 
-  it('should renders the velocity component with correct props', async () => {
-    const { getByText } = await act(() => setup(['']))
+  it('should renders the velocity component with correct props', () => {
+    const { getByText } = setup([''])
 
-    await waitFor(() => {
-      expect(getByText(20)).toBeInTheDocument()
-      expect(getByText(14)).toBeInTheDocument()
-    })
+    expect(getByText(20)).toBeInTheDocument()
+    expect(getByText(14)).toBeInTheDocument()
   })
 
-  it('should renders the CycleTime component with correct props', async () => {
-    const { getByText } = await act(() => setup(['']))
+  it('should renders the CycleTime component with correct props', () => {
+    const { getByText } = setup([''])
 
-    await waitFor(() => {
-      expect(getByText('30.26(days/card)')).toBeInTheDocument()
-      expect(getByText('21.18(days/SP)')).toBeInTheDocument()
-      expect(getByText('57.25%')).toBeInTheDocument()
-      expect(getByText('12.13(days/SP)')).toBeInTheDocument()
-    })
+    expect(getByText('30.26(days/card)')).toBeInTheDocument()
+    expect(getByText('21.18(days/SP)')).toBeInTheDocument()
+    expect(getByText('57.25%')).toBeInTheDocument()
+    expect(getByText('12.13(days/SP)')).toBeInTheDocument()
   })
 
   it('should call handleBack method when click back button given back button enabled', async () => {
-    const { getByText } = await act(() => setup(['']))
-
-    await userEvent.click(getByText(BACK))
-
+    const { getByText } = setup([''])
+    const back = getByText(BACK)
+    await userEvent.click(back)
     expect(backStep).toHaveBeenCalledTimes(1)
   })
 
-  it('should not show export pipeline button when not select deployment frequency', async () => {
-    const { queryByText } = await act(() => setup([REQUIRED_DATA_LIST[1]]))
-
+  it('should not show export pipeline button when not select deployment frequency', () => {
+    const { queryByText } = setup([REQUIRED_DATA_LIST[1]])
     const exportPipelineButton = queryByText(EXPORT_PIPELINE_DATA)
-
     expect(exportPipelineButton).not.toBeInTheDocument()
   })
 
   it.each([[REQUIRED_DATA_LIST[4]], [REQUIRED_DATA_LIST[5]], [REQUIRED_DATA_LIST[6]], [REQUIRED_DATA_LIST[7]]])(
     'should show export pipeline button when select %s',
-    async (requiredData) => {
-      const { getByText } = await act(() => setup([requiredData]))
+    (requiredData) => {
+      const { getByText } = setup([requiredData])
       const exportPipelineButton = getByText(EXPORT_PIPELINE_DATA)
-
       expect(exportPipelineButton).toBeInTheDocument()
     }
   )
 
-  it('should show errorMessage when generateReport has error message', async () => {
-    mocked(useGenerateReportEffect).mockReturnValue({
-      generateReport: jest.fn(),
-      isLoading: false,
-      errorMessage: 'error message',
-      isServerError: false,
-    })
-
-    const { getByText } = await act(() => setup(['']))
-
+  it('should show errorMessage when generateReport has error message', () => {
+    reportHook.current.errorMessage = 'error message'
+    const { getByText } = setup([''])
     expect(getByText('error message')).toBeInTheDocument()
   })
 
-  it('should show errorMessage when click export pipeline button given csv not exist', async () => {
-    const { getByText } = await act(() => setup([REQUIRED_DATA_LIST[4]]))
-
-    await userEvent.click(getByText(EXPORT_PIPELINE_DATA))
-
+  it('should show errorMessage when click export pipeline button given csv not exist', () => {
+    const { getByText } = setup([REQUIRED_DATA_LIST[4]])
+    userEvent.click(getByText(EXPORT_PIPELINE_DATA))
     expect(getByText('failed export csv')).toBeInTheDocument()
   })
 
   describe('export board data', () => {
-    it('should not show export board button when not select board metrics', async () => {
-      const { queryByText } = await act(() => setup([REQUIRED_DATA_LIST[4]]))
-
+    it('should not show export board button when not select board metrics', () => {
+      const { queryByText } = setup([REQUIRED_DATA_LIST[4]])
       const exportPipelineButton = queryByText(EXPORT_BOARD_DATA)
-
       expect(exportPipelineButton).not.toBeInTheDocument()
     })
 
     it.each([[REQUIRED_DATA_LIST[1]], [REQUIRED_DATA_LIST[2]], [REQUIRED_DATA_LIST[3]]])(
       'should show export board button when select %s',
-      async (requiredData) => {
-        const { getByText } = await act(() => setup([requiredData]))
+      (requiredData) => {
+        const { getByText } = setup([requiredData])
         const exportPipelineButton = getByText(EXPORT_BOARD_DATA)
-
         expect(exportPipelineButton).toBeInTheDocument()
       }
     )
 
-    it('should show errorMessage when click export board button given csv not exist', async () => {
-      const { getByText } = await act(() => setup([REQUIRED_DATA_LIST[1]]))
-      await userEvent.click(getByText(EXPORT_BOARD_DATA))
-
+    it('should show errorMessage when click export board button given csv not exist', () => {
+      const { getByText } = setup([REQUIRED_DATA_LIST[1]])
+      userEvent.click(getByText(EXPORT_BOARD_DATA))
       expect(getByText('failed export csv')).toBeInTheDocument()
     })
   })
 
-  it('should show errorMessage when click export metric button given csv not exist', async () => {
-    const { getByText } = await act(() => setup(['']))
-
-    await userEvent.click(getByText(EXPORT_METRIC_DATA))
-
+  it('should show errorMessage when click export metric button given csv not exist', () => {
+    const { getByText } = setup([''])
+    userEvent.click(getByText(EXPORT_METRIC_DATA))
     expect(getByText('Export metric data')).toBeInTheDocument()
   })
 
-  it('should show export metric button when visiting this page', async () => {
-    const { getByText } = await act(() => setup(['']))
-
+  it('should show export metric button when visiting this page', () => {
+    const { getByText } = setup([''])
     const exportMetricButton = getByText(EXPORT_METRIC_DATA)
     expect(exportMetricButton).toBeInTheDocument()
   })
 
-  it('should check error page show when isReportError is true', async () => {
-    mocked(useGenerateReportEffect).mockReturnValue({
-      generateReport: jest.fn(),
-      isLoading: false,
-      errorMessage: 'error message',
-      isServerError: true,
-    })
+  it('should check error page show when isReportError is true', () => {
+    reportHook.current.isServerError = true
+    reportHook.current.errorMessage = 'error message'
 
-    await setup([REQUIRED_DATA_LIST[1]])
+    setup([REQUIRED_DATA_LIST[1]])
 
-    await waitFor(() => {
-      expect(navigateMock).toHaveBeenCalledWith(ERROR_PAGE_ROUTE)
-    })
+    expect(navigateMock).toHaveBeenCalledWith(ERROR_PAGE_ROUTE)
   })
 
-  it('should render loading page when isLoading is true', async () => {
-    mocked(useGenerateReportEffect).mockReturnValue({
-      generateReport: jest.fn(),
-      isLoading: true,
-      errorMessage: '',
-      isServerError: false,
-    })
+  it('should render loading page when isLoading is true', () => {
+    reportHook.current.isLoading = true
 
-    const { getByTestId } = await act(() => setup(['']))
+    const { getByTestId } = setup([''])
 
-    await waitFor(() => {
-      expect(getByTestId('loading-page')).toBeInTheDocument()
-    })
+    expect(getByTestId('loading-page')).toBeInTheDocument()
   })
 
-  it('should call resetProps and updateProps when remaining time is less than or equal to 5 minutes', async () => {
+  it('should call resetProps and updateProps when remaining time is less than or equal to 5 minutes', () => {
     const initExportValidityTimeMin = 30
     React.useState = jest.fn().mockReturnValue([
       initExportValidityTimeMin,
@@ -262,10 +239,10 @@ describe('Report Step', () => {
     ])
     const resetProps = jest.fn()
     const updateProps = jest.fn()
-    result.current.resetProps = resetProps
-    result.current.updateProps = updateProps
+    notificationHook.current.resetProps = resetProps
+    notificationHook.current.updateProps = updateProps
     jest.useFakeTimers()
-    await setup([''])
+    setup([''])
 
     expect(resetProps).not.toBeCalled()
     expect(updateProps).not.toBeCalledWith({
@@ -288,5 +265,35 @@ describe('Report Step', () => {
     })
 
     jest.useRealTimers()
+  })
+
+  it('should call fetchExportData when clicking "Export metric data"', async () => {
+    const { result } = renderHook(() => useExportCsvEffect())
+    const { getByText } = setup([''])
+
+    const exportButton = getByText(EXPORT_METRIC_DATA)
+    expect(exportButton).toBeInTheDocument()
+    await userEvent.click(exportButton)
+    expect(result.current.fetchExportData).toBeCalled()
+  })
+
+  it('should call fetchExportData when clicking "Export board data"', async () => {
+    const { result } = renderHook(() => useExportCsvEffect())
+    const { getByText } = setup([REQUIRED_DATA_LIST[2]])
+
+    const exportButton = getByText(EXPORT_BOARD_DATA)
+    expect(exportButton).toBeInTheDocument()
+    await userEvent.click(exportButton)
+    expect(result.current.fetchExportData).toBeCalled()
+  })
+
+  it('should call fetchExportData when clicking "Export pipeline data"', async () => {
+    const { result } = renderHook(() => useExportCsvEffect())
+    const { getByText } = setup([REQUIRED_DATA_LIST[6]])
+
+    const exportButton = getByText(EXPORT_PIPELINE_DATA)
+    expect(exportButton).toBeInTheDocument()
+    await userEvent.click(exportButton)
+    expect(result.current.fetchExportData).toBeCalled()
   })
 })

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -441,6 +441,12 @@ export const MOCK_REPORT_RESPONSE = {
   ],
   exportValidityTime: 1800000,
 }
+
+export const MOCK_RETRIEVE_REPORT_RESPONSE = {
+  callbackUrl: 'reports/123',
+  interval: 10,
+}
+
 export const EXPECTED_REPORT_VALUES = {
   velocityList: [
     { id: 0, name: 'Velocity(Story Point)', valueList: [{ value: 20 }] },

--- a/frontend/__tests__/src/hooks/useGenerateReportEffect.test.tsx
+++ b/frontend/__tests__/src/hooks/useGenerateReportEffect.test.tsx
@@ -1,95 +1,171 @@
-import { act, renderHook, waitFor } from '@testing-library/react'
-import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
+import { renderHook, waitFor } from '@testing-library/react'
 import { useGenerateReportEffect } from '@src/hooks/useGenerateReportEffect'
-import { INTERNAL_SERVER_ERROR_MESSAGE, MOCK_GENERATE_REPORT_REQUEST_PARAMS, MOCK_REPORT_RESPONSE } from '../fixtures'
+import {
+  ERROR_MESSAGE_TIME_DURATION,
+  INTERNAL_SERVER_ERROR_MESSAGE,
+  MOCK_GENERATE_REPORT_REQUEST_PARAMS,
+  MOCK_REPORT_RESPONSE,
+  MOCK_RETRIEVE_REPORT_RESPONSE,
+} from '../fixtures'
 import { reportClient } from '@src/clients/report/ReportClient'
 import { reportMapper } from '@src/hooks/reportMapper/report'
 import { NotFoundException } from '@src/exceptions/NotFoundException'
 import { UnknownException } from '@src/exceptions/UnkonwException'
 import { InternalServerException } from '@src/exceptions/InternalServerException'
+import { HttpStatusCode } from 'axios'
+import clearAllMocks = jest.clearAllMocks
 
 jest.mock('@src/hooks/reportMapper/report', () => ({
   reportMapper: jest.fn(),
 }))
-
+jest.useFakeTimers()
 describe('use generate report effect', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
+  afterAll(() => {
+    clearAllMocks()
   })
 
-  it('should init data state when render hook', async () => {
+  it('should init data state when render hook', () => {
     const { result } = renderHook(() => useGenerateReportEffect())
-
     expect(result.current.isLoading).toEqual(false)
   })
+
   it('should set error message when generate report throw error', async () => {
-    jest.useFakeTimers()
-    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
+    const { result } = renderHook(() => useGenerateReportEffect())
+    const setTimeout = jest.spyOn(global, 'setTimeout')
+    reportClient.retrieveReport = jest.fn().mockImplementation(async () => {
       throw new Error('error')
     })
-    const { result } = renderHook(() => useGenerateReportEffect())
-
-    expect(result.current.isLoading).toEqual(false)
-
-    act(() => {
+    await waitFor(() => {
       result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
-      jest.advanceTimersByTime(ERROR_MESSAGE_TIME_DURATION)
+      expect(result.current.errorMessage).toEqual('generate report: error')
     })
 
-    expect(result.current.errorMessage).toEqual('')
+    jest.advanceTimersByTime(ERROR_MESSAGE_TIME_DURATION)
+
+    await waitFor(() => {
+      expect(setTimeout).toBeCalled()
+      expect(result.current.errorMessage).toEqual('')
+    })
   })
 
   it('should set error message when generate report response status 404', async () => {
-    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
+    const { result } = renderHook(() => useGenerateReportEffect())
+    const setTimeout = jest.spyOn(global, 'setTimeout')
+    reportClient.retrieveReport = jest.fn().mockImplementation(async () => {
       throw new NotFoundException('error message')
     })
-    const { result } = renderHook(() => useGenerateReportEffect())
-
-    act(() => {
+    await waitFor(() => {
       result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(result.current.errorMessage).toEqual('generate report: error message')
     })
 
-    await waitFor(() => expect(result.current.errorMessage).toEqual('generate report: error message'))
+    jest.advanceTimersByTime(ERROR_MESSAGE_TIME_DURATION)
+
+    await waitFor(() => {
+      expect(setTimeout).toBeCalled()
+      expect(result.current.errorMessage).toEqual('')
+    })
   })
 
   it('should call reportMapper method when generate report response status 200', async () => {
-    reportClient.retrieveReport = jest.fn().mockReturnValue(MOCK_REPORT_RESPONSE)
-
     const { result } = renderHook(() => useGenerateReportEffect())
+    reportClient.retrieveReport = jest
+      .fn()
+      .mockImplementation(async () => ({ response: MOCK_RETRIEVE_REPORT_RESPONSE }))
+    reportClient.pollingReport = jest.fn().mockImplementation(async () => ({
+      status: HttpStatusCode.Created,
+      response: MOCK_REPORT_RESPONSE,
+    }))
 
-    act(() => {
+    await waitFor(() => {
       result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     })
 
-    await waitFor(() => {
-      expect(reportMapper).toHaveBeenCalledTimes(1)
-    })
+    expect(reportMapper).toHaveBeenCalledTimes(1)
   })
 
   it('should set error message when generate report response status 500', async () => {
-    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
+    const { result } = renderHook(() => useGenerateReportEffect())
+    reportClient.retrieveReport = jest.fn().mockImplementation(async () => {
       throw new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE)
     })
-    const { result } = renderHook(() => useGenerateReportEffect())
-
-    act(() => {
+    await waitFor(() => {
       result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(result.current.isServerError).toEqual(true)
     })
-
-    await waitFor(() => expect(result.current.isServerError).toEqual(true))
   })
 
   it('should set isServerError is true when throw unknownException', async () => {
-    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
+    const { result } = renderHook(() => useGenerateReportEffect())
+    reportClient.retrieveReport = jest.fn().mockImplementation(async () => {
       throw new UnknownException()
     })
 
-    const { result } = renderHook(() => useGenerateReportEffect())
-
-    act(() => {
+    await waitFor(() => {
       result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(result.current.isServerError).toEqual(true)
+    })
+  })
+
+  it('should call polling report and setTimeout when calling startPollingReports given pollingReport response return 204 ', async () => {
+    const setTimeout = jest.spyOn(global, 'setTimeout')
+    const { result } = renderHook(() => useGenerateReportEffect())
+    reportClient.pollingReport = jest
+      .fn()
+      .mockImplementation(async () => ({ status: HttpStatusCode.NoContent, response: MOCK_REPORT_RESPONSE }))
+
+    reportClient.retrieveReport = jest
+      .fn()
+      .mockImplementation(async () => ({ response: MOCK_RETRIEVE_REPORT_RESPONSE }))
+
+    await waitFor(() => {
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(reportClient.pollingReport).toBeCalled()
+      expect(setTimeout).toBeCalled()
     })
 
-    await waitFor(() => expect(result.current.isServerError).toEqual(true))
+    jest.runOnlyPendingTimers()
+    expect(reportClient.pollingReport).toBeCalled()
+  })
+
+  it('should return error message when calling startPollingReports given pollingReport response return 5xx ', async () => {
+    const { result } = renderHook(() => useGenerateReportEffect())
+    reportClient.pollingReport = jest.fn().mockImplementation(async () => {
+      throw new InternalServerException('error')
+    })
+
+    reportClient.retrieveReport = jest
+      .fn()
+      .mockImplementation(async () => ({ response: MOCK_RETRIEVE_REPORT_RESPONSE }))
+
+    await waitFor(() => {
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(reportClient.pollingReport).toBeCalled()
+      expect(result.current.isServerError).toEqual(true)
+    })
+  })
+
+  it('should return error message when calling startPollingReports given pollingReport response return 4xx ', async () => {
+    const setTimeout = jest.spyOn(global, 'setTimeout')
+    const { result } = renderHook(() => useGenerateReportEffect())
+    result.current.stopPollingReports = jest.fn()
+    reportClient.pollingReport = jest.fn().mockImplementation(async () => {
+      throw new NotFoundException('file not found')
+    })
+    reportClient.retrieveReport = jest
+      .fn()
+      .mockImplementation(async () => ({ response: MOCK_RETRIEVE_REPORT_RESPONSE }))
+
+    await waitFor(() => {
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      expect(result.current.errorMessage).toEqual('generate report: file not found')
+    })
+
+    jest.advanceTimersByTime(ERROR_MESSAGE_TIME_DURATION)
+
+    await waitFor(() => {
+      expect(setTimeout).toBeCalled()
+      expect(result.current.errorMessage).toEqual('')
+    })
   })
 })

--- a/frontend/__tests__/src/hooks/useGenerateReportEffect.test.tsx
+++ b/frontend/__tests__/src/hooks/useGenerateReportEffect.test.tsx
@@ -24,7 +24,7 @@ describe('use generate report effect', () => {
   })
   it('should set error message when generate report throw error', async () => {
     jest.useFakeTimers()
-    reportClient.report = jest.fn().mockImplementation(() => {
+    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
       throw new Error('error')
     })
     const { result } = renderHook(() => useGenerateReportEffect())
@@ -32,7 +32,7 @@ describe('use generate report effect', () => {
     expect(result.current.isLoading).toEqual(false)
 
     act(() => {
-      result.current.generateReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
       jest.advanceTimersByTime(ERROR_MESSAGE_TIME_DURATION)
     })
 
@@ -40,25 +40,25 @@ describe('use generate report effect', () => {
   })
 
   it('should set error message when generate report response status 404', async () => {
-    reportClient.report = jest.fn().mockImplementation(() => {
+    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
       throw new NotFoundException('error message')
     })
     const { result } = renderHook(() => useGenerateReportEffect())
 
     act(() => {
-      result.current.generateReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     })
 
     await waitFor(() => expect(result.current.errorMessage).toEqual('generate report: error message'))
   })
 
   it('should call reportMapper method when generate report response status 200', async () => {
-    reportClient.report = jest.fn().mockReturnValue(MOCK_REPORT_RESPONSE)
+    reportClient.retrieveReport = jest.fn().mockReturnValue(MOCK_REPORT_RESPONSE)
 
     const { result } = renderHook(() => useGenerateReportEffect())
 
     act(() => {
-      result.current.generateReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     })
 
     await waitFor(() => {
@@ -67,27 +67,27 @@ describe('use generate report effect', () => {
   })
 
   it('should set error message when generate report response status 500', async () => {
-    reportClient.report = jest.fn().mockImplementation(() => {
+    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
       throw new InternalServerException(INTERNAL_SERVER_ERROR_MESSAGE)
     })
     const { result } = renderHook(() => useGenerateReportEffect())
 
     act(() => {
-      result.current.generateReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     })
 
     await waitFor(() => expect(result.current.isServerError).toEqual(true))
   })
 
   it('should set isServerError is true when throw unknownException', async () => {
-    reportClient.report = jest.fn().mockImplementation(() => {
+    reportClient.retrieveReport = jest.fn().mockImplementation(() => {
       throw new UnknownException()
     })
 
     const { result } = renderHook(() => useGenerateReportEffect())
 
     act(() => {
-      result.current.generateReport(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
+      result.current.startPollingReports(MOCK_GENERATE_REPORT_REQUEST_PARAMS)
     })
 
     await waitFor(() => expect(result.current.isServerError).toEqual(true))

--- a/frontend/src/clients/report/ReportClient.ts
+++ b/frontend/src/clients/report/ReportClient.ts
@@ -1,8 +1,15 @@
 import { HttpClient } from '@src/clients/Httpclient'
 import { ReportRequestDTO } from '@src/clients/report/dto/request'
+import { ReportCallbackResponse } from '@src/clients/report/dto/response'
 
 export class ReportClient extends HttpClient {
+  reportCallbackResponse: ReportCallbackResponse = {
+    status: 0,
+    callbackURL: '',
+    interval: 0,
+  }
   reportResponse = {
+    status: 0,
     velocity: {
       velocityForSP: 0,
       velocityForCards: 0,
@@ -53,9 +60,23 @@ export class ReportClient extends HttpClient {
     },
   }
 
-  report = async (params: ReportRequestDTO) => {
+  retrieveReport = async (params: ReportRequestDTO) => {
     await this.axiosInstance
       .post(`/reports`, params, {})
+      .then((res) => {
+        this.reportCallbackResponse = res.data
+      })
+      .catch((e) => {
+        throw e
+      })
+    return {
+      response: this.reportCallbackResponse,
+    }
+  }
+
+  pollingReport = async (url: string) => {
+    await this.axiosInstance
+      .get(url)
       .then((res) => {
         this.reportResponse = res.data
       })

--- a/frontend/src/clients/report/ReportClient.ts
+++ b/frontend/src/clients/report/ReportClient.ts
@@ -3,13 +3,12 @@ import { ReportRequestDTO } from '@src/clients/report/dto/request'
 import { ReportCallbackResponse } from '@src/clients/report/dto/response'
 
 export class ReportClient extends HttpClient {
+  status = 0
   reportCallbackResponse: ReportCallbackResponse = {
-    status: 0,
-    callbackURL: '',
+    callbackUrl: '',
     interval: 0,
   }
   reportResponse = {
-    status: 0,
     velocity: {
       velocityForSP: 0,
       velocityForCards: 0,
@@ -78,12 +77,14 @@ export class ReportClient extends HttpClient {
     await this.axiosInstance
       .get(url)
       .then((res) => {
+        this.status = res.status
         this.reportResponse = res.data
       })
       .catch((e) => {
         throw e
       })
     return {
+      status: this.status,
       response: this.reportResponse,
     }
   }

--- a/frontend/src/clients/report/dto/response.ts
+++ b/frontend/src/clients/report/dto/response.ts
@@ -1,3 +1,5 @@
+import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
+
 export interface ReportResponseDTO {
   velocity?: VelocityResponse
   cycleTime?: CycleTimeResponse
@@ -117,4 +119,21 @@ export interface MeanTimeToRecoveryResponse {
 export interface ClassificationNameValuePair {
   name: string
   value: number
+}
+
+export interface ReportCallbackResponse {
+  status: number
+  callbackURL: string
+  interval: number
+}
+
+export interface ReportResponse {
+  velocityList?: ReportDataWithTwoColumns[]
+  cycleTimeList?: ReportDataWithTwoColumns[]
+  classification?: ReportDataWithThreeColumns[]
+  deploymentFrequencyList?: ReportDataWithThreeColumns[]
+  meanTimeToRecoveryList?: ReportDataWithThreeColumns[]
+  leadTimeForChangesList?: ReportDataWithThreeColumns[]
+  changeFailureRateList?: ReportDataWithThreeColumns[]
+  exportValidityTimeMin?: number
 }

--- a/frontend/src/clients/report/dto/response.ts
+++ b/frontend/src/clients/report/dto/response.ts
@@ -122,8 +122,7 @@ export interface ClassificationNameValuePair {
 }
 
 export interface ReportCallbackResponse {
-  status: number
-  callbackURL: string
+  callbackUrl: string
   interval: number
 }
 

--- a/frontend/src/components/Loading/index.tsx
+++ b/frontend/src/components/Loading/index.tsx
@@ -1,10 +1,11 @@
 import { CircularProgress } from '@mui/material'
-import { LoadingDrop } from './style'
+import { LoadingDrop, LoadingTypography } from './style'
 
-export const Loading = () => {
+export const Loading = ({ wording }: { wording: string }) => {
   return (
     <LoadingDrop open>
       <CircularProgress size='8rem' data-testid='loading-page' />
+      {wording && <LoadingTypography>wording</LoadingTypography>}
     </LoadingDrop>
   )
 }

--- a/frontend/src/components/Loading/index.tsx
+++ b/frontend/src/components/Loading/index.tsx
@@ -1,11 +1,15 @@
 import { CircularProgress } from '@mui/material'
 import { LoadingDrop, LoadingTypography } from './style'
 
-export const Loading = ({ wording }: { wording: string }) => {
+export interface LoadingProps {
+  message?: string
+}
+
+export const Loading = ({ message }: LoadingProps) => {
   return (
     <LoadingDrop open>
       <CircularProgress size='8rem' data-testid='loading-page' />
-      {wording && <LoadingTypography>wording</LoadingTypography>}
+      {message && <LoadingTypography>{message}</LoadingTypography>}
     </LoadingDrop>
   )
 }

--- a/frontend/src/components/Loading/style.tsx
+++ b/frontend/src/components/Loading/style.tsx
@@ -15,6 +15,7 @@ export const LoadingDrop = styled(Backdrop)({
 })
 
 export const LoadingTypography = styled(Typography)({
-  fontSize: '0.88rem',
-  marginTop: '1rem',
+  fontSize: '1rem',
+  marginTop: '2rem',
+  color: 'black',
 })

--- a/frontend/src/components/Loading/style.tsx
+++ b/frontend/src/components/Loading/style.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material/styles'
-import { Backdrop } from '@mui/material'
+import { Backdrop, Typography } from '@mui/material'
 import { theme } from '@src/theme'
 import { Z_INDEX } from '@src/constants'
 
@@ -8,4 +8,13 @@ export const LoadingDrop = styled(Backdrop)({
   zIndex: Z_INDEX.MODAL_BACKDROP,
   backgroundColor: 'rgba(199,199,199,0.43)',
   color: theme.main.backgroundColor,
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+})
+
+export const LoadingTypography = styled(Typography)({
+  fontSize: '0.88rem',
+  marginTop: '1rem',
 })

--- a/frontend/src/components/Loading/style.tsx
+++ b/frontend/src/components/Loading/style.tsx
@@ -17,5 +17,5 @@ export const LoadingDrop = styled(Backdrop)({
 export const LoadingTypography = styled(Typography)({
   fontSize: '1rem',
   marginTop: '2rem',
-  color: 'black',
+  color: theme.main.secondColor,
 })

--- a/frontend/src/components/Metrics/ReportStep/index.tsx
+++ b/frontend/src/components/Metrics/ReportStep/index.tsx
@@ -11,6 +11,7 @@ import {
   INIT_REPORT_DATA_WITH_TWO_COLUMNS,
   NAME,
   PIPELINE_STEP,
+  REPORT_LOADING_MESSAGE,
   REQUIRED_DATA,
 } from '@src/constants'
 import ReportForTwoColumns from '@src/components/Common/ReportForTwoColumns'
@@ -270,7 +271,7 @@ const ReportStep = ({ updateProps }: useNotificationLayoutEffectInterface) => {
   return (
     <>
       {isLoading ? (
-        <Loading />
+        <Loading message={REPORT_LOADING_MESSAGE} />
       ) : isServerError ? (
         navigate(ERROR_PAGE_ROUTE)
       ) : (

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -224,3 +224,6 @@ export const HEADER_NOTIFICATION_MESSAGE = {
   FIRST_REPORT: 'The file needs to be exported within %s minutes, otherwise it will expire.',
   EXPIRE_IN_FIVE_MINUTES: 'The file will expire in 5 minutes, please download it in time.',
 }
+
+export const REPORT_LOADING_MESSAGE =
+  'Report is being generated, please do not refresh the page otherwise all the data will be disappear.'

--- a/frontend/src/hooks/reportMapper/report.ts
+++ b/frontend/src/hooks/reportMapper/report.ts
@@ -6,7 +6,6 @@ import { classificationMapper } from '@src/hooks/reportMapper/classification'
 import { deploymentFrequencyMapper } from '@src/hooks/reportMapper/deploymentFrequency'
 import { leadTimeForChangesMapper } from '@src/hooks/reportMapper/leadTimeForChanges'
 import { meanTimeToRecoveryMapper } from '@src/hooks/reportMapper/meanTimeToRecovery'
-import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
 import { exportValidityTimeMapper } from '@src/hooks/reportMapper/exportValidityTime'
 
 export const reportMapper = ({

--- a/frontend/src/hooks/reportMapper/report.ts
+++ b/frontend/src/hooks/reportMapper/report.ts
@@ -1,4 +1,4 @@
-import { ReportResponseDTO } from '@src/clients/report/dto/response'
+import { ReportResponse, ReportResponseDTO } from '@src/clients/report/dto/response'
 import { changeFailureRateMapper } from '@src/hooks/reportMapper/changeFailureRate'
 import { velocityMapper } from '@src/hooks/reportMapper/velocity'
 import { cycleTimeMapper } from '@src/hooks/reportMapper/cycleTime'
@@ -18,16 +18,7 @@ export const reportMapper = ({
   leadTimeForChanges,
   changeFailureRate,
   exportValidityTime,
-}: ReportResponseDTO): {
-  velocityList?: ReportDataWithTwoColumns[]
-  cycleTimeList?: ReportDataWithTwoColumns[]
-  classification?: ReportDataWithThreeColumns[]
-  deploymentFrequencyList?: ReportDataWithThreeColumns[]
-  meanTimeToRecoveryList?: ReportDataWithThreeColumns[]
-  leadTimeForChangesList?: ReportDataWithThreeColumns[]
-  changeFailureRateList?: ReportDataWithThreeColumns[]
-  exportValidityTimeMin?: number
-} => {
+}: ReportResponseDTO): ReportResponse => {
   const velocityList = velocity && velocityMapper(velocity)
 
   const cycleTimeList = cycleTime && cycleTimeMapper(cycleTime)

--- a/frontend/src/hooks/useGenerateReportEffect.ts
+++ b/frontend/src/hooks/useGenerateReportEffect.ts
@@ -2,7 +2,6 @@ import { useRef, useState } from 'react'
 import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
 import { reportClient } from '@src/clients/report/ReportClient'
 import { ReportRequestDTO } from '@src/clients/report/dto/request'
-import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
 import { UnknownException } from '@src/exceptions/UnkonwException'
 import { InternalServerException } from '@src/exceptions/InternalServerException'
 import { HttpStatusCode } from 'axios'
@@ -29,7 +28,7 @@ export const useGenerateReportEffect = (): useGenerateReportEffectInterface => {
     setIsLoading(true)
     reportClient
       .retrieveReport(params)
-      .then((res) => pollingReport(res.response.callbackURL, res.response.interval))
+      .then((res) => pollingReport(res.response.callbackUrl, res.response.interval))
       .catch((e) => {
         const err = e as Error
         if (err instanceof InternalServerException || err instanceof UnknownException) {
@@ -48,7 +47,7 @@ export const useGenerateReportEffect = (): useGenerateReportEffectInterface => {
     reportClient
       .pollingReport(url)
       .then((res) => {
-        if (res.response.status === HttpStatusCode.Created) {
+        if (res.status === HttpStatusCode.Created) {
           stopPollingReports()
           setReports(reportMapper(res.response))
         } else {

--- a/frontend/src/hooks/useGenerateReportEffect.ts
+++ b/frontend/src/hooks/useGenerateReportEffect.ts
@@ -1,56 +1,83 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { ERROR_MESSAGE_TIME_DURATION } from '@src/constants'
 import { reportClient } from '@src/clients/report/ReportClient'
 import { ReportRequestDTO } from '@src/clients/report/dto/request'
-import { reportMapper } from '@src/hooks/reportMapper/report'
 import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure'
 import { UnknownException } from '@src/exceptions/UnkonwException'
 import { InternalServerException } from '@src/exceptions/InternalServerException'
+import { HttpStatusCode } from 'axios'
+import { reportMapper } from '@src/hooks/reportMapper/report'
+import { ReportResponse } from '@src/clients/report/dto/response'
 
 export interface useGenerateReportEffectInterface {
-  generateReport: (params: ReportRequestDTO) => Promise<
-    | {
-        velocityList?: ReportDataWithTwoColumns[]
-        cycleTimeList?: ReportDataWithTwoColumns[]
-        classification?: ReportDataWithThreeColumns[]
-        deploymentFrequencyList?: ReportDataWithThreeColumns[]
-        leadTimeForChangesList?: ReportDataWithThreeColumns[]
-        changeFailureRateList?: ReportDataWithThreeColumns[]
-      }
-    | undefined
-  >
+  startPollingReports: (params: ReportRequestDTO) => void
+  stopPollingReports: () => void
   isLoading: boolean
   isServerError: boolean
   errorMessage: string
+  reports: ReportResponse | undefined
 }
 
 export const useGenerateReportEffect = (): useGenerateReportEffectInterface => {
   const [isLoading, setIsLoading] = useState(false)
   const [isServerError, setIsServerError] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
+  const [reports, setReports] = useState<ReportResponse>()
+  const timerIdRef = useRef<NodeJS.Timer>()
 
-  const generateReport = async (params: ReportRequestDTO) => {
+  const startPollingReports = (params: ReportRequestDTO) => {
     setIsLoading(true)
-    try {
-      const res = await reportClient.report(params)
-      return reportMapper(res.response)
-    } catch (e) {
-      const err = e as Error
-      if (err instanceof InternalServerException || err instanceof UnknownException) {
-        setIsServerError(true)
-      } else {
-        setErrorMessage(`generate report: ${err.message}`)
-        setTimeout(() => {
-          setErrorMessage('')
-        }, ERROR_MESSAGE_TIME_DURATION)
-      }
-    } finally {
-      setIsLoading(false)
-    }
+    reportClient
+      .retrieveReport(params)
+      .then((res) => pollingReport(res.response.callbackURL, res.response.interval))
+      .catch((e) => {
+        const err = e as Error
+        if (err instanceof InternalServerException || err instanceof UnknownException) {
+          setIsServerError(true)
+        } else {
+          setErrorMessage(`generate report: ${err.message}`)
+          setTimeout(() => {
+            setErrorMessage('')
+          }, ERROR_MESSAGE_TIME_DURATION)
+        }
+        stopPollingReports()
+      })
+  }
+
+  const pollingReport = (url: string, interval: number) => {
+    reportClient
+      .pollingReport(url)
+      .then((res) => {
+        if (res.response.status === HttpStatusCode.Created) {
+          stopPollingReports()
+          setReports(reportMapper(res.response))
+        } else {
+          timerIdRef.current = setTimeout(() => pollingReport(url, interval), interval * 1000)
+        }
+      })
+      .catch((e) => {
+        const err = e as Error
+        if (err instanceof InternalServerException || err instanceof UnknownException) {
+          setIsServerError(true)
+        } else {
+          setErrorMessage(`generate report: ${err.message}`)
+          setTimeout(() => {
+            setErrorMessage('')
+          }, ERROR_MESSAGE_TIME_DURATION)
+        }
+        stopPollingReports()
+      })
+  }
+
+  const stopPollingReports = () => {
+    setIsLoading(false)
+    clearInterval(timerIdRef.current)
   }
 
   return {
-    generateReport,
+    startPollingReports,
+    stopPollingReports,
+    reports,
     isLoading,
     isServerError,
     errorMessage,


### PR DESCRIPTION
## Summary

[Frontend] Keep polling from generate report callback to fetch the result

## Before

_Description_

**Screenshots**
<img width="1505" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/150229041/2f1f0ca5-1458-44a4-a69b-fbafa530cbf0">


## After

_Description_

**Screenshots**
![image](https://github.com/au-heartbeat/Heartbeat/assets/150229041/ffe70fba-abc4-4da7-967f-4acbe094efc9)


## Note

_Null_
