### PR TITLE
ADM-fix: [frontend] fix: fix retry

### DIFF
--- a/frontend/src/containers/ReportStep/DoraMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/DoraMetrics/index.tsx
@@ -196,11 +196,11 @@ const DoraMetrics = ({
         ])}`
       : '';
 
-  const hasDoraError = !!(timeoutError || getErrorMessage4BuildKite() || getErrorMessage4Github());
+  const hasDoraError = !!(getErrorMessage4BuildKite() || getErrorMessage4Github());
 
   const shouldShowRetry = () => {
     const dataGetCompleted = doraReport?.sourceControlMetricsCompleted && doraReport?.pipelineMetricsCompleted;
-    return hasDoraError && dataGetCompleted;
+    return (hasDoraError && dataGetCompleted) || timeoutError;
   };
 
   const handleRetry = () => {
@@ -216,9 +216,11 @@ const DoraMetrics = ({
       <StyledMetricsSection>
         <StyledTitleWrapper>
           <ReportTitle title={REPORT_PAGE.DORA.TITLE} />
-          {!hasDoraError && (doraReport?.pipelineMetricsCompleted || doraReport?.sourceControlMetricsCompleted) && (
-            <StyledShowMore onClick={onShowDetail}>{SHOW_MORE}</StyledShowMore>
-          )}
+          {!hasDoraError &&
+            !timeoutError &&
+            (doraReport?.pipelineMetricsCompleted || doraReport?.sourceControlMetricsCompleted) && (
+              <StyledShowMore onClick={onShowDetail}>{SHOW_MORE}</StyledShowMore>
+            )}
           {shouldShowRetry() && <StyledRetry onClick={handleRetry}>{RETRY}</StyledRetry>}
         </StyledTitleWrapper>
         {shouldShowSourceControl && (


### PR DESCRIPTION
## Summary

前端错误处理重构以后，断网的情况会触发超时的 Error，对这种情况在 Dashboard 也展示 Retry 按钮

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
