### PR TITLE
[ADM-766][Backend] fix formula of ChangeFailureRate

### DIFF
--- a/backend/src/main/java/heartbeat/service/report/calculator/ChangeFailureRateCalculator.java
+++ b/backend/src/main/java/heartbeat/service/report/calculator/ChangeFailureRateCalculator.java
@@ -27,8 +27,11 @@ public class ChangeFailureRateCalculator {
 
 		List<ChangeFailureRateOfPipeline> changeFailureRateOfPipelines = deployTimesList.stream().map(item -> {
 			int failedTimesOfPipeline = item.getFailed().size();
-			int passedTimesOfPipeline = item.getPassed().size();
-			int totalTimesOfPipeline = failedTimesOfPipeline + passedTimesOfPipeline;
+			int validPassedTimesOfPipeline = (int) item.getPassed()
+				.stream()
+				.filter(deployInfo -> item.getPipelineStep().equals(deployInfo.getJobName()))
+				.count();
+			int totalTimesOfPipeline = failedTimesOfPipeline + validPassedTimesOfPipeline;
 
 			float failureRateOfPipeline = totalTimesOfPipeline == 0 ? 0
 					: (float) failedTimesOfPipeline / totalTimesOfPipeline;

--- a/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
@@ -687,7 +687,7 @@ class GenerateReporterServiceTest {
 		}
 
 		@Test
-		void shouldReturnCompletedNullGivenMetricsDataCompletedNullWhenGetDataFromCache() {
+		void shouldReturnMetricsCompletedStatusIsNullWhenAsyncMetricsStatusIsNull() {
 			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId)).thenReturn(null);

--- a/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
@@ -4,7 +4,6 @@ import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
 import heartbeat.controller.report.dto.response.ChangeFailureRate;
 import heartbeat.service.pipeline.buildkite.builder.DeployTimesBuilder;
-import heartbeat.service.report.calculator.ChangeFailureRateCalculator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,13 +28,19 @@ class CalculateChangeFailureRateTest {
 
 	private static final String FAILED_STATE = "failed";
 
+	private static final String JOB_NAME_EQUALS_PIPELINE_STEP = "xx";
+
 	@InjectMocks
 	private ChangeFailureRateCalculator changeFailureRate;
 
 	@Test
 	public void testCalculateChangeFailureRate() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(DeployInfo.builder().jobFinishTime(JOB_FINISH_TIME_2023).state(PASSED_STATE).build()))
+			.withPassed(List.of(DeployInfo.builder()
+				.jobFinishTime(JOB_FINISH_TIME_2023)
+				.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
+				.state(PASSED_STATE)
+				.build()))
 			.withFailed(List.of(DeployInfo.builder().jobFinishTime(JOB_FINISH_TIME_2022).state(FAILED_STATE).build()))
 			.build();
 

--- a/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
@@ -35,18 +35,16 @@ class CalculateChangeFailureRateTest {
 	@Test
 	public void testCalculateChangeFailureRate() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(DeployInfoBuilder.withDefault()
-				.withJobName(OTHER_JOB_NAME)
-				.withJobFinishTime(JOB_FINISH_TIME_2023)
-				.build(), DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
+			.withPassed(List.of(DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build(),
+					DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
 			.withFailed(List.of(DeployInfo.builder().jobFinishTime(JOB_FINISH_TIME_2022).state(FAILED_STATE).build()))
 			.build();
 
 		ChangeFailureRate changeFailureRate = this.changeFailureRate.calculate(List.of(mockedDeployTimes));
 
-		assertThat(changeFailureRate.getAvgChangeFailureRate().getFailureRate()).isEqualTo(0.5F);
+		assertThat(changeFailureRate.getAvgChangeFailureRate().getFailureRate()).isEqualTo(0.3333F);
 		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalFailedTimes()).isEqualTo(1);
-		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalTimes()).isEqualTo(2);
+		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalTimes()).isEqualTo(3);
 	}
 
 	@Test
@@ -61,6 +59,23 @@ class CalculateChangeFailureRateTest {
 		assertThat(changeFailureRate.getAvgChangeFailureRate().getFailureRate()).isEqualTo(0.0F);
 		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalFailedTimes()).isEqualTo(0);
 		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalTimes()).isEqualTo(0);
+	}
+
+	@Test
+	public void testCalculateChangeFailureRateWhenHavePassedDeployInfoWhoseJobNameIsNotEqualToPipelineStep() {
+		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
+			.withPassed(List.of(DeployInfoBuilder.withDefault()
+				.withJobName(OTHER_JOB_NAME)
+				.withJobFinishTime(JOB_FINISH_TIME_2023)
+				.build(), DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
+			.withFailed(List.of(DeployInfo.builder().jobFinishTime(JOB_FINISH_TIME_2022).state(FAILED_STATE).build()))
+			.build();
+
+		ChangeFailureRate changeFailureRate = this.changeFailureRate.calculate(List.of(mockedDeployTimes));
+
+		assertThat(changeFailureRate.getAvgChangeFailureRate().getFailureRate()).isEqualTo(0.5F);
+		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalFailedTimes()).isEqualTo(1);
+		assertThat(changeFailureRate.getAvgChangeFailureRate().getTotalTimes()).isEqualTo(2);
 	}
 
 }

--- a/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/CalculateChangeFailureRateTest.java
@@ -3,6 +3,7 @@ package heartbeat.service.report.calculator;
 import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
 import heartbeat.controller.report.dto.response.ChangeFailureRate;
+import heartbeat.service.pipeline.buildkite.builder.DeployInfoBuilder;
 import heartbeat.service.pipeline.buildkite.builder.DeployTimesBuilder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,11 +25,9 @@ class CalculateChangeFailureRateTest {
 
 	private static final String JOB_FINISH_TIME_2023 = "2023-09-08T22:45:33.981Z";
 
-	private static final String PASSED_STATE = "passed";
-
 	private static final String FAILED_STATE = "failed";
 
-	private static final String JOB_NAME_EQUALS_PIPELINE_STEP = "xx";
+	private static final String OTHER_JOB_NAME = "JobName";
 
 	@InjectMocks
 	private ChangeFailureRateCalculator changeFailureRate;
@@ -36,11 +35,10 @@ class CalculateChangeFailureRateTest {
 	@Test
 	public void testCalculateChangeFailureRate() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(DeployInfo.builder()
-				.jobFinishTime(JOB_FINISH_TIME_2023)
-				.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-				.state(PASSED_STATE)
-				.build()))
+			.withPassed(List.of(DeployInfoBuilder.withDefault()
+				.withJobName(OTHER_JOB_NAME)
+				.withJobFinishTime(JOB_FINISH_TIME_2023)
+				.build(), DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
 			.withFailed(List.of(DeployInfo.builder().jobFinishTime(JOB_FINISH_TIME_2022).state(FAILED_STATE).build()))
 			.build();
 

--- a/backend/src/test/java/heartbeat/service/report/calculator/CalculateDeploymentFrequencyTest.java
+++ b/backend/src/test/java/heartbeat/service/report/calculator/CalculateDeploymentFrequencyTest.java
@@ -1,9 +1,9 @@
 package heartbeat.service.report.calculator;
 
-import heartbeat.client.dto.pipeline.buildkite.DeployInfo;
 import heartbeat.client.dto.pipeline.buildkite.DeployTimes;
 import heartbeat.controller.report.dto.response.AvgDeploymentFrequency;
 import heartbeat.controller.report.dto.response.DeploymentFrequency;
+import heartbeat.service.pipeline.buildkite.builder.DeployInfoBuilder;
 import heartbeat.service.pipeline.buildkite.builder.DeployTimesBuilder;
 import heartbeat.service.report.WorkDay;
 import org.junit.jupiter.api.Test;
@@ -29,15 +29,11 @@ class CalculateDeploymentFrequencyTest {
 
 	private static final String JOB_FINISH_TIME_2023 = "2023-09-08T22:45:33.981Z";
 
-	private static final String PASSED_STATE = "passed";
-
 	private static final String START_TIME = "0000000000000";
 
 	private static final String END_TIME = "1662739199000";
 
-	private static final String JOB_NAME_EQUALS_PIPELINE_STEP = "xx";
-
-	private static final String OTHER_JOB_NAME = "yy";
+	private static final String OTHER_JOB_NAME = "JobName";
 
 	@InjectMocks
 	private DeploymentFrequencyCalculator deploymentFrequency;
@@ -48,22 +44,12 @@ class CalculateDeploymentFrequencyTest {
 	@Test
 	public void testCalculateDeploymentFrequency() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2022)
-						.state(PASSED_STATE)
-						.build(),
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2023)
-						.state(PASSED_STATE)
-						.build()))
+			.withPassed(List.of(DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2022).build(),
+					DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
 			.build();
 		DeploymentFrequency expectedDeploymentFrequency = DeploymentFrequency.builder()
 			.avgDeploymentFrequency(AvgDeploymentFrequency.builder().deploymentFrequency(0.2F).build())
 			.build();
-
 		when(workDay.calculateWorkDaysBetween(anyLong(), anyLong())).thenReturn(10);
 
 		DeploymentFrequency deploymentFrequency = this.deploymentFrequency.calculate(List.of(mockedDeployTimes),
@@ -76,16 +62,11 @@ class CalculateDeploymentFrequencyTest {
 	@Test
 	public void testCalculateDeploymentFrequencyWhenWorkDayIsZero() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(DeployInfo.builder()
-				.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-				.jobFinishTime(JOB_FINISH_TIME_2022)
-				.state(PASSED_STATE)
-				.build()))
+			.withPassed(List.of(DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2022).build()))
 			.build();
 		DeploymentFrequency expectedDeploymentFrequency = DeploymentFrequency.builder()
 			.avgDeploymentFrequency(AvgDeploymentFrequency.builder().deploymentFrequency(0.0F).build())
 			.build();
-
 		when(workDay.calculateWorkDaysBetween(anyLong(), anyLong())).thenReturn(0);
 
 		DeploymentFrequency deploymentFrequency = this.deploymentFrequency.calculate(List.of(mockedDeployTimes),
@@ -101,7 +82,6 @@ class CalculateDeploymentFrequencyTest {
 		DeploymentFrequency expectedDeploymentFrequency = DeploymentFrequency.builder()
 			.avgDeploymentFrequency(AvgDeploymentFrequency.builder().deploymentFrequency(0.0F).build())
 			.build();
-
 		when(workDay.calculateWorkDaysBetween(anyLong(), anyLong())).thenReturn(10);
 
 		DeploymentFrequency deploymentFrequency = this.deploymentFrequency.calculate(List.of(mockedDeployTimes),
@@ -114,22 +94,12 @@ class CalculateDeploymentFrequencyTest {
 	@Test
 	public void testCalculateDeploymentFrequencyWhenHaveTwoDeployInfo() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2022)
-						.state(PASSED_STATE)
-						.build(),
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2022)
-						.state(PASSED_STATE)
-						.build()))
+			.withPassed(List.of(DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2022).build(),
+					DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2022).build()))
 			.build();
 		DeploymentFrequency expectedDeploymentFrequency = DeploymentFrequency.builder()
 			.avgDeploymentFrequency(AvgDeploymentFrequency.builder().deploymentFrequency(0.2F).build())
 			.build();
-
 		when(workDay.calculateWorkDaysBetween(anyLong(), anyLong())).thenReturn(10);
 
 		DeploymentFrequency deploymentFrequency = this.deploymentFrequency.calculate(List.of(mockedDeployTimes),
@@ -156,27 +126,16 @@ class CalculateDeploymentFrequencyTest {
 	@Test
 	public void testCalculateDeploymentFrequencyWhenHaveDeployInfoWhoseJobNameIsNotEqualToPipelineStep() {
 		DeployTimes mockedDeployTimes = DeployTimesBuilder.withDefault()
-			.withPassed(List.of(
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2022)
-						.state(PASSED_STATE)
+			.withPassed(List.of(DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2022).build(),
+					DeployInfoBuilder.withDefault()
+						.withJobName(OTHER_JOB_NAME)
+						.withJobFinishTime(JOB_FINISH_TIME_2022)
 						.build(),
-					DeployInfo.builder()
-						.jobName(OTHER_JOB_NAME)
-						.jobFinishTime(JOB_FINISH_TIME_2022)
-						.state(PASSED_STATE)
-						.build(),
-					DeployInfo.builder()
-						.jobName(JOB_NAME_EQUALS_PIPELINE_STEP)
-						.jobFinishTime(JOB_FINISH_TIME_2023)
-						.state(PASSED_STATE)
-						.build()))
+					DeployInfoBuilder.withDefault().withJobFinishTime(JOB_FINISH_TIME_2023).build()))
 			.build();
 		DeploymentFrequency expectedDeploymentFrequency = DeploymentFrequency.builder()
 			.avgDeploymentFrequency(AvgDeploymentFrequency.builder().deploymentFrequency(0.2F).build())
 			.build();
-
 		when(workDay.calculateWorkDaysBetween(anyLong(), anyLong())).thenReturn(10);
 
 		DeploymentFrequency deploymentFrequency = this.deploymentFrequency.calculate(List.of(mockedDeployTimes),

--- a/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
@@ -100,21 +100,21 @@ class GithubServiceTest {
 		deployTimes = List.of(DeployTimes.builder()
 			.pipelineId("fs-platform-onboarding")
 			.pipelineName("Name")
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.passed(List.of(DeployInfo.builder()
-				.jobName("Step")
+				.jobName("FakeName")
 				.pipelineCreateTime("2022-07-23T04:05:00.000+00:00")
 				.jobStartTime("2022-07-23T04:04:00.000+00:00")
 				.jobFinishTime("2022-07-23T04:06:00.000+00:00")
 				.commitId("111")
 				.state("passed")
-				.jobName("Step")
+				.jobName("FakeName")
 				.build()))
 			.build());
 
 		pipelineLeadTimes = List.of(PipelineLeadTime.builder()
 			.pipelineName("Name")
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
 				.prCreatedTime(1658548980000L)
@@ -321,7 +321,7 @@ class GithubServiceTest {
 	void shouldReturnEmptyMergeLeadTimeWhenPullRequestInfoIsEmpty() {
 		String mockToken = "mockToken";
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -345,7 +345,7 @@ class GithubServiceTest {
 	void shouldReturnEmptyMergeLeadTimeWhenPullRequestInfoGot404Error() {
 		String mockToken = "mockToken";
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -370,7 +370,7 @@ class GithubServiceTest {
 		String mockToken = "mockToken";
 		pullRequestInfo.setMergedAt(null);
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -482,7 +482,7 @@ class GithubServiceTest {
 			.build();
 		pipelineLeadTimes = List.of(PipelineLeadTime.builder()
 			.pipelineName("Name")
-			.pipelineStep("Step")
+			.pipelineStep("FakeName")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
 				.jobFinishTime(1658549160000L)

--- a/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/source/github/GithubServiceTest.java
@@ -48,6 +48,10 @@ import java.util.concurrent.CompletionException;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class GithubServiceTest {
 
+	public static final String PIPELINE_STEP = "FakeName";
+
+	private static final String JOB_NAME = PIPELINE_STEP;
+
 	@Mock
 	GitHubFeignClient gitHubFeignClient;
 
@@ -100,21 +104,21 @@ class GithubServiceTest {
 		deployTimes = List.of(DeployTimes.builder()
 			.pipelineId("fs-platform-onboarding")
 			.pipelineName("Name")
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.passed(List.of(DeployInfo.builder()
-				.jobName("FakeName")
+				.jobName(JOB_NAME)
 				.pipelineCreateTime("2022-07-23T04:05:00.000+00:00")
 				.jobStartTime("2022-07-23T04:04:00.000+00:00")
 				.jobFinishTime("2022-07-23T04:06:00.000+00:00")
 				.commitId("111")
 				.state("passed")
-				.jobName("FakeName")
+				.jobName(JOB_NAME)
 				.build()))
 			.build());
 
 		pipelineLeadTimes = List.of(PipelineLeadTime.builder()
 			.pipelineName("Name")
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
 				.prCreatedTime(1658548980000L)
@@ -321,7 +325,7 @@ class GithubServiceTest {
 	void shouldReturnEmptyMergeLeadTimeWhenPullRequestInfoIsEmpty() {
 		String mockToken = "mockToken";
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -345,7 +349,7 @@ class GithubServiceTest {
 	void shouldReturnEmptyMergeLeadTimeWhenPullRequestInfoGot404Error() {
 		String mockToken = "mockToken";
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -370,7 +374,7 @@ class GithubServiceTest {
 		String mockToken = "mockToken";
 		pullRequestInfo.setMergedAt(null);
 		List<PipelineLeadTime> expect = List.of(PipelineLeadTime.builder()
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.pipelineName("Name")
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
@@ -482,7 +486,7 @@ class GithubServiceTest {
 			.build();
 		pipelineLeadTimes = List.of(PipelineLeadTime.builder()
 			.pipelineName("Name")
-			.pipelineStep("FakeName")
+			.pipelineStep(PIPELINE_STEP)
 			.leadTimes(List.of(LeadTime.builder()
 				.commitId("111")
 				.jobFinishTime(1658549160000L)

--- a/frontend/cypress/e2e/createANewProject.cy.ts
+++ b/frontend/cypress/e2e/createANewProject.cy.ts
@@ -25,7 +25,7 @@ const leadTimeForChangeData = [
   { label: 'Total Lead Time(Hours)', value: '-65.70' },
 ];
 
-const changeFailureRateData = [{ label: 'Failure Rate', value: '42.67' }];
+const changeFailureRateData = [{ label: 'Failure Rate', value: '91.43' }];
 
 const metricsTextList = [
   'Board configuration',


### PR DESCRIPTION
## Summary

After discussion, we have decided to modify the formula of ChangeFailureRate. The formula now excludes passed builds that haven't reached the final step.

## Before

The formula includes passed builds that haven't reached the final step.

**Screenshots**
<img width="1273" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/4966fa1a-31a3-4ca7-bcfb-5566a36ef0cc">

## After

The formula now excludes passed builds that haven't reached the final step.

**Screenshots**
<img width="1287" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/3cb09eb6-6743-4f36-b0cb-26e83b3011df">

## Note

_Null_
