### PR TITLE
ADM-734: [frontend] fix: set letters in board column to uppercase

### DIFF
--- a/frontend/__tests__/containers/MetricsStep/CycleTime.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/CycleTime.test.tsx
@@ -97,14 +97,14 @@ describe('CycleTime', () => {
     it('should show selectors title when render Crews component', () => {
       setup();
 
-      expect(screen.getByText('Analysis, In Dev, doing')).toBeInTheDocument();
-      expect(screen.getByText('Test')).toBeInTheDocument();
-      expect(screen.getByText('To do')).toBeInTheDocument();
+      expect(screen.getByText('ANALYSIS, IN DEV, DOING')).toBeInTheDocument();
+      expect(screen.getByText('TEST')).toBeInTheDocument();
+      expect(screen.getByText('TO DO')).toBeInTheDocument();
     });
 
     it('should always show board status column tooltip', async () => {
       setup();
-      userEvent.hover(screen.getByText('Analysis, In Dev, doing'));
+      userEvent.hover(screen.getByText('ANALYSIS, IN DEV, DOING'));
 
       await waitFor(() => {
         expect(screen.getByRole('tooltip', { name: 'Analysis, In Dev, doing' })).toBeVisible();
@@ -344,11 +344,11 @@ describe('CycleTime', () => {
     it('should show status mapping table when cycle time settings type by status', async () => {
       setup();
 
-      expect(screen.getByText('Analysis')).toBeInTheDocument();
-      expect(screen.getByText('In Dev')).toBeInTheDocument();
-      expect(screen.getByText('doing')).toBeInTheDocument();
-      expect(screen.getByText('Test')).toBeInTheDocument();
-      expect(screen.getByText('To do')).toBeInTheDocument();
+      expect(screen.getByText('ANALYSIS')).toBeInTheDocument();
+      expect(screen.getByText('IN DEV')).toBeInTheDocument();
+      expect(screen.getAllByText('DOING')[0]).toBeInTheDocument();
+      expect(screen.getByText('TEST')).toBeInTheDocument();
+      expect(screen.getByText('TO DO')).toBeInTheDocument();
     });
 
     it('should show selected option when click the dropDown button ', async () => {

--- a/frontend/src/containers/MetricsStep/CycleTime/Table/index.tsx
+++ b/frontend/src/containers/MetricsStep/CycleTime/Table/index.tsx
@@ -116,10 +116,10 @@ const CycleTimeTable = () => {
           <TableBody>
             {data.map(([boardKey, boardSupplement, state], index) => (
               <TableRow hover key={index}>
-                <StyledTableRowCell>{boardKey}</StyledTableRowCell>
+                <StyledTableRowCell>{boardKey.toUpperCase()}</StyledTableRowCell>
                 <StyledTableRowCell>
                   <Tooltip title={boardSupplement} arrow>
-                    <EllipsisText fitContent>{boardSupplement}</EllipsisText>
+                    <EllipsisText fitContent>{boardSupplement.toUpperCase()}</EllipsisText>
                   </Tooltip>
                 </StyledTableRowCell>
                 <StyledTableRowCell>


### PR DESCRIPTION
## Summary

In cycle time setting table, the letters in board column are not capitalized which is not matched the Jira board column, so we need to fix it. [JIRA](https://dorametrics.atlassian.net/browse/ADM-734?atlOrigin=eyJpIjoiNDk1MWNiOWZhZDFmNGNjMzgyNTBkNjVkNWE5M2I0NDEiLCJwIjoiaiJ9)
...

## Before

The letters in board column are not capitalized.

**Screenshots**
<img width="1231" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/d33b544a-6a9f-4f95-8b1b-d22b2786759f">


## After

The letters in board column are capitalized.

**Screenshots**
<img width="1225" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/19996581-6e34-49e7-896a-415a6b59d3c9">

## Note

_Null_
