### PR TITLE
Adm-649:[Backend][Frontend] Verify failed when return GitHub repos size empty

### DIFF
--- a/backend/src/main/java/heartbeat/exception/GithubRepoEmptyException.java
+++ b/backend/src/main/java/heartbeat/exception/GithubRepoEmptyException.java
@@ -1,0 +1,12 @@
+package heartbeat.exception;
+
+import lombok.Getter;
+
+@Getter
+public class GithubRepoEmptyException extends BaseException {
+
+	public GithubRepoEmptyException(String message) {
+		super(message, 400);
+	}
+
+}

--- a/backend/src/main/java/heartbeat/exception/RestResponseEntityExceptionHandler.java
+++ b/backend/src/main/java/heartbeat/exception/RestResponseEntityExceptionHandler.java
@@ -59,6 +59,13 @@ public class RestResponseEntityExceptionHandler {
 			.body(new RestApiErrorResponse(ex.getStatus(), ex.getMessage(), "Token is incorrect"));
 	}
 
+	@ExceptionHandler(value = GithubRepoEmptyException.class)
+	protected ResponseEntity<Object> handleGithubRepoEmptyException(GithubRepoEmptyException ex) {
+		return ResponseEntity.status(ex.getStatus())
+			.body(new RestApiErrorResponse(ex.getStatus(), ex.getMessage(),
+					"The GitHub repo size is 0, please recheck the token!"));
+	}
+
 	@ExceptionHandler(value = PermissionDenyException.class)
 	protected ResponseEntity<Object> handlePermissionDenyException(PermissionDenyException ex) {
 		return ResponseEntity.status(ex.getStatus())

--- a/backend/src/test/java/heartbeat/exception/RestResponseEntityExceptionHandlerTest.java
+++ b/backend/src/test/java/heartbeat/exception/RestResponseEntityExceptionHandlerTest.java
@@ -166,6 +166,19 @@ class RestResponseEntityExceptionHandlerTest {
 	}
 
 	@Test
+	public void shouldHandleGithubRepoEmptyException() {
+		GithubRepoEmptyException ex = new GithubRepoEmptyException("No GitHub repositories found.");
+
+		ResponseEntity<Object> response = restExceptionHandler.handleGithubRepoEmptyException(ex);
+
+		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+		assertNotNull(response.getBody());
+		assertTrue(response.getBody() instanceof RestApiErrorResponse);
+		RestApiErrorResponse errorResponse = (RestApiErrorResponse) response.getBody();
+		assertEquals("No GitHub repositories found.", errorResponse.getMessage());
+	}
+
+	@Test
 	public void shouldHandleFileIOException() {
 		FileIOException ex = new FileIOException(new IOException("File read failed"));
 

--- a/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
@@ -12,10 +12,7 @@ import heartbeat.client.dto.codebase.github.PipelineLeadTime;
 import heartbeat.client.dto.codebase.github.PullRequestInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
-import heartbeat.exception.InternalServerErrorException;
-import heartbeat.exception.NotFoundException;
-import heartbeat.exception.PermissionDenyException;
-import heartbeat.exception.UnauthorizedException;
+import heartbeat.exception.*;
 import heartbeat.service.source.github.model.PipelineInfoOfRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,10 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.HashMap;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 
 @ExtendWith(MockitoExtension.class)
@@ -202,6 +196,16 @@ class GithubServiceTest {
         assertThatThrownBy(() -> githubService.verifyToken("mockToken")).isInstanceOf(InternalServerErrorException.class)
                 .hasMessageContaining("UnExpected Exception");
     }
+
+	@Test
+	void shouldGithubReturnEmptyWhenVerifyGithubThrowGithubRepoEmptyException() {
+		String githubEmptyToken = "123456";
+		when(gitHubFeignClient.getReposByOrganizationName("org1", githubEmptyToken)).thenReturn(new ArrayList<>());
+
+		assertThatThrownBy(() -> githubService.verifyToken(githubEmptyToken))
+			.isInstanceOf(GithubRepoEmptyException.class)
+			.hasMessageContaining("No GitHub repositories found.");
+	}
 
 	@Test
 	void shouldReturnNullWhenMergeTimeIsNull() {

--- a/frontend/src/components/Metrics/ConfigStep/SourceControl/index.tsx
+++ b/frontend/src/components/Metrics/ConfigStep/SourceControl/index.tsx
@@ -125,6 +125,7 @@ export const SourceControl = () => {
       return field
     })
     setFields(newFieldsValue)
+    dispatch(updateSourceControlVerifyState(false))
   }
 
   return (


### PR DESCRIPTION
## Summary
fronted:
When the Source Control input receives Github tokens and is verified, the button should update to 'Verify' instead of 'Reset'. This logic is synchronized with the Board and Pipeline Tool.

backend:
After inputting Github tokens, if the server verifies the token and returns an empty Github repositories result, then an exception should be thrown.

## Before

_Description_

**Screenshots**
<img width="1640" alt="brefore" src="https://github.com/thoughtworks/HeartBeat/assets/60456779/e625f9ff-20fe-4c12-94aa-30e622bceadb">


## After

_Description_

**Screenshots**
<img width="1641" alt="after" src="https://github.com/thoughtworks/HeartBeat/assets/60456779/f41b4cda-3bd2-45ad-a4cc-87c5cbf0e5b2">

## Note

_Null_
