### PR TITLE
[frontend] ADM-646: enhance style for tooltip

### DIFF
--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/index.tsx
@@ -14,10 +14,11 @@ import { WarningNotification } from '@src/components/Common/WarningNotification'
 import { CYCLE_TIME_TOOLTIP, DONE } from '@src/constants'
 import {
   CycleTimeContainer,
+  StyledTooltip,
   TitleAndTooltipContainer,
   TooltipContainer,
 } from '@src/components/Metrics/MetricsStep/CycleTime/style'
-import { IconButton, Tooltip } from '@mui/material'
+import { IconButton } from '@mui/material'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
 interface cycleTimeProps {
@@ -66,11 +67,11 @@ export const CycleTime = ({ title }: cycleTimeProps) => {
       <TitleAndTooltipContainer>
         <MetricsSettingTitle title={title} />
         <TooltipContainer>
-          <Tooltip title={CYCLE_TIME_TOOLTIP}>
+          <StyledTooltip title={CYCLE_TIME_TOOLTIP}>
             <IconButton aria-label='info'>
               <InfoOutlinedIcon />
             </IconButton>
-          </Tooltip>
+          </StyledTooltip>
         </TooltipContainer>
       </TitleAndTooltipContainer>
       <CycleTimeContainer>

--- a/frontend/src/components/Metrics/MetricsStep/CycleTime/style.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/CycleTime/style.tsx
@@ -1,5 +1,5 @@
 import { styled } from '@mui/material/styles'
-import { Checkbox } from '@mui/material'
+import { Checkbox, Tooltip } from '@mui/material'
 import { PipelineMetricSelectionWrapper } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/style'
 
 export const FlagCardItem = styled('div')({
@@ -40,3 +40,10 @@ export const TitleAndTooltipContainer = styled('div')({
 export const TooltipContainer = styled('div')({
   marginLeft: '4px',
 })
+
+export const StyledTooltip = styled(({ className, ...props }: any) => (
+  <Tooltip placement='right-start' {...props} componentsProps={{ tooltip: { className: className } }} />
+))(`
+    max-width: 500px;
+    margin-top: 10px;
+`)


### PR DESCRIPTION
## Summary

enhance style for tooltip

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
before:
<img width="733" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/4066f757-8927-4536-ba7e-cdfbabaea00e">
after:
<img width="810" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/b9eb580f-af59-4f39-8ca3-d06170aed6e1">


## Note

_Null_
