### PR TITLE
[frontend] ADM-728: generate detail report relate to 'classification'

### DIFF
--- a/frontend/__tests__/src/containers/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/src/containers/ReportStep/ReportStep.test.tsx
@@ -2,11 +2,14 @@ import { render, renderHook, screen, waitFor } from '@testing-library/react';
 import ReportStep from '@src/containers/ReportStep';
 import {
   BACK,
+  BOARD_METRICS_TITLE,
+  CLASSIFICATION,
   EMPTY_REPORT_VALUES,
   ERROR_PAGE_ROUTE,
   EXPORT_BOARD_DATA,
   EXPORT_METRIC_DATA,
   EXPORT_PIPELINE_DATA,
+  LEAD_TIME_FOR_CHANGES,
   MOCK_DATE_RANGE,
   MOCK_JIRA_VERIFY_RESPONSE,
   MOCK_REPORT_RESPONSE,
@@ -151,6 +154,18 @@ describe('Report Step', () => {
       setup(REQUIRED_DATA_LIST);
 
       expect(screen.getAllByTestId('loading-page')).toHaveLength(6);
+    });
+
+    it('should render detail page when metrics only select classification', () => {
+      setup([CLASSIFICATION]);
+
+      expect(screen.getByText(BACK)).toBeInTheDocument();
+    });
+
+    it('should render report page when board metrics select classification and dora metrics has value too', () => {
+      setup([CLASSIFICATION, LEAD_TIME_FOR_CHANGES]);
+
+      expect(screen.getByText(BOARD_METRICS_TITLE)).toBeInTheDocument();
     });
 
     it('should render the velocity component with correct props', async () => {

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -21,6 +21,8 @@ export const SHOW_MORE = 'show more >';
 
 export const BACK = 'Back';
 
+export const BOARD_METRICS_TITLE = 'Board Metrics';
+
 export const VERIFY = 'Verify';
 
 export const RESET = 'Reset';

--- a/frontend/src/containers/MetricsStep/style.tsx
+++ b/frontend/src/containers/MetricsStep/style.tsx
@@ -1,5 +1,6 @@
 import { styled } from '@mui/material/styles';
 import { Divider } from '@src/components/Common/MetricsSettingTitle/style';
+import { theme } from '@src/theme';
 
 export const MetricSelectionHeader = styled('div')({
   display: 'flex',
@@ -16,8 +17,9 @@ export const MetricSelectionWrapper = styled('div')({
   padding: '1.5rem',
   marginBottom: '1.5rem',
   borderRadius: '0.75rem',
-  border: '0.1rem',
-  boxShadow: '0 0.25rem 1rem 0 rgba(0, 0, 0, 0.08)',
+  border: theme.main.cardBorder,
+  background: theme.main.color,
+  boxShadow: theme.main.cardShadow,
   position: 'relative',
 });
 

--- a/frontend/src/containers/ReportStep/ReportDetail/board.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/board.tsx
@@ -7,11 +7,19 @@ import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataSt
 import { Optional } from '@src/utils/types';
 import { withGoBack } from './withBack';
 import { METRICS_TITLE } from '@src/constants/resources';
+import { Loading } from '@src/components/Loading';
+import { styled } from '@mui/material/styles';
 
 interface Property {
   data: ReportResponseDTO;
   onBack: () => void;
 }
+
+export const StyledLoadingWrapper = styled('div')({
+  position: 'relative',
+  height: '5rem',
+  width: '100%',
+});
 
 const showSectionWith2Columns = (title: string, value: Optional<ReportDataWithTwoColumns[]>) =>
   value && <ReportForTwoColumns title={title} data={value} />;
@@ -23,13 +31,17 @@ export const BoardDetail = withGoBack(({ data }: Property) => {
     <>
       {showSectionWith2Columns(METRICS_TITLE.VELOCITY, mappedData.velocityList)}
       {showSectionWith2Columns(METRICS_TITLE.CYCLE_TIME, mappedData.cycleTimeList)}
-      {mappedData.classification && (
+      {mappedData.classification ? (
         <ReportForThreeColumns
           title={METRICS_TITLE.CLASSIFICATION}
           fieldName={'Field Name'}
           listName={'Subtitle'}
           data={mappedData.classification}
         />
+      ) : (
+        <StyledLoadingWrapper>
+          <Loading size='1.5rem' backgroundColor='transparent' />
+        </StyledLoadingWrapper>
       )}
     </>
   );

--- a/frontend/src/containers/ReportStep/index.tsx
+++ b/frontend/src/containers/ReportStep/index.tsx
@@ -51,13 +51,10 @@ const ReportStep = ({ notification, handleSave }: ReportStepProps) => {
 
   const shouldShowBoardMetrics = useAppSelector(isSelectBoardMetrics);
   const shouldShowDoraMetrics = useAppSelector(isSelectDoraMetrics);
+  const onlySelectClassification = metrics.length === 1 && metrics[0] === REQUIRED_DATA.CLASSIFICATION;
 
   useEffect(() => {
-    setPageType(
-      metrics.length === 1 && metrics[0] === REQUIRED_DATA.CLASSIFICATION
-        ? REPORT_PAGE_TYPE.BOARD
-        : REPORT_PAGE_TYPE.SUMMARY
-    );
+    setPageType(onlySelectClassification ? REPORT_PAGE_TYPE.BOARD : REPORT_PAGE_TYPE.SUMMARY);
   }, []);
 
   useLayoutEffect(() => {
@@ -140,11 +137,11 @@ const ReportStep = ({ notification, handleSave }: ReportStepProps) => {
       )}
     </>
   );
-  const showBoardDetail = (data: ReportResponseDTO) => <BoardDetail onBack={() => backToSummaryPage()} data={data} />;
+  const showBoardDetail = (data: ReportResponseDTO) => <BoardDetail onBack={() => handleBack()} data={data} />;
   const showDoraDetail = (data: ReportResponseDTO) => <DoraDetail onBack={() => backToSummaryPage()} data={data} />;
 
   const handleBack = () => {
-    pageType === REPORT_PAGE_TYPE.SUMMARY ? dispatch(backStep()) : backToSummaryPage();
+    pageType === REPORT_PAGE_TYPE.SUMMARY || onlySelectClassification ? dispatch(backStep()) : backToSummaryPage();
   };
 
   const backToSummaryPage = () => {

--- a/frontend/src/containers/ReportStep/index.tsx
+++ b/frontend/src/containers/ReportStep/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useLayoutEffect, useState } from 'react';
 import { useGenerateReportEffect } from '@src/hooks/useGenerateReportEffect';
 import { useAppSelector } from '@src/hooks';
 import { isSelectBoardMetrics, isSelectDoraMetrics, selectConfig } from '@src/context/config/configSlice';
-import { MESSAGE, REPORT_PAGE_TYPE } from '@src/constants/resources';
+import { MESSAGE, REPORT_PAGE_TYPE, REQUIRED_DATA } from '@src/constants/resources';
 import { StyledCalendarWrapper, StyledErrorNotification } from '@src/containers/ReportStep/style';
 import { ErrorNotification } from '@src/components/ErrorNotification';
 import { useNavigate } from 'react-router-dom';
@@ -44,12 +44,21 @@ const ReportStep = ({ notification, handleSave }: ReportStepProps) => {
 
   const startDate = configData.basic.dateRange.startDate ?? '';
   const endDate = configData.basic.dateRange.endDate ?? '';
+  const metrics = configData.basic.metrics;
 
   const { updateProps, resetProps } = notification;
   const [errorMessage, setErrorMessage] = useState<string>();
 
   const shouldShowBoardMetrics = useAppSelector(isSelectBoardMetrics);
   const shouldShowDoraMetrics = useAppSelector(isSelectDoraMetrics);
+
+  useEffect(() => {
+    setPageType(
+      metrics.length === 1 && metrics[0] === REQUIRED_DATA.CLASSIFICATION
+        ? REPORT_PAGE_TYPE.BOARD
+        : REPORT_PAGE_TYPE.SUMMARY
+    );
+  }, []);
 
   useLayoutEffect(() => {
     exportValidityTimeMin &&


### PR DESCRIPTION
## Summary

generate detail report relate to 'classification'

## Before

_Description_

**Screenshots**
<img width="1187" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/e0d10a66-8af3-43a5-8906-8a7e4455a9e6">

## After

_Description_

**Screenshots**
<img width="1179" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/295f5e86-2739-4712-859b-2be2c4afaffb">
## Note

_Null_
