### PR TITLE
ADM-674:[backend] Remove uncontrolled executor and refine testing.

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,7 +38,7 @@ cd HearBeat/backend
 ## 4. Run the e2e environment
 ```shell script
 cd HearBeat/backend
-./gradlew bootRun --args='--spring.profiles.active=e2e'
+./gradlew bootRun --args='--spring.profiles.active=local --MOCK_SERVER_URL=http://localhost:4323'
 ```
 
 ## 5. How to run the local environment

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -116,14 +116,13 @@ public class JiraService {
 
 			return getJiraColumnsAsync(boardRequestParam, baseUrl,
 					getJiraBoardConfig(baseUrl, boardRequestParam.getBoardId(), boardRequestParam.getToken()))
-				.thenCombine(
-					getUserAsync(boardType, baseUrl, boardRequestParam),
-					(jiraColumnResult, users) -> BoardConfigDTO.builder()
-						.targetFields(neededTargetFields)
-						.jiraColumnResponse(jiraColumnResult.getJiraColumnResponse())
-						.ignoredTargetFields(ignoredTargetFields)
-						.users(users)
-						.build())
+				.thenCombine(getUserAsync(boardType, baseUrl, boardRequestParam),
+						(jiraColumnResult, users) -> BoardConfigDTO.builder()
+							.targetFields(neededTargetFields)
+							.jiraColumnResponse(jiraColumnResult.getJiraColumnResponse())
+							.ignoredTargetFields(ignoredTargetFields)
+							.users(users)
+							.build())
 				.join();
 		}
 		catch (RuntimeException e) {

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -107,29 +107,23 @@ public class JiraService {
 	public BoardConfigDTO getJiraConfiguration(BoardType boardType, BoardRequestParam boardRequestParam) {
 		URI baseUrl = urlGenerator.getUri(boardRequestParam.getSite());
 		try {
-			JiraBoardConfigDTO jiraBoardConfigDTO = getJiraBoardConfig(baseUrl, boardRequestParam.getBoardId(),
-					boardRequestParam.getToken());
-			CompletableFuture<JiraColumnResult> jiraColumnsFuture = getJiraColumnsAsync(boardRequestParam, baseUrl,
-					jiraBoardConfigDTO);
-			CompletableFuture<List<TargetField>> targetFieldFuture = getTargetFieldAsync(baseUrl, boardRequestParam);
-			List<TargetField> ignoredTargetFields = targetFieldFuture.join()
-				.stream()
-				.filter(this::isIgnoredTargetField)
-				.toList();
-			List<TargetField> neededTargetFields = targetFieldFuture.join()
-				.stream()
-				.filter(targetField -> !isIgnoredTargetField(targetField))
-				.toList();
 
-			return jiraColumnsFuture.thenCombine(targetFieldFuture,
-					(jiraColumnResult, targetFields) -> getUserAsync(boardType, baseUrl, boardRequestParam)
-						.thenApply(users -> BoardConfigDTO.builder()
-							.targetFields(neededTargetFields)
-							.jiraColumnResponse(jiraColumnResult.getJiraColumnResponse())
-							.ignoredTargetFields(ignoredTargetFields)
-							.users(users)
-							.build())
-						.join())
+			Map<Boolean, List<TargetField>> partitions = getTargetFieldAsync(baseUrl, boardRequestParam).join()
+				.stream()
+				.collect(Collectors.partitioningBy(this::isIgnoredTargetField));
+			List<TargetField> ignoredTargetFields = partitions.get(true);
+			List<TargetField> neededTargetFields = partitions.get(false);
+
+			return getJiraColumnsAsync(boardRequestParam, baseUrl,
+					getJiraBoardConfig(baseUrl, boardRequestParam.getBoardId(), boardRequestParam.getToken()))
+				.thenCombine(
+					getUserAsync(boardType, baseUrl, boardRequestParam),
+					(jiraColumnResult, users) -> BoardConfigDTO.builder()
+						.targetFields(neededTargetFields)
+						.jiraColumnResponse(jiraColumnResult.getJiraColumnResponse())
+						.ignoredTargetFields(ignoredTargetFields)
+						.users(users)
+						.build())
 				.join();
 		}
 		catch (RuntimeException e) {
@@ -183,8 +177,7 @@ public class JiraService {
 
 	private CompletableFuture<JiraColumnResult> getJiraColumnsAsync(BoardRequestParam boardRequestParam, URI baseUrl,
 			JiraBoardConfigDTO jiraBoardConfigDTO) {
-		return CompletableFuture.supplyAsync(() -> getJiraColumns(boardRequestParam, baseUrl, jiraBoardConfigDTO),
-				customTaskExecutor);
+		return CompletableFuture.supplyAsync(() -> getJiraColumns(boardRequestParam, baseUrl, jiraBoardConfigDTO));
 	}
 
 	public JiraColumnResult getJiraColumns(BoardRequestParam boardRequestParam, URI baseUrl,
@@ -197,8 +190,7 @@ public class JiraService {
 			.getColumns()
 			.stream()
 			.map(jiraColumn -> CompletableFuture.supplyAsync(
-					() -> getColumnNameAndStatus(jiraColumn, baseUrl, jiraColumns, boardRequestParam.getToken()),
-					customTaskExecutor))
+					() -> getColumnNameAndStatus(jiraColumn, baseUrl, jiraColumns, boardRequestParam.getToken())))
 			.toList();
 
 		List<JiraColumnDTO> columnResponse = futures.stream().map(CompletableFuture::join).toList();
@@ -271,7 +263,7 @@ public class JiraService {
 
 	private CompletableFuture<List<String>> getUserAsync(BoardType boardType, URI baseUrl,
 			BoardRequestParam boardRequestParam) {
-		return CompletableFuture.supplyAsync(() -> getUsers(boardType, baseUrl, boardRequestParam), customTaskExecutor);
+		return CompletableFuture.supplyAsync(() -> getUsers(boardType, baseUrl, boardRequestParam));
 	}
 
 	private List<String> getUsers(BoardType boardType, URI baseUrl, BoardRequestParam boardRequestParam) {
@@ -280,7 +272,6 @@ public class JiraService {
 		if (allCards.isEmpty()) {
 			throw new NoContentException("There is no cards.");
 		}
-
 		List<CompletableFuture<List<String>>> futures = allCards.stream()
 			.map(jiraCard -> CompletableFuture
 				.supplyAsync(() -> getAssigneeSet(baseUrl, jiraCard, boardRequestParam.getToken()), customTaskExecutor))
@@ -467,16 +458,16 @@ public class JiraService {
 		CardCustomFieldKey cardCustomFieldKey = covertCustomFieldKey(targetFields);
 		String keyFlagged = cardCustomFieldKey.getFlagged();
 		List<JiraCardDTO> realDoneCards = new ArrayList<>();
-		List<JiraCard> futures = new ArrayList<>();
+		List<JiraCard> jiraCards = new ArrayList<>();
 
 		for (JiraCard allDoneCard : allDoneCards) {
 			CardHistoryResponseDTO jiraCardHistory = jiraFeignClient.getJiraCardHistory(baseUrl, allDoneCard.getKey(),
 					request.getToken());
 			if (isRealDoneCardByHistory(jiraCardHistory, request)) {
-				futures.add(allDoneCard);
+				jiraCards.add(allDoneCard);
 			}
 		}
-		futures.forEach(doneCard -> {
+		jiraCards.forEach(doneCard -> {
 			CycleTimeInfoDTO cycleTimeInfoDTO = getCycleTime(baseUrl, doneCard.getKey(), request.getToken(),
 					request.isTreatFlagCardAsBlock(), keyFlagged, request.getStatus());
 			List<String> assigneeSet = getAssigneeSet(request, baseUrl, filterMethod, doneCard);

--- a/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
@@ -491,7 +491,8 @@ class JiraServiceTest {
 	void shouldThrowCustomExceptionWhenCallJiraFeignClientToGetBoardConfigFailed() {
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-		when(jiraFeignClient.getJiraBoardConfiguration(any(), any(), any())).thenThrow(new CustomFeignClientException(400, "exception"));
+		when(jiraFeignClient.getJiraBoardConfiguration(any(), any(), any()))
+			.thenThrow(new CustomFeignClientException(400, "exception"));
 		when(jiraFeignClient.getTargetField(baseUrl, "project key", "token"))
 			.thenReturn(FIELD_RESPONSE_BUILDER().build());
 		assertThatThrownBy(() -> jiraService.getJiraConfiguration(boardTypeJira, BoardRequestParam.builder().build()))

--- a/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraServiceTest.java
@@ -391,11 +391,13 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowExceptionWhenGetJiraConfigurationThrowsUnExpectedException() {
+		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
 		when(jiraFeignClient.getJiraBoardConfiguration(any(URI.class), any(), any()))
 			.thenThrow(new CompletionException(new Exception("UnExpected Exception")));
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-
+		when(jiraFeignClient.getTargetField(baseUrl, "project key", "token"))
+			.thenReturn(FIELD_RESPONSE_BUILDER().build());
 		assertThatThrownBy(() -> jiraService.getJiraConfiguration(boardTypeJira, boardRequestParam))
 			.isInstanceOf(InternalServerErrorException.class)
 			.hasMessageContaining("UnExpected Exception");
@@ -431,15 +433,11 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowExceptionWhenGetTargetFieldFailed() {
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
-		StatusSelfDTO doneStatusSelf = DONE_STATUS_SELF_RESPONSE_BUILDER().build();
-		StatusSelfDTO doingStatusSelf = DOING_STATUS_SELF_RESPONSE_BUILDER().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		String token = "token";
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
 
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-		when(jiraFeignClient.getJiraBoardConfiguration(baseUrl, BOARD_ID, token)).thenReturn(jiraBoardConfigDTO);
 		when(jiraFeignClient.getTargetField(baseUrl, boardRequestParam.getProjectKey(), token))
 			.thenThrow(new CustomFeignClientException(500, "exception"));
 
@@ -450,15 +448,11 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowExceptionWhenGetTargetFieldReturnNull() {
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
-		StatusSelfDTO doneStatusSelf = DONE_STATUS_SELF_RESPONSE_BUILDER().build();
-		StatusSelfDTO doingStatusSelf = DOING_STATUS_SELF_RESPONSE_BUILDER().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		String token = "token";
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
 
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-		when(jiraFeignClient.getJiraBoardConfiguration(baseUrl, BOARD_ID, token)).thenReturn(jiraBoardConfigDTO);
 		when(jiraFeignClient.getTargetField(baseUrl, boardRequestParam.getProjectKey(), token)).thenReturn(null);
 
 		assertThatThrownBy(() -> jiraService.getJiraConfiguration(boardTypeJira, BOARD_REQUEST_BUILDER().build()))
@@ -468,9 +462,6 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowExceptionWhenGetTargetFieldReturnEmpty() {
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
-		StatusSelfDTO doneStatusSelf = DONE_STATUS_SELF_RESPONSE_BUILDER().build();
-		StatusSelfDTO doingStatusSelf = DOING_STATUS_SELF_RESPONSE_BUILDER().build();
 		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		String token = "token";
 		BoardRequestParam boardRequestParam = BOARD_REQUEST_BUILDER().build();
@@ -479,7 +470,6 @@ class JiraServiceTest {
 			.build();
 
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-		when(jiraFeignClient.getJiraBoardConfiguration(baseUrl, BOARD_ID, token)).thenReturn(jiraBoardConfigDTO);
 		when(jiraFeignClient.getTargetField(baseUrl, boardRequestParam.getProjectKey(), token))
 			.thenReturn(emptyProjectFieldResponse);
 
@@ -490,12 +480,7 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowCustomExceptionWhenGetJiraBoardConfig() {
-		JiraBoardConfigDTO jiraBoardConfigDTO = JIRA_BOARD_CONFIG_RESPONSE_BUILDER().build();
-		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
-		String token = "token";
-
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
-		doReturn(jiraBoardConfigDTO).when(jiraFeignClient).getJiraBoardConfiguration(baseUrl, BOARD_ID, token);
 
 		assertThatThrownBy(() -> jiraService.getJiraConfiguration(boardTypeJira, BOARD_REQUEST_BUILDER().build()))
 			.isInstanceOf(PermissionDenyException.class)
@@ -504,10 +489,11 @@ class JiraServiceTest {
 
 	@Test
 	void shouldThrowCustomExceptionWhenCallJiraFeignClientToGetBoardConfigFailed() {
-
+		URI baseUrl = URI.create(SITE_ATLASSIAN_NET);
 		when(urlGenerator.getUri(any())).thenReturn(URI.create(SITE_ATLASSIAN_NET));
 		when(jiraFeignClient.getJiraBoardConfiguration(any(), any(), any())).thenThrow(new CustomFeignClientException(400, "exception"));
-
+		when(jiraFeignClient.getTargetField(baseUrl, "project key", "token"))
+			.thenReturn(FIELD_RESPONSE_BUILDER().build());
 		assertThatThrownBy(() -> jiraService.getJiraConfiguration(boardTypeJira, BoardRequestParam.builder().build()))
 			.isInstanceOf(Exception.class)
 			.hasMessageContaining("exception");


### PR DESCRIPTION
## Summary

Some requests running in threads might be blocked when thread pool core size is not enough although it did not reach to the max size. Then refined it as removing some uncontrolled executors. 

## Before

Some requests running in threads might be blocked

## After

No requests running in threads might be blocked
 
## Note

For multiple thread calling, we can not run it anywhere. We should fine that the exact thing we have to use multiple threads essentially. 
