### PR TITLE
ADM-688:[backend]fix: revert and fix workday test cross year failed i…

### DIFF
--- a/backend/src/test/java/heartbeat/service/report/WorkDayTest.java
+++ b/backend/src/test/java/heartbeat/service/report/WorkDayTest.java
@@ -11,11 +11,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDate;
-import java.time.Year;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,7 +29,6 @@ class WorkDayTest {
 
 	@Test
 	void shouldReturnDayIsHoliday() {
-		String year = Year.now().toString();
 		List<HolidayDTO> holidayDTOList = List.of(
 				HolidayDTO.builder().date("2023-01-01").name("元旦").isOffDay(true).build(),
 				HolidayDTO.builder().date("2023-01-28").name("春节").isOffDay(false).build());
@@ -43,7 +42,8 @@ class WorkDayTest {
 			.atStartOfDay(ZoneOffset.UTC)
 			.toInstant()
 			.toEpochMilli();
-		when(holidayFeignClient.getHolidays(year))
+
+		when(holidayFeignClient.getHolidays(any()))
 			.thenReturn(HolidaysResponseDTO.builder().days(holidayDTOList).build());
 
 		workDay.changeConsiderHolidayMode(true);


### PR DESCRIPTION
…ssue

## Summary
Fix the workdayTest cross year failed issue
## Before

The year parameter was hardcoded "2023", when the action executes,it would get the year by `Calendar.YEAR` and the test would fail.

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

Remove the hardcoded year, change the parameter to `any()`.

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
