### PR TITLE
Adm-649:[Backend][Frontend] Verify failed when return GitHub repos size empty

### DIFF
--- a/backend/src/main/java/heartbeat/exception/GithubRepoEmptyException.java
+++ b/backend/src/main/java/heartbeat/exception/GithubRepoEmptyException.java
@@ -1,12 +1,13 @@
 package heartbeat.exception;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class GithubRepoEmptyException extends BaseException {
 
 	public GithubRepoEmptyException(String message) {
-		super(message, 400);
+		super(message, HttpStatus.BAD_REQUEST.value());
 	}
 
 }

--- a/backend/src/test/java/heartbeat/controller/report/GenerateReporterControllerTest.java
+++ b/backend/src/test/java/heartbeat/controller/report/GenerateReporterControllerTest.java
@@ -182,6 +182,7 @@ class GenerateReporterControllerTest {
 		assertEquals("/reports/" + currentTimeStamp, callbackUrl);
 		assertEquals("10", interval);
 
+		Thread.sleep(2000L);
 		verify(asyncExceptionHandler).put(currentTimeStamp, requestFailedException);
 	}
 

--- a/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
@@ -12,7 +12,11 @@ import heartbeat.client.dto.codebase.github.PipelineLeadTime;
 import heartbeat.client.dto.codebase.github.PullRequestInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
-import heartbeat.exception.*;
+import heartbeat.exception.GithubRepoEmptyException;
+import heartbeat.exception.InternalServerErrorException;
+import heartbeat.exception.NotFoundException;
+import heartbeat.exception.PermissionDenyException;
+import heartbeat.exception.UnauthorizedException;
 import heartbeat.service.source.github.model.PipelineInfoOfRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,7 +37,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
 
 @ExtendWith(MockitoExtension.class)


### PR DESCRIPTION
## Summary
fronted:
When the Source Control input receives Github tokens and is verified, the button should update to 'Verify' instead of 'Reset'. This logic is synchronized with the Board and Pipeline Tool.

backend:
After inputting Github tokens, if the server verifies the token and returns an empty Github repositories result, then an exception should be thrown.

## Before

_Description_

**Screenshots**
<img width="1640" alt="brefore" src="https://github.com/thoughtworks/HeartBeat/assets/60456779/e625f9ff-20fe-4c12-94aa-30e622bceadb">


## After

_Description_

**Screenshots**
<img width="1641" alt="after" src="https://github.com/thoughtworks/HeartBeat/assets/60456779/f41b4cda-3bd2-45ad-a4cc-87c5cbf0e5b2">

## Note

_Null_
