### PR TITLE
ADM-714: [frontend] handle 5 series error routing

### DIFF
--- a/frontend/__tests__/src/client/BoardClient.test.ts
+++ b/frontend/__tests__/src/client/BoardClient.test.ts
@@ -8,6 +8,7 @@ import {
   VERIFY_ERROR_MESSAGE,
 } from '../fixtures';
 import { boardClient } from '@src/clients/board/BoardClient';
+import { AXIOS_ERROR_MESSAGE } from '../../src/fixtures';
 import { HttpStatusCode } from 'axios';
 
 const server = setupServer(
@@ -107,6 +108,6 @@ describe('verify board request', () => {
 
     await expect(async () => {
       await boardClient.getVerifyBoard(MOCK_BOARD_VERIFY_REQUEST_PARAMS);
-    }).rejects.toThrow('Network Error');
+    }).rejects.toThrow(AXIOS_ERROR_MESSAGE.ERR_NETWORK);
   });
 });

--- a/frontend/__tests__/src/client/BoardClient.test.ts
+++ b/frontend/__tests__/src/client/BoardClient.test.ts
@@ -102,11 +102,11 @@ describe('verify board request', () => {
     }).rejects.toThrow(VERIFY_ERROR_MESSAGE.UNKNOWN);
   });
 
-  it('should throw unknown error when board verify response empty', async () => {
+  it('should throw `Network Error` when board verify encountered netwrok error', async () => {
     server.use(rest.post(MOCK_BOARD_URL_FOR_JIRA, (req, res) => res.networkError('Network Error')));
 
     await expect(async () => {
       await boardClient.getVerifyBoard(MOCK_BOARD_VERIFY_REQUEST_PARAMS);
-    }).rejects.toThrow(VERIFY_ERROR_MESSAGE.UNKNOWN);
+    }).rejects.toThrow('Network Error');
   });
 });

--- a/frontend/__tests__/src/client/PipelineToolClient.test.ts
+++ b/frontend/__tests__/src/client/PipelineToolClient.test.ts
@@ -113,8 +113,25 @@ describe('PipelineToolClient', () => {
         }
       );
 
-      it('should return "Unknown error" as a last resort when error code didn\'t match the predeifned erorr cases', async () => {
-        server.use(rest.post(MOCK_PIPELINE_GET_INFO_URL, (req, res, ctx) => res(ctx.status(503))));
+      it('should return ERR_NETWORK error as its code when axios client detect network error', async () => {
+        server.use(
+          rest.post(MOCK_PIPELINE_GET_INFO_URL, (req, res, ctx) => {
+            return res.networkError('mock network error');
+          })
+        );
+
+        const result = await pipelineToolClient.getInfo(MOCK_PIPELINE_VERIFY_REQUEST_PARAMS);
+
+        expect(result.code).toEqual('ERR_NETWORK');
+        expect(result.data).toBeUndefined();
+      });
+
+      it('should return "Unknown error" as a last resort when axios error code didn\'t match the predeifned erorr cases', async () => {
+        server.use(
+          rest.post(MOCK_PIPELINE_GET_INFO_URL, (req, res, ctx) => {
+            return res(ctx.status(-1), ctx.body('mock error not covered by httpClient'));
+          })
+        );
 
         const result = await pipelineToolClient.getInfo(MOCK_PIPELINE_VERIFY_REQUEST_PARAMS);
 

--- a/frontend/__tests__/src/client/PipelineToolClient.test.ts
+++ b/frontend/__tests__/src/client/PipelineToolClient.test.ts
@@ -8,7 +8,6 @@ import {
 } from '../fixtures';
 import { pipelineToolClient } from '@src/clients/pipeline/PipelineToolClient';
 import { HttpStatusCode } from 'axios';
-import { AXIOS_ERROR_MESSAGE } from '../../src/fixtures';
 
 const server = setupServer(
   rest.post(MOCK_PIPELINE_VERIFY_URL, (req, res, ctx) => {

--- a/frontend/__tests__/src/client/PipelineToolClient.test.ts
+++ b/frontend/__tests__/src/client/PipelineToolClient.test.ts
@@ -115,7 +115,7 @@ describe('PipelineToolClient', () => {
 
       it('should return ERR_NETWORK error as its code when axios client detect network error', async () => {
         server.use(
-          rest.post(MOCK_PIPELINE_GET_INFO_URL, (req, res, ctx) => {
+          rest.post(MOCK_PIPELINE_GET_INFO_URL, (req, res) => {
             return res.networkError('mock network error');
           })
         );

--- a/frontend/__tests__/src/client/PipelineToolClient.test.ts
+++ b/frontend/__tests__/src/client/PipelineToolClient.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../fixtures';
 import { pipelineToolClient } from '@src/clients/pipeline/PipelineToolClient';
 import { HttpStatusCode } from 'axios';
+import { AXIOS_ERROR_MESSAGE } from '../../src/fixtures';
 
 const server = setupServer(
   rest.post(MOCK_PIPELINE_VERIFY_URL, (req, res, ctx) => {
@@ -122,7 +123,7 @@ describe('PipelineToolClient', () => {
 
         const result = await pipelineToolClient.getInfo(MOCK_PIPELINE_VERIFY_REQUEST_PARAMS);
 
-        expect(result.code).toEqual('ERR_NETWORK');
+        expect(result.code).toEqual('HB_TIMEOUT');
         expect(result.data).toBeUndefined();
       });
 

--- a/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
+++ b/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
@@ -6,7 +6,6 @@ import PresentationForErrorCases, {
   IPresentationForErrorCasesProps,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases';
 import userEvent from '@testing-library/user-event';
-import { AxiosError } from 'axios';
 
 const setup = (props: IPresentationForErrorCasesProps) =>
   render(
@@ -40,40 +39,32 @@ describe('<PresentationForErrorCases />', () => {
     }
   );
 
-  const retryErrors = [
-    { code: AxiosError.ECONNABORTED },
-    { code: AxiosError.ETIMEDOUT },
-    { code: AxiosError.ERR_NETWORK },
-  ];
-  it.each(retryErrors)(
-    'should display "try again" when error code is axios predefined error: $code',
-    async ({ code }) => {
-      const retrySpy = jest.fn();
-      const mockTimeoutError = {
-        code,
-        errorTitle: 'Service Unavailable!',
-        errorMessage: 'Data loading failed, please try again',
-        isLoading: false,
-        retry: retrySpy,
-      };
-      setup(mockTimeoutError);
+  it('should display "try again" when error code is axios predefined error: $code', async () => {
+    const retrySpy = jest.fn();
+    const mockTimeoutError = {
+      code: 'HB_TIMEOUT',
+      errorTitle: 'Service Unavailable!',
+      errorMessage: 'Data loading failed, please try again',
+      isLoading: false,
+      retry: retrySpy,
+    };
+    setup(mockTimeoutError);
 
-      const titleNode = screen.queryByText(mockTimeoutError.errorTitle);
-      const tryAgainNode = screen.getByText('try again');
+    const titleNode = screen.queryByText(mockTimeoutError.errorTitle);
+    const tryAgainNode = screen.getByText('try again');
 
-      expect(titleNode).not.toBeInTheDocument();
-      expect(tryAgainNode).toBeInTheDocument();
+    expect(titleNode).not.toBeInTheDocument();
+    expect(tryAgainNode).toBeInTheDocument();
 
-      await userEvent.click(tryAgainNode);
+    await userEvent.click(tryAgainNode);
 
-      expect(retrySpy).toHaveBeenCalled();
-    }
-  );
+    expect(retrySpy).toHaveBeenCalled();
+  });
 
   it('should not fire duplicated retry behavior when retry func is loading', async () => {
     const retrySpy = jest.fn();
     const mockTimeoutErrorProps = {
-      code: AxiosError.ETIMEDOUT,
+      code: 'HB_TIMEOUT',
       errorTitle: 'Service Unavailable!',
       errorMessage: 'Data loading failed, please try again',
       isLoading: true,

--- a/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
+++ b/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
@@ -6,6 +6,7 @@ import PresentationForErrorCases, {
   IPresentationForErrorCasesProps,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases';
 import userEvent from '@testing-library/user-event';
+import { AxiosError } from 'axios';
 
 const setup = (props: IPresentationForErrorCasesProps) =>
   render(
@@ -15,7 +16,7 @@ const setup = (props: IPresentationForErrorCasesProps) =>
   );
 
 describe('<PresentationForErrorCases />', () => {
-  const errors = [
+  const commonErrors = [
     { code: 204, title: 'No pipeline!' },
     { code: 400, title: 'Invalid input!' },
     { code: 401, title: 'Unauthorized request!' },
@@ -25,7 +26,7 @@ describe('<PresentationForErrorCases />', () => {
   ];
   const errorMessage =
     'Please go back to the previous page and change your pipeline token with correct access permission.';
-  it.each(errors)(
+  it.each(commonErrors)(
     'should properly render error UI with title:$title and corresponding message',
     ({ code, title: errorTitle }) => {
       const props = { code, errorTitle, errorMessage, isLoading: false, retry: () => '' };
@@ -39,32 +40,40 @@ describe('<PresentationForErrorCases />', () => {
     }
   );
 
-  it('should display "try again" when error code is 503', async () => {
-    const retrySpy = jest.fn();
-    const mockTimeoutError = {
-      code: 503,
-      errorTitle: 'Service Unavailable!',
-      errorMessage: 'Data loading failed, please try again',
-      isLoading: false,
-      retry: retrySpy,
-    };
-    setup(mockTimeoutError);
+  const retryErrors = [
+    { code: AxiosError.ECONNABORTED },
+    { code: AxiosError.ETIMEDOUT },
+    { code: AxiosError.ERR_NETWORK },
+  ];
+  it.each(retryErrors)(
+    'should display "try again" when error code is axios predefined error: $code',
+    async ({ code }) => {
+      const retrySpy = jest.fn();
+      const mockTimeoutError = {
+        code,
+        errorTitle: 'Service Unavailable!',
+        errorMessage: 'Data loading failed, please try again',
+        isLoading: false,
+        retry: retrySpy,
+      };
+      setup(mockTimeoutError);
 
-    const titleNode = screen.queryByText(mockTimeoutError.errorTitle);
-    const tryAgainNode = screen.getByText('try again');
+      const titleNode = screen.queryByText(mockTimeoutError.errorTitle);
+      const tryAgainNode = screen.getByText('try again');
 
-    expect(titleNode).not.toBeInTheDocument();
-    expect(tryAgainNode).toBeInTheDocument();
+      expect(titleNode).not.toBeInTheDocument();
+      expect(tryAgainNode).toBeInTheDocument();
 
-    await userEvent.click(tryAgainNode);
+      await userEvent.click(tryAgainNode);
 
-    expect(retrySpy).toHaveBeenCalled();
-  });
+      expect(retrySpy).toHaveBeenCalled();
+    }
+  );
 
   it('should not fire duplicated retry behavior when retry func is loading', async () => {
     const retrySpy = jest.fn();
     const mockTimeoutErrorProps = {
-      code: 503,
+      code: AxiosError.ETIMEDOUT,
       errorTitle: 'Service Unavailable!',
       errorMessage: 'Data loading failed, please try again',
       isLoading: true,

--- a/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
+++ b/frontend/__tests__/src/containers/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases.test.tsx
@@ -33,7 +33,6 @@ describe('<PresentationForErrorCases />', () => {
 
       const titleNode = screen.getByText(errorTitle);
       const messageNode = screen.getByText(errorMessage);
-
       expect(titleNode).toBeVisible();
       expect(messageNode).toBeVisible();
     }

--- a/frontend/__tests__/src/fixtures.ts
+++ b/frontend/__tests__/src/fixtures.ts
@@ -119,6 +119,10 @@ export enum VERIFY_ERROR_MESSAGE {
   UNKNOWN = 'Unknown',
 }
 
+export enum AXIOS_ERROR_MESSAGE {
+  ERR_NETWORK = 'Network Error',
+}
+
 export const VERIFY_FAILED = 'verify failed';
 
 export const MOCK_BOARD_VERIFY_REQUEST_PARAMS = {

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -37,7 +37,7 @@ export class HttpClient {
             case HttpStatusCode.Forbidden:
               throw new ForbiddenException(errorMessage, status);
             default:
-              if (status > 500) {
+              if (status >= 500) {
                 window.location.href = ROUTE.ERROR_PAGE;
                 throw new InternalServerException(errorMessage, status);
               }

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosInstance, HttpStatusCode, AxiosError, Axios } from 'axios';
+import axios, { AxiosInstance, HttpStatusCode } from 'axios';
+import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
 import { BadRequestException } from '@src/exceptions/BadRequestException';
 import { UnauthorizedException } from '@src/exceptions/UnauthorizedException';
 import { InternalServerException } from '@src/exceptions/InternalServerException';
@@ -20,7 +21,7 @@ export class HttpClient {
       (res) => res,
       (error) => {
         const { code, response } = error;
-        if (code === AxiosError.ECONNABORTED || code === AxiosError.ETIMEDOUT) {
+        if (HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === code)) {
           throw new TimeoutException(error?.message, code);
         } else if (response && response.status) {
           const { status, data, statusText } = response;

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, HttpStatusCode } from 'axios';
+import { ROUTE } from '@src/constants/router';
 import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
 import { BadRequestException } from '@src/exceptions/BadRequestException';
 import { UnauthorizedException } from '@src/exceptions/UnauthorizedException';
@@ -37,6 +38,7 @@ export class HttpClient {
               throw new ForbiddenException(errorMessage, status);
             default:
               if (status > 500) {
+                window.location.href = ROUTE.ERROR_PAGE;
                 throw new InternalServerException(errorMessage, status);
               }
               throw new UnknownException();

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -24,7 +24,7 @@ export class HttpClient {
         const { code, response } = error;
         if (HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === code)) {
           throw new TimeoutException(error?.message, code);
-        } else if (response && response.status) {
+        } else if (response && response.status && response.status > 0) {
           const { status, data, statusText } = response;
           const errorMessage = data?.hintInfo ?? statusText;
           switch (status) {

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -1,6 +1,6 @@
 import axios, { AxiosInstance, HttpStatusCode } from 'axios';
 import { ROUTE } from '@src/constants/router';
-import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
+import { AXIOS_NETWORK_ERROR_CODES, HEARTBEAT_EXCEPTION_CODE } from '@src/constants/resources';
 import { BadRequestException } from '@src/exceptions/BadRequestException';
 import { UnauthorizedException } from '@src/exceptions/UnauthorizedException';
 import { InternalServerException } from '@src/exceptions/InternalServerException';
@@ -22,20 +22,20 @@ export class HttpClient {
       (res) => res,
       (error) => {
         const { code, response } = error;
-        if (HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === code)) {
-          throw new TimeoutException(error?.message, code);
+        if (AXIOS_NETWORK_ERROR_CODES.some((predefinedCode) => predefinedCode === code)) {
+          throw new TimeoutException(error?.message, HEARTBEAT_EXCEPTION_CODE.TIMEOUT);
         } else if (response && response.status && response.status > 0) {
           const { status, data, statusText } = response;
           const errorMessage = data?.hintInfo ?? statusText;
           switch (status) {
             case HttpStatusCode.BadRequest:
-              throw new BadRequestException(errorMessage, status);
+              throw new BadRequestException(errorMessage, HttpStatusCode.BadRequest);
             case HttpStatusCode.Unauthorized:
-              throw new UnauthorizedException(errorMessage, status);
+              throw new UnauthorizedException(errorMessage, HttpStatusCode.Unauthorized);
             case HttpStatusCode.NotFound:
-              throw new NotFoundException(errorMessage, status);
+              throw new NotFoundException(errorMessage, HttpStatusCode.NotFound);
             case HttpStatusCode.Forbidden:
-              throw new ForbiddenException(errorMessage, status);
+              throw new ForbiddenException(errorMessage, HttpStatusCode.Forbidden);
             default:
               if (status >= 500) {
                 window.location.href = ROUTE.ERROR_PAGE;

--- a/frontend/src/clients/Httpclient.ts
+++ b/frontend/src/clients/Httpclient.ts
@@ -34,12 +34,10 @@ export class HttpClient {
               throw new NotFoundException(errorMessage, status);
             case HttpStatusCode.Forbidden:
               throw new ForbiddenException(errorMessage, status);
-            case HttpStatusCode.InternalServerError:
-              throw new InternalServerException(errorMessage, status);
-            // todo // 5 series error
-            // case HttpStatusCode.ServiceUnavailable:
-            //   throw new TimeoutException(errorMessage, status);
             default:
+              if (status > 500) {
+                throw new InternalServerException(errorMessage, status);
+              }
               throw new UnknownException();
           }
         } else {

--- a/frontend/src/clients/pipeline/PipelineToolClient.ts
+++ b/frontend/src/clients/pipeline/PipelineToolClient.ts
@@ -12,12 +12,12 @@ import {
 } from '@src/constants/resources';
 
 export interface IVerifyPipelineToolResult {
-  code: number | undefined | null;
+  code: number | string | undefined | null;
   errorTitle: string;
 }
 
 export interface IGetPipelineToolInfoResult {
-  code: number | undefined | null;
+  code: number | string | undefined | null;
   data?: IPipelineInfoResponseDTO;
   errorTitle: string;
   errorMessage: string;

--- a/frontend/src/clients/pipeline/PipelineToolClient.ts
+++ b/frontend/src/clients/pipeline/PipelineToolClient.ts
@@ -61,10 +61,7 @@ export class PipelineToolClient extends HttpClient {
       }
       result.code = response.status;
     } catch (e) {
-      if (isAxiosError(e) && e.code === AxiosError.ERR_NETWORK) {
-        result.code = e.code;
-        result.errorTitle = e.message;
-      } else if (isHeartBeatException(e)) {
+      if (isHeartBeatException(e)) {
         const exception = e as IHeartBeatException;
         result.code = exception.code;
         result.errorTitle = PIPELINE_TOOL_GET_INFO_ERROR_CASE_TEXT_MAPPING[`${exception.code}`] || UNKNOWN_ERROR_TITLE;

--- a/frontend/src/clients/pipeline/PipelineToolClient.ts
+++ b/frontend/src/clients/pipeline/PipelineToolClient.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@src/clients/Httpclient';
-import { HttpStatusCode, AxiosError, isAxiosError } from 'axios';
+import { HttpStatusCode } from 'axios';
 import { isHeartBeatException } from '@src/exceptions';
 import { IHeartBeatException } from '@src/exceptions/ExceptionType';
 import { IPipelineVerifyRequestDTO, PipelineInfoRequestDTO } from '@src/clients/pipeline/dto/request';

--- a/frontend/src/clients/pipeline/PipelineToolClient.ts
+++ b/frontend/src/clients/pipeline/PipelineToolClient.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@src/clients/Httpclient';
-import { HttpStatusCode } from 'axios';
+import { HttpStatusCode, AxiosError, isAxiosError } from 'axios';
 import { isHeartBeatException } from '@src/exceptions';
 import { IHeartBeatException } from '@src/exceptions/ExceptionType';
 import { IPipelineVerifyRequestDTO, PipelineInfoRequestDTO } from '@src/clients/pipeline/dto/request';
@@ -61,7 +61,10 @@ export class PipelineToolClient extends HttpClient {
       }
       result.code = response.status;
     } catch (e) {
-      if (isHeartBeatException(e)) {
+      if (isAxiosError(e) && e.code === AxiosError.ERR_NETWORK) {
+        result.code = e.code;
+        result.errorTitle = e.message;
+      } else if (isHeartBeatException(e)) {
         const exception = e as IHeartBeatException;
         result.code = exception.code;
         result.errorTitle = PIPELINE_TOOL_GET_INFO_ERROR_CASE_TEXT_MAPPING[`${exception.code}`] || UNKNOWN_ERROR_TITLE;

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
@@ -12,7 +12,7 @@ import {
   StyledRetryButton,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/style';
 import { PIPELINE_TOOL_RETRY_MESSAGE, PIPELINE_TOOL_RETRY_TRIGGER_MESSAGE } from '@src/constants/resources';
-import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
+import { HEARTBEAT_EXCEPTION_CODE } from '@src/constants/resources';
 
 export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoResult {
   retry: () => void;
@@ -21,7 +21,7 @@ export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoRes
 
 const PresentationForErrorCases = (props: IPresentationForErrorCasesProps) => {
   const handleRetry = useCallback(() => !props.isLoading && props.retry(), [props]);
-  const isShowRetryUI = HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === props.code);
+  const isShowRetryUI = HEARTBEAT_EXCEPTION_CODE.TIMEOUT === props.code;
   return (
     <StyledContainer aria-label='Error UI for pipeline settings'>
       <StyledImageContainer>

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
@@ -12,7 +12,7 @@ import {
   StyledRetryButton,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/style';
 import { PIPELINE_TOOL_RETRY_MESSAGE, PIPELINE_TOOL_RETRY_TRIGGER_MESSAGE } from '@src/constants/resources';
-import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
+import { HEARTBEAT_NETWORK_ERROR_CODES, HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
 
 export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoResult {
   retry: () => void;
@@ -21,7 +21,9 @@ export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoRes
 
 const PresentationForErrorCases = (props: IPresentationForErrorCasesProps) => {
   const handleRetry = useCallback(() => !props.isLoading && props.retry(), [props]);
-  const isShowRetryUI = HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === props.code);
+  const isShowRetryUI = [...HEARTBEAT_NETWORK_ERROR_CODES, ...HEARTBEAT_TIMEOUT_ERROR_CODES].some(
+    (predefinedCode) => predefinedCode === props.code
+  );
   return (
     <StyledContainer aria-label='Error UI for pipeline settings'>
       <StyledImageContainer>

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
@@ -11,8 +11,8 @@ import {
   StyledRetryMessage,
   StyledRetryButton,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/style';
-import { HttpStatusCode } from 'axios';
 import { PIPELINE_TOOL_RETRY_MESSAGE, PIPELINE_TOOL_RETRY_TRIGGER_MESSAGE } from '@src/constants/resources';
+import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
 
 export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoResult {
   retry: () => void;
@@ -21,12 +21,13 @@ export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoRes
 
 const PresentationForErrorCases = (props: IPresentationForErrorCasesProps) => {
   const handleRetry = useCallback(() => !props.isLoading && props.retry(), [props]);
+  const isShowRetryUI = HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === props.code);
   return (
     <StyledContainer aria-label='Error UI for pipeline settings'>
       <StyledImageContainer>
         <StyledImage src={errorSvg} alt={'pipeline info error'} loading='lazy' />
       </StyledImageContainer>
-      {props.code === HttpStatusCode.ServiceUnavailable ? (
+      {isShowRetryUI ? (
         <StyledRetryMessage>
           <span>{PIPELINE_TOOL_RETRY_MESSAGE}</span>
           <StyledRetryButton onClick={handleRetry} isLoading={props.isLoading}>

--- a/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
+++ b/frontend/src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/index.tsx
@@ -12,7 +12,7 @@ import {
   StyledRetryButton,
 } from '@src/components/Metrics/MetricsStep/DeploymentFrequencySettings/PresentationForErrorCases/style';
 import { PIPELINE_TOOL_RETRY_MESSAGE, PIPELINE_TOOL_RETRY_TRIGGER_MESSAGE } from '@src/constants/resources';
-import { HEARTBEAT_NETWORK_ERROR_CODES, HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
+import { HEARTBEAT_TIMEOUT_ERROR_CODES } from '@src/constants/resources';
 
 export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoResult {
   retry: () => void;
@@ -21,9 +21,7 @@ export interface IPresentationForErrorCasesProps extends IGetPipelineToolInfoRes
 
 const PresentationForErrorCases = (props: IPresentationForErrorCasesProps) => {
   const handleRetry = useCallback(() => !props.isLoading && props.retry(), [props]);
-  const isShowRetryUI = [...HEARTBEAT_NETWORK_ERROR_CODES, ...HEARTBEAT_TIMEOUT_ERROR_CODES].some(
-    (predefinedCode) => predefinedCode === props.code
-  );
+  const isShowRetryUI = HEARTBEAT_TIMEOUT_ERROR_CODES.some((predefinedCode) => predefinedCode === props.code);
   return (
     <StyledContainer aria-label='Error UI for pipeline settings'>
       <StyledImageContainer>

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -211,7 +211,8 @@ export const REPORT_PAGE = {
   },
 };
 
-export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ERR_NETWORK, AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT];
+export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT];
+export const HEARTBEAT_NETWORK_ERROR_CODES = [AxiosError.ERR_NETWORK];
 
 export const PIPELINE_TOOL_VERIFY_ERROR_CASE_TEXT_MAPPING: { [key: string]: string } = {
   '401': 'Token is incorrect!',

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -211,8 +211,7 @@ export const REPORT_PAGE = {
   },
 };
 
-export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT];
-export const HEARTBEAT_NETWORK_ERROR_CODES = [AxiosError.ERR_NETWORK];
+export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT, AxiosError.ERR_NETWORK];
 
 export const PIPELINE_TOOL_VERIFY_ERROR_CASE_TEXT_MAPPING: { [key: string]: string } = {
   '401': 'Token is incorrect!',

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -211,7 +211,10 @@ export const REPORT_PAGE = {
   },
 };
 
-export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT, AxiosError.ERR_NETWORK];
+export const AXIOS_NETWORK_ERROR_CODES = [AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT, AxiosError.ERR_NETWORK];
+export enum HEARTBEAT_EXCEPTION_CODE {
+  TIMEOUT = 'HB_TIMEOUT',
+}
 
 export const PIPELINE_TOOL_VERIFY_ERROR_CASE_TEXT_MAPPING: { [key: string]: string } = {
   '401': 'Token is incorrect!',

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -1,3 +1,5 @@
+import { AxiosError } from 'axios';
+
 export const CALENDAR = {
   REGULAR: 'Regular Calendar(Weekend Considered)',
   CHINA: 'Calendar with Chinese Holiday',
@@ -208,6 +210,8 @@ export const REPORT_PAGE = {
     TITLE: 'DORA Metrics',
   },
 };
+
+export const HEARTBEAT_TIMEOUT_ERROR_CODES = [AxiosError.ERR_NETWORK, AxiosError.ECONNABORTED, AxiosError.ETIMEDOUT];
 
 export const PIPELINE_TOOL_VERIFY_ERROR_CASE_TEXT_MAPPING: { [key: string]: string } = {
   '401': 'Token is incorrect!',

--- a/frontend/src/exceptions/ExceptionType.ts
+++ b/frontend/src/exceptions/ExceptionType.ts
@@ -1,4 +1,4 @@
 export interface IHeartBeatException {
-  code?: number;
+  code?: number | string;
   message: string;
 }

--- a/frontend/src/exceptions/TimeoutException.ts
+++ b/frontend/src/exceptions/TimeoutException.ts
@@ -1,8 +1,8 @@
 import { IHeartBeatException } from '@src/exceptions/ExceptionType';
 
 export class TimeoutException extends Error implements IHeartBeatException {
-  code: number;
-  constructor(message: string, status: number) {
+  code: number | string;
+  constructor(message: string, status: number | string) {
     super(message);
     this.code = status;
   }


### PR DESCRIPTION
## Summary

1. 根据业务需求，我们将axios所体现的`超时`和`网络问题`都视为可以重试的情形，并提供了相应的UI；所以在基类HttpClient上对这些特殊的错误code做了处理，以便业务型的client总能拿到标准的输出。
2. 5系列的错误应直接将用户redirect到`/error-page`路由展示相应页面；目前做了一个比较粗糙的处理，如果希望利用router状态进行跳转（避免整个页面的重新加载，包括脚本，文档，css等），需要将router集成到store里，effort较大，需要新开一张卡track。

## Before

_Description_

## After

_Description_

## Note

_Null_
