### PR TITLE
[frontend]ADM-728: add loading for table and report title

### DIFF
--- a/frontend/__tests__/src/components/Common/ReportForThreeColumns.test.tsx
+++ b/frontend/__tests__/src/components/Common/ReportForThreeColumns.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReportForThreeColumns from '@src/components/Common/ReportForThreeColumns';
+import clearAllMocks = jest.clearAllMocks;
+
+describe('Report for three columns', () => {
+  afterEach(() => {
+    clearAllMocks();
+  });
+
+  it('should show loading when data is empty', () => {
+    render(<ReportForThreeColumns title='title' fieldName='fieldName' listName='listName' data={undefined} />);
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+  });
+
+  it('should show table when has data', () => {
+    const mockData = [
+      { id: 0, name: 'name1', valuesList: [{ name: 'test1', value: '1' }] },
+      { id: 1, name: 'name2', valuesList: [{ name: 'test2', value: '2' }] },
+      { id: 2, name: 'name3', valuesList: [{ name: 'test3', value: '3' }] },
+    ];
+
+    render(<ReportForThreeColumns title='title' fieldName='fieldName' listName='listName' data={mockData} />);
+
+    expect(screen.getByTestId('title')).toBeInTheDocument();
+  });
+});

--- a/frontend/__tests__/src/components/Loading/Loading.test.tsx
+++ b/frontend/__tests__/src/components/Loading/Loading.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { Loading } from '@src/components/Loading';
 
 describe('Loading', () => {
@@ -11,8 +11,20 @@ describe('Loading', () => {
   });
 
   it('should show Loading message when has message', () => {
-    const { getByText } = render(<Loading message={'loading...'} />);
+    render(<Loading message={'loading...'} />);
 
-    expect(getByText('loading...')).toBeInTheDocument();
+    expect(screen.getByText('loading...')).toBeInTheDocument();
+  });
+
+  it('should in page center when placement is center', () => {
+    render(<Loading placement={'center'} />);
+
+    expect(screen.getByTestId('loading')).toHaveStyle({ 'align-items': 'center' });
+  });
+
+  it('should in page start when placement is start', () => {
+    render(<Loading placement={'start'} />);
+
+    expect(screen.getByTestId('loading')).toHaveStyle({ 'align-items': 'flex-start' });
   });
 });

--- a/frontend/__tests__/src/containers/ReportStep/BoardMetrics.test.tsx
+++ b/frontend/__tests__/src/containers/ReportStep/BoardMetrics.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import clearAllMocks = jest.clearAllMocks;
 import BoardMetrics from '@src/containers/ReportStep/BoradMetrics';
-import { MOCK_REPORT_RESPONSE } from '../../../src/fixtures';
+import { CLASSIFICATION, LEAD_TIME_FOR_CHANGES, MOCK_REPORT_RESPONSE } from '../../../src/fixtures';
 import { setupStore } from '../../../src/utils/setupStoreUtil';
 import { Provider } from 'react-redux';
 import { RETRY } from '@src/constants/resources';
 import userEvent from '@testing-library/user-event';
+import { updateMetrics } from '@src/context/config/configSlice';
 
 describe('Report Card', () => {
   afterEach(() => {
@@ -56,5 +57,31 @@ describe('Report Card', () => {
     await userEvent.click(getByText(RETRY));
 
     expect(mockHandleRetry).toHaveBeenCalled();
+  });
+
+  it('should show loading button when board metrics select classification and dora metrics has value too ', async () => {
+    const store = setupStore();
+    store.dispatch(updateMetrics([CLASSIFICATION, LEAD_TIME_FOR_CHANGES]));
+    const mockData = {
+      ...MOCK_REPORT_RESPONSE,
+      boardMetricsCompleted: false,
+    };
+
+    render(
+      <Provider store={store}>
+        <BoardMetrics
+          isBackFromDetail={false}
+          startDate={''}
+          endDate={''}
+          startToRequestBoardData={mockHandleRetry}
+          onShowDetail={onShowDetail}
+          boardReport={mockData}
+          csvTimeStamp={1705014731}
+          timeoutError={''}
+        />
+      </Provider>
+    );
+
+    expect(screen.getByTestId('loading')).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/src/containers/ReportStep/ReportDetail/board.test.tsx
+++ b/frontend/__tests__/src/containers/ReportStep/ReportDetail/board.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, within } from '@testing-library/react';
 import { BoardDetail } from '@src/containers/ReportStep/ReportDetail';
 import { reportMapper } from '@src/hooks/reportMapper/report';
 import React from 'react';
+import { Provider } from 'react-redux';
+import { setupStore } from '../../../utils/setupStoreUtil';
+import { updateMetrics } from '@src/context/config/configSlice';
+import { REQUIRED_DATA_LIST } from '../../../fixtures';
 
 jest.mock('@src/hooks/reportMapper/report');
 
@@ -13,7 +17,13 @@ describe('board', () => {
 
   it('should render a back link', () => {
     (reportMapper as jest.Mock).mockReturnValue({});
-    render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+    render(
+      <Provider store={setupStore()}>
+        <BoardDetail data={data} onBack={jest.fn()} />
+      </Provider>
+    );
+
     expect(screen.getByTestId('ArrowBackIcon')).toBeInTheDocument();
     expect(screen.getByText('Back')).toBeInTheDocument();
   });
@@ -26,7 +36,13 @@ describe('board', () => {
           { id: 1, name: 'name2', valueList: [{ value: 2 }] },
         ],
       });
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+      render(
+        <Provider store={setupStore()}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       const velocityTable = screen.getByTestId('Velocity');
       expect(screen.getByText('Velocity')).toBeInTheDocument();
       expect(velocityTable).toBeInTheDocument();
@@ -37,7 +53,13 @@ describe('board', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         velocityList: null,
       });
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+      render(
+        <Provider store={setupStore()}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       expect(screen.queryAllByText('Velocity').length).toEqual(0);
     });
   });
@@ -51,7 +73,13 @@ describe('board', () => {
           { id: 2, name: 'name3', valueList: [{ value: 3 }] },
         ],
       });
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+      render(
+        <Provider store={setupStore()}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       const cycleTimeTable = screen.getByTestId('Cycle Time');
       expect(screen.getByText('Cycle Time')).toBeInTheDocument();
       expect(cycleTimeTable).toBeInTheDocument();
@@ -62,7 +90,13 @@ describe('board', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         cycleTimeList: null,
       });
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+      render(
+        <Provider store={setupStore()}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       expect(screen.queryAllByText('Cycle Time').length).toEqual(0);
     });
   });
@@ -77,8 +111,15 @@ describe('board', () => {
           { id: 3, name: 'name4', valuesList: [{ name: 'test4', value: 4 }] },
         ],
       });
+      const store = setupStore();
+      store.dispatch(updateMetrics(REQUIRED_DATA_LIST));
 
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+      render(
+        <Provider store={store}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       const classificationTable = screen.getByTestId('Classification');
       expect(screen.getByText('Classification')).toBeInTheDocument();
       expect(classificationTable).toBeInTheDocument();
@@ -89,7 +130,13 @@ describe('board', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         classification: null,
       });
-      render(<BoardDetail data={data} onBack={jest.fn()} />);
+
+      render(
+        <Provider store={setupStore()}>
+          <BoardDetail data={data} onBack={jest.fn()} />
+        </Provider>
+      );
+
       expect(screen.queryAllByText('Classification').length).toEqual(0);
     });
   });
@@ -107,7 +154,15 @@ describe('board', () => {
         { id: 2, name: 'name3', valuesList: [{ name: 'test3', value: 3 }] },
       ],
     });
-    render(<BoardDetail data={data} onBack={jest.fn()} />);
+    const store = setupStore();
+    store.dispatch(updateMetrics(REQUIRED_DATA_LIST));
+
+    render(
+      <Provider store={store}>
+        <BoardDetail data={data} onBack={jest.fn()} />
+      </Provider>
+    );
+
     const velocityTable = screen.getByTestId('Velocity');
     const cycleTimeTable = screen.getByTestId('Cycle Time');
     const classificationTable = screen.getByTestId('Classification');

--- a/frontend/src/components/Common/ReportForThreeColumns/index.tsx
+++ b/frontend/src/components/Common/ReportForThreeColumns/index.tsx
@@ -49,7 +49,7 @@ export const ReportForThreeColumns = ({ title, fieldName, listName, data }: Repo
   };
 
   const renderRows = () =>
-    data.slice(0, data.length === 2 && data[1].name === AVERAGE_FIELD ? 1 : data.length).map((row) => (
+    data?.slice(0, data?.length === 2 && data[1]?.name === AVERAGE_FIELD ? 1 : data?.length).map((row) => (
       <Fragment key={row.id}>
         <TableRow data-testid={'tr'}>
           <ColumnTableCell rowSpan={row.valuesList.length + 1}>{emojiRow(row)}</ColumnTableCell>

--- a/frontend/src/components/Common/ReportForThreeColumns/index.tsx
+++ b/frontend/src/components/Common/ReportForThreeColumns/index.tsx
@@ -12,13 +12,22 @@ import { AVERAGE_FIELD, METRICS_TITLE, REPORT_SUFFIX_UNITS } from '@src/constant
 import { getEmojiUrls, removeExtraEmojiName } from '@src/emojis/emoji';
 import { EmojiWrap, StyledAvatar, StyledTypography } from '@src/emojis/style';
 import { ReportSelectionTitle } from '@src/containers/MetricsStep/style';
+import { Loading } from '@src/components/Loading';
+import { styled } from '@mui/material/styles';
+import { Optional } from '@src/utils/types';
 
 interface ReportForThreeColumnsProps {
   title: string;
   fieldName: string;
   listName: string;
-  data: ReportDataWithThreeColumns[];
+  data: Optional<ReportDataWithThreeColumns[]>;
 }
+
+export const StyledLoadingWrapper = styled('div')({
+  position: 'relative',
+  height: '12rem',
+  width: '100%',
+});
 
 export const ReportForThreeColumns = ({ title, fieldName, listName, data }: ReportForThreeColumnsProps) => {
   const emojiRow = (row: ReportDataWithThreeColumns) => {
@@ -66,16 +75,22 @@ export const ReportForThreeColumns = ({ title, fieldName, listName, data }: Repo
     <>
       <Container>
         <ReportSelectionTitle>{title}</ReportSelectionTitle>
-        <Table data-test-id={title} data-testid={title}>
-          <TableHead>
-            <TableRow>
-              <StyledTableCell>{fieldName}</StyledTableCell>
-              <StyledTableCell>{listName}</StyledTableCell>
-              <StyledTableCell>{`Value${getTitleUnit(title)}`}</StyledTableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>{renderRows()}</TableBody>
-        </Table>
+        {data ? (
+          <Table data-test-id={title} data-testid={title}>
+            <TableHead>
+              <TableRow>
+                <StyledTableCell>{fieldName}</StyledTableCell>
+                <StyledTableCell>{listName}</StyledTableCell>
+                <StyledTableCell>{`Value${getTitleUnit(title)}`}</StyledTableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>{renderRows()}</TableBody>
+          </Table>
+        ) : (
+          <StyledLoadingWrapper>
+            <Loading size='1.5rem' backgroundColor='transparent' />
+          </StyledLoadingWrapper>
+        )}
       </Container>
     </>
   );

--- a/frontend/src/components/Loading/index.tsx
+++ b/frontend/src/components/Loading/index.tsx
@@ -12,7 +12,7 @@ export interface LoadingProps {
 
 export const Loading = ({ message, size = '8rem', backgroundColor, placement = 'center' }: LoadingProps) => {
   return (
-    <LoadingDrop placement={placement} open style={{ backgroundColor: backgroundColor }}>
+    <LoadingDrop data-testid='loading' placement={placement} open style={{ backgroundColor: backgroundColor }}>
       <CircularProgress size={size} data-testid='loading-page' />
       {message && <LoadingTypography>{message}</LoadingTypography>}
     </LoadingDrop>

--- a/frontend/src/components/Loading/index.tsx
+++ b/frontend/src/components/Loading/index.tsx
@@ -1,15 +1,18 @@
 import { CircularProgress } from '@mui/material';
 import { LoadingDrop, LoadingTypography } from './style';
 
+export type Placement = 'start' | 'center';
+
 export interface LoadingProps {
   message?: string;
   size?: string;
   backgroundColor?: string;
+  placement?: Placement;
 }
 
-export const Loading = ({ message, size = '8rem', backgroundColor }: LoadingProps) => {
+export const Loading = ({ message, size = '8rem', backgroundColor, placement = 'center' }: LoadingProps) => {
   return (
-    <LoadingDrop open style={{ backgroundColor: backgroundColor }}>
+    <LoadingDrop placement={placement} open style={{ backgroundColor: backgroundColor }}>
       <CircularProgress size={size} data-testid='loading-page' />
       {message && <LoadingTypography>{message}</LoadingTypography>}
     </LoadingDrop>

--- a/frontend/src/components/Loading/index.tsx
+++ b/frontend/src/components/Loading/index.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress } from '@mui/material';
 import { LoadingDrop, LoadingTypography } from './style';
+import React from 'react';
 
 export type Placement = 'start' | 'center';
 

--- a/frontend/src/components/Loading/style.tsx
+++ b/frontend/src/components/Loading/style.tsx
@@ -2,17 +2,19 @@ import { styled } from '@mui/material/styles';
 import { Backdrop, Typography } from '@mui/material';
 import { theme } from '@src/theme';
 import { Z_INDEX } from '@src/constants/commons';
+import { Placement } from '@src/components/Loading/index';
 
-export const LoadingDrop = styled(Backdrop)({
+export const LoadingDrop = styled(Backdrop)((props: { placement: Placement }) => ({
   position: 'absolute',
   zIndex: Z_INDEX.MODAL_BACKDROP,
   backgroundColor: 'rgba(199,199,199,0.43)',
   color: theme.main.backgroundColor,
   display: 'flex',
   flexDirection: 'column',
-  alignItems: 'center',
+  alignItems: props.placement === 'center' ? 'center' : 'flex-start',
+  left: props.placement === 'center' ? '0' : '9rem',
   justifyContent: 'center',
-});
+}));
 
 export const LoadingTypography = styled(Typography)({
   fontSize: '1rem',

--- a/frontend/src/components/Loading/style.tsx
+++ b/frontend/src/components/Loading/style.tsx
@@ -12,7 +12,6 @@ export const LoadingDrop = styled(Backdrop)((props: { placement: Placement }) =>
   display: 'flex',
   flexDirection: 'column',
   alignItems: props.placement === 'center' ? 'center' : 'flex-start',
-  left: props.placement === 'center' ? '0' : '9rem',
   justifyContent: 'center',
 }));
 

--- a/frontend/src/containers/ReportStep/BoradMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/BoradMetrics/index.tsx
@@ -26,6 +26,7 @@ import { ReportTitle } from '@src/components/Common/ReportGrid/ReportTitle';
 import { ReportGrid } from '@src/components/Common/ReportGrid';
 import { ReportResponseDTO } from '@src/clients/report/dto/response';
 import { Nullable } from '@src/utils/types';
+import { Loading } from '@src/components/Loading';
 
 interface BoardMetricsProps {
   startToRequestBoardData: (request: ReportRequestDTO) => void;
@@ -138,6 +139,15 @@ const BoardMetrics = ({
     startToRequestBoardData(getBoardReportRequestBody());
   };
 
+  const isShowShowMoreLoading = () => {
+    return (
+      boardMetrics.length === 1 &&
+      boardMetrics[0] === REQUIRED_DATA.CLASSIFICATION &&
+      !(timeoutError || getErrorMessage()) &&
+      !boardReport?.boardMetricsCompleted
+    );
+  };
+
   useEffect(() => {
     !isBackFromDetail && startToRequestBoardData(getBoardReportRequestBody());
   }, []);
@@ -150,6 +160,7 @@ const BoardMetrics = ({
           {!(timeoutError || getErrorMessage()) && boardReport?.boardMetricsCompleted && (
             <StyledShowMore onClick={onShowDetail}>{SHOW_MORE}</StyledShowMore>
           )}
+          {isShowShowMoreLoading() && <Loading placement='start' size='0.8rem' backgroundColor='transparent' />}
           {(timeoutError || getErrorMessage()) && <StyledRetry onClick={handleRetry}>{RETRY}</StyledRetry>}
         </StyledTitleWrapper>
         <ReportGrid reportDetails={getBoardItems()} errorMessage={timeoutError || getErrorMessage()} />

--- a/frontend/src/containers/ReportStep/BoradMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/BoradMetrics/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useAppSelector } from '@src/hooks';
 import _ from 'lodash';
 import { selectConfig, selectJiraColumns } from '@src/context/config/configSlice';
@@ -16,6 +16,7 @@ import { BoardReportRequestDTO, ReportRequestDTO } from '@src/clients/report/dto
 import { selectMetricsContent } from '@src/context/Metrics/metricsSlice';
 import dayjs from 'dayjs';
 import {
+  StyledLoading,
   StyledMetricsSection,
   StyledRetry,
   StyledShowMore,
@@ -160,7 +161,11 @@ const BoardMetrics = ({
           {!(timeoutError || getErrorMessage()) && boardReport?.boardMetricsCompleted && (
             <StyledShowMore onClick={onShowDetail}>{SHOW_MORE}</StyledShowMore>
           )}
-          {isShowShowMoreLoading() && <Loading placement='start' size='0.8rem' backgroundColor='transparent' />}
+          {isShowShowMoreLoading() && (
+            <StyledLoading>
+              <Loading placement='start' size='0.8rem' backgroundColor='transparent' />
+            </StyledLoading>
+          )}
           {(timeoutError || getErrorMessage()) && <StyledRetry onClick={handleRetry}>{RETRY}</StyledRetry>}
         </StyledTitleWrapper>
         <ReportGrid reportDetails={getBoardItems()} errorMessage={timeoutError || getErrorMessage()} />

--- a/frontend/src/containers/ReportStep/BoradMetrics/style.tsx
+++ b/frontend/src/containers/ReportStep/BoradMetrics/style.tsx
@@ -9,6 +9,7 @@ export const StyledTitleWrapper = styled('div')({
   display: 'flex',
   alignItems: 'center',
   marginBottom: '1rem',
+  position: 'relative',
 });
 
 export const StyledShowMore = styled('div')({

--- a/frontend/src/containers/ReportStep/BoradMetrics/style.tsx
+++ b/frontend/src/containers/ReportStep/BoradMetrics/style.tsx
@@ -20,6 +20,11 @@ export const StyledShowMore = styled('div')({
   cursor: 'pointer',
 });
 
+export const StyledLoading = styled('div')({
+  position: 'relative',
+  left: '1rem',
+});
+
 export const StyledRetry = styled('div')({
   marginLeft: '0.5rem',
   fontSize: '0.8rem',

--- a/frontend/src/containers/ReportStep/ReportDetail/board.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/board.tsx
@@ -6,42 +6,33 @@ import { reportMapper } from '@src/hooks/reportMapper/report';
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import { Optional } from '@src/utils/types';
 import { withGoBack } from './withBack';
-import { METRICS_TITLE } from '@src/constants/resources';
-import { Loading } from '@src/components/Loading';
-import { styled } from '@mui/material/styles';
+import { METRICS_TITLE, REQUIRED_DATA } from '@src/constants/resources';
+import { useAppSelector } from '@src/hooks';
+import { selectMetrics } from '@src/context/config/configSlice';
 
 interface Property {
   data: ReportResponseDTO;
   onBack: () => void;
 }
 
-export const StyledLoadingWrapper = styled('div')({
-  position: 'relative',
-  height: '5rem',
-  width: '100%',
-});
-
 const showSectionWith2Columns = (title: string, value: Optional<ReportDataWithTwoColumns[]>) =>
   value && <ReportForTwoColumns title={title} data={value} />;
 
 export const BoardDetail = withGoBack(({ data }: Property) => {
+  const metrics = useAppSelector(selectMetrics);
   const mappedData = reportMapper(data);
 
   return (
     <>
       {showSectionWith2Columns(METRICS_TITLE.VELOCITY, mappedData.velocityList)}
       {showSectionWith2Columns(METRICS_TITLE.CYCLE_TIME, mappedData.cycleTimeList)}
-      {mappedData.classification ? (
+      {metrics.includes(REQUIRED_DATA.CLASSIFICATION) && (
         <ReportForThreeColumns
           title={METRICS_TITLE.CLASSIFICATION}
           fieldName={'Field Name'}
           listName={'Subtitle'}
           data={mappedData.classification}
         />
-      ) : (
-        <StyledLoadingWrapper>
-          <Loading size='1.5rem' backgroundColor='transparent' />
-        </StyledLoadingWrapper>
       )}
     </>
   );


### PR DESCRIPTION
## Summary

add loading for table and report title

## Before

_Description_

**Screenshots**
<img width="995" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/b7c370e7-912e-48b4-87fa-39037ecb0a5b">

## After

_Description_

**Screenshots**
<img width="930" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/c6ae0b00-b3b9-4935-a572-2bf8b974da27">

## Note

_Null_
