### PR TITLE
[ADM-783][Frontend] Keep user's input for board/pipeline/source control of config page

### DIFF
--- a/frontend/__tests__/containers/ConfigStep/Board.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/Board.test.tsx
@@ -81,7 +81,7 @@ describe('Board', () => {
 
   it('should show detail options when click board field', async () => {
     setup();
-    await userEvent.click(screen.getByRole('button', { name: /board jira/i }));
+    await userEvent.click(screen.getByRole('button', { name: CONFIG_TITLE.BOARD }));
     const listBox = within(screen.getByRole('listbox'));
     const options = listBox.getAllByRole('option');
     const optionValue = options.map((li) => li.getAttribute('data-value'));
@@ -91,7 +91,7 @@ describe('Board', () => {
 
   it('should show board type when select board field value ', async () => {
     setup();
-    await userEvent.click(screen.getByRole('button', { name: /board jira/i }));
+    await userEvent.click(screen.getByRole('button', { name: CONFIG_TITLE.BOARD }));
 
     await waitFor(() => {
       expect(screen.getByRole('option', { name: /jira/i })).toBeInTheDocument();
@@ -163,7 +163,7 @@ describe('Board', () => {
     await userEvent.click(screen.getByRole('option', { name: /jira/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: /board jira/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: CONFIG_TITLE.BOARD })).toBeInTheDocument();
     });
   });
 
@@ -203,7 +203,7 @@ describe('Board', () => {
     });
   });
 
-  it('should check error notification show and disappear when board verify response status is 401', async () => {
+  it('should show error message when board verify response status is 401', async () => {
     server.use(rest.post(MOCK_BOARD_URL_FOR_JIRA, (_, res, ctx) => res(ctx.status(HttpStatusCode.Unauthorized))));
     setup();
     await fillBoardFieldsInformation();
@@ -211,7 +211,9 @@ describe('Board', () => {
     await userEvent.click(screen.getByRole('button', { name: /verify/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/email is incorrect/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Token is invalid, please change your token with correct access permission!/i),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -138,6 +138,24 @@ describe('PipelineTool', () => {
     expect(getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
   });
 
+  it('should not show error message when field does not trigger any event given an empty value', () => {
+    setup();
+
+    screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement;
+
+    expect(screen.queryByText(TOKEN_ERROR_MESSAGE[1])).not.toBeInTheDocument();
+  });
+
+  it('should show error message when focus on field given an empty value', () => {
+    setup();
+
+    const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement;
+    fireEvent.focus(tokenInput, { target: { value: '' } });
+
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument();
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
+  });
+
   it('should show error message and error style when token is invalid', async () => {
     const { getByText } = setup();
     const mockInfo = 'mockToken';

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -141,16 +141,13 @@ describe('PipelineTool', () => {
   it('should not show error message when field does not trigger any event given an empty value', () => {
     setup();
 
-    screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement;
-
     expect(screen.queryByText(TOKEN_ERROR_MESSAGE[1])).not.toBeInTheDocument();
   });
 
   it('should show error message when focus on field given an empty value', () => {
     setup();
 
-    const tokenInput = screen.getByTestId('pipelineToolTextField').querySelector('input') as HTMLInputElement;
-    fireEvent.focus(tokenInput, { target: { value: '' } });
+    fireEvent.focus(screen.getByLabelText('input Token'));
 
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument();
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);

--- a/frontend/__tests__/containers/ConfigStep/SourceControl.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/SourceControl.test.tsx
@@ -125,6 +125,24 @@ describe('SourceControl', () => {
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
   });
 
+  it('should not show error message when field does not trigger any event given an empty value', () => {
+    setup();
+
+    screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement;
+
+    expect(screen.queryByText(TOKEN_ERROR_MESSAGE[1])).not.toBeInTheDocument();
+  });
+
+  it('should show error message when focus on field given an empty value', () => {
+    setup();
+
+    const tokenInput = screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement;
+    fireEvent.focus(tokenInput, { target: { value: '' } });
+
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument();
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
+  });
+
   it('should show error message and error style when token is invalid', () => {
     setup();
     const mockInfo = 'mockToken';

--- a/frontend/__tests__/containers/ConfigStep/SourceControl.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/SourceControl.test.tsx
@@ -128,16 +128,13 @@ describe('SourceControl', () => {
   it('should not show error message when field does not trigger any event given an empty value', () => {
     setup();
 
-    screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement;
-
     expect(screen.queryByText(TOKEN_ERROR_MESSAGE[1])).not.toBeInTheDocument();
   });
 
   it('should show error message when focus on field given an empty value', () => {
     setup();
 
-    const tokenInput = screen.getByTestId('sourceControlTextField').querySelector('input') as HTMLInputElement;
-    fireEvent.focus(tokenInput, { target: { value: '' } });
+    fireEvent.focus(screen.getByLabelText('input Token'));
 
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument();
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);

--- a/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
+++ b/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
@@ -106,8 +106,6 @@ describe('use verify board state', () => {
 
     await waitFor(() => {
       const boardId = result.current.fields.find((field) => field.key === 'Board Id');
-
-      expect(boardId?.validatedError).toBe('');
       expect(boardId?.verifiedError).toBe('Board Id is incorrect!');
     });
   });

--- a/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
+++ b/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
@@ -1,4 +1,4 @@
-import { useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect';
+import { useVerifyBoardEffect, useVerifyBoardStateInterface } from '@src/hooks/useVerifyBoardEffect';
 import { MOCK_BOARD_URL_FOR_JIRA, FAKE_TOKEN } from '@test/fixtures';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { setupServer } from 'msw/node';
@@ -15,19 +15,18 @@ jest.mock('react-redux', () => ({
 
 jest.mock('@src/hooks/useAppDispatch', () => ({
   useAppSelector: () => ({ type: BOARD_TYPES.JIRA }),
+  useAppDispatch: jest.fn(() => jest.fn()),
 }));
 
 const server = setupServer();
 
-const mockConfig = {
-  type: 'jira',
-  boardId: '1',
-  site: 'fake',
-  email: 'fake@fake.com',
-  token: FAKE_TOKEN,
-  startTime: null,
-  endTime: null,
+const updateFields = (result: { current: useVerifyBoardStateInterface }) => {
+  result.current.updateField('Board Id', '1');
+  result.current.updateField('Email', 'fake@qq.com');
+  result.current.updateField('Site', 'fake');
+  result.current.updateField('Token', FAKE_TOKEN);
 };
+
 describe('use verify board state', () => {
   beforeAll(() => server.listen());
   afterAll(() => {
@@ -38,24 +37,7 @@ describe('use verify board state', () => {
     const { result } = renderHook(() => useVerifyBoardEffect());
 
     expect(result.current.isLoading).toBe(false);
-    expect(result.current.formFields.length).toBe(5);
-  });
-
-  it('should got success callback when call verify function given success call', async () => {
-    server.use(
-      rest.post(MOCK_BOARD_URL_FOR_JIRA, (_, res, ctx) => {
-        return res(ctx.status(HttpStatusCode.Ok), ctx.json({ projectKey: 'FAKE' }));
-      }),
-    );
-
-    const { result } = renderHook(() => useVerifyBoardEffect());
-    const { verifyJira } = result.current;
-
-    const callback = await verifyJira(mockConfig);
-
-    await waitFor(() => {
-      expect(callback.response.projectKey).toEqual('FAKE');
-    });
+    expect(result.current.fields.length).toBe(5);
   });
 
   it('should got email and token fields error message when call verify function given a invalid token', async () => {
@@ -67,14 +49,11 @@ describe('use verify board state', () => {
 
     const { result } = renderHook(() => useVerifyBoardEffect());
     await act(() => {
-      result.current.verifyJira(mockConfig);
+      updateFields(result);
+      result.current.verifyJira();
     });
 
-    await waitFor(() => {
-      const emailFiled = result.current.formFields.find((field) => field.name === 'email');
-      expect(emailFiled?.errorMessage).toBe('Email is incorrect!');
-    });
-    const tokenField = result.current.formFields.find((field) => field.name === 'token');
+    const tokenField = result.current.fields.find((field) => field.key === 'Token');
     expect(tokenField?.errorMessage).toBe('Token is invalid, please change your token with correct access permission!');
   });
 
@@ -92,11 +71,12 @@ describe('use verify board state', () => {
 
     const { result } = renderHook(() => useVerifyBoardEffect());
     await act(() => {
-      result.current.verifyJira(mockConfig);
+      updateFields(result);
+      result.current.verifyJira();
     });
 
     await waitFor(() => {
-      const site = result.current.formFields.find((field) => field.name === 'site');
+      const site = result.current.fields.find((field) => field.key === 'Site');
 
       expect(site?.errorMessage).toBe('Site is incorrect!');
     });
@@ -116,11 +96,12 @@ describe('use verify board state', () => {
 
     const { result } = renderHook(() => useVerifyBoardEffect());
     await act(() => {
-      result.current.verifyJira(mockConfig);
+      updateFields(result);
+      result.current.verifyJira();
     });
 
     await waitFor(() => {
-      const boardId = result.current.formFields.find((field) => field.name === 'boardId');
+      const boardId = result.current.fields.find((field) => field.key === 'Board Id');
 
       expect(boardId?.errorMessage).toBe('Board Id is incorrect!');
     });

--- a/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
+++ b/frontend/__tests__/hooks/useVerifyBoardEffect.test.tsx
@@ -110,6 +110,23 @@ describe('use verify board state', () => {
     });
   });
 
+  it('should got token fields error message when call verify function given a unknown error', async () => {
+    server.use(
+      rest.post(MOCK_BOARD_URL_FOR_JIRA, (_, res, ctx) => {
+        return res(ctx.status(HttpStatusCode.ServiceUnavailable));
+      }),
+    );
+
+    const { result } = renderHook(() => useVerifyBoardEffect());
+    await act(() => {
+      updateFields(result);
+      result.current.verifyJira();
+    });
+
+    const tokenField = result.current.fields.find((field) => field.key === 'Token');
+    expect(tokenField?.verifiedError).toBe('Unknown error');
+  });
+
   it('should clear all verified error messages when update a verified error field', async () => {
     server.use(
       rest.post(MOCK_BOARD_URL_FOR_JIRA, (_, res, ctx) => {

--- a/frontend/__tests__/hooks/useVerifyPipelineToolEffect.test.tsx
+++ b/frontend/__tests__/hooks/useVerifyPipelineToolEffect.test.tsx
@@ -29,7 +29,7 @@ describe('use verify pipelineTool state', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual('');
+      expect(result.current.verifiedError).toEqual('');
       expect(result.current.isLoading).toEqual(false);
     });
   });
@@ -43,7 +43,7 @@ describe('use verify pipelineTool state', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual(`Token is incorrect!`);
+      expect(result.current.verifiedError).toEqual(`Token is incorrect!`);
     });
   });
 
@@ -56,15 +56,15 @@ describe('use verify pipelineTool state', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual(
+      expect(result.current.verifiedError).toEqual(
         'Forbidden request, please change your token with correct access permission.',
       );
     });
 
-    result.current.clearErrorMessage();
+    result.current.clearVerifiedError();
 
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual('');
+      expect(result.current.verifiedError).toEqual('');
     });
   });
 });

--- a/frontend/__tests__/hooks/useVerifySourceControlTokenEffect.test.tsx
+++ b/frontend/__tests__/hooks/useVerifySourceControlTokenEffect.test.tsx
@@ -40,7 +40,7 @@ describe('use verify sourceControl token', () => {
     await waitFor(() => {
       expect(result.current.isLoading).toEqual(false);
     });
-    await waitFor(() => expect(result.current.errorMessage).toBeUndefined());
+    await waitFor(() => expect(result.current.verifiedError).toBeUndefined());
   });
 
   it('should set error message when get verify sourceControl response status 401', async () => {
@@ -58,7 +58,7 @@ describe('use verify sourceControl token', () => {
       expect(result.current.isLoading).toEqual(false);
     });
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual(MOCK_SOURCE_CONTROL_VERIFY_ERROR_CASE_TEXT);
+      expect(result.current.verifiedError).toEqual(MOCK_SOURCE_CONTROL_VERIFY_ERROR_CASE_TEXT);
     });
   });
 
@@ -70,10 +70,10 @@ describe('use verify sourceControl token', () => {
     const { result } = setup();
 
     await act(() => result.current.verifyToken(MOCK_SOURCE_CONTROL_VERIFY_REQUEST_PARAMS));
-    await act(() => result.current.clearErrorMessage());
+    await act(() => result.current.clearVerifiedError());
 
     await waitFor(() => {
-      expect(result.current.errorMessage).toEqual('');
+      expect(result.current.verifiedError).toEqual('');
     });
   });
 });

--- a/frontend/cypress/e2e/createANewProject.cy.ts
+++ b/frontend/cypress/e2e/createANewProject.cy.ts
@@ -1,5 +1,5 @@
+import { GITHUB_TOKEN, PIPELINE_TOKEN } from '../fixtures/fixtures';
 import { TIPS } from '../../src/constants/resources';
-import { GITHUB_TOKEN } from '../fixtures/fixtures';
 import metricsPage from '../pages/metrics/metrics';
 import configPage from '../pages/metrics/config';
 import reportPage from '../pages/metrics/report';
@@ -40,8 +40,8 @@ const textInputValues = [
 
 const tokenInputValues = [
   { index: 0, value: 'mockToken' },
-  { index: 1, value: 'mock1234'.repeat(5) },
-  { index: 2, value: `${GITHUB_TOKEN}` },
+  { index: 1, value: PIPELINE_TOKEN },
+  { index: 2, value: GITHUB_TOKEN },
 ];
 
 const checkCycleTimeTooltip = () => {
@@ -121,9 +121,9 @@ describe('Create a new project', () => {
     configPage.getVerifiedButton(configPage.boardConfigSection).should('be.disabled');
     configPage.getResetButton(configPage.boardConfigSection).should('be.enabled');
 
-    configPage.fillPipelineToolFieldsInfoAndVerify('mock1234'.repeat(5));
+    configPage.fillPipelineToolFieldsInfoAndVerify(PIPELINE_TOKEN);
 
-    configPage.fillSourceControlFieldsInfoAndVerify(`${GITHUB_TOKEN}`);
+    configPage.fillSourceControlFieldsInfoAndVerify(GITHUB_TOKEN);
 
     configPage.nextStepButton.should('be.enabled');
 

--- a/frontend/cypress/e2e/importAProject.cy.ts
+++ b/frontend/cypress/e2e/importAProject.cy.ts
@@ -56,8 +56,8 @@ const textInputValues = [
 
 const tokenInputValues = [
   { index: 0, value: 'mockToken' },
-  { index: 1, value: `${PIPELINE_TOKEN}` },
-  { index: 2, value: `${GITHUB_TOKEN}` },
+  { index: 1, value: PIPELINE_TOKEN },
+  { index: 2, value: GITHUB_TOKEN },
 ];
 
 const checkFieldsExist = (fields: string[]) => {

--- a/frontend/cypress/e2e/importAProject.cy.ts
+++ b/frontend/cypress/e2e/importAProject.cy.ts
@@ -1,4 +1,4 @@
-import { GITHUB_TOKEN } from '../fixtures/fixtures';
+import { GITHUB_TOKEN, PIPELINE_TOKEN } from '../fixtures/fixtures';
 import metricsPage from '../pages/metrics/metrics';
 import { Metrics } from '../pages/metrics/metrics';
 import configPage from '../pages/metrics/config';
@@ -56,7 +56,7 @@ const textInputValues = [
 
 const tokenInputValues = [
   { index: 0, value: 'mockToken' },
-  { index: 1, value: 'mockToken' },
+  { index: 1, value: `${PIPELINE_TOKEN}` },
   { index: 2, value: `${GITHUB_TOKEN}` },
 ];
 
@@ -137,6 +137,7 @@ describe('Import project from file', () => {
     checkInputValue('.MuiInput-input', 'ConfigFileForImporting');
 
     cy.waitForNetworkIdle('@api', 2000);
+    configPage.pipelineToolTokenInput.type(PIPELINE_TOKEN);
     configPage.verifyAndClickNextToMetrics();
 
     configPage.goMetricsStep();
@@ -181,6 +182,7 @@ describe('Import project from file', () => {
     checkInputValue('.MuiInput-input', 'ConfigFileForImporting');
 
     cy.waitForNetworkIdle('@api', 2000);
+    configPage.pipelineToolTokenInput.type(PIPELINE_TOKEN);
     configPage.verifyAndClickNextToMetrics();
 
     configPage.goMetricsStep();

--- a/frontend/cypress/fixtures/NewConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/NewConfigFileForImporting.json
@@ -24,7 +24,7 @@
   "pipeline": "mockToken",
   "pipelineTool": {
     "type": "BuildKite",
-    "token": "mockToken"
+    "token": ""
   },
   "sourceControl": {
     "type": "GitHub",

--- a/frontend/cypress/fixtures/OldConfigFileForImporting.json
+++ b/frontend/cypress/fixtures/OldConfigFileForImporting.json
@@ -22,7 +22,7 @@
   "pipeline": "mockToken",
   "pipelineTool": {
     "type": "BuildKite",
-    "token": "mockToken"
+    "token": ""
   },
   "sourceControl": {
     "type": "GitHub",

--- a/frontend/cypress/fixtures/fixtures.ts
+++ b/frontend/cypress/fixtures/fixtures.ts
@@ -5,6 +5,8 @@ export const BOARD_PROJECT_KEY = 'mockProjectKey';
 
 export const GITHUB_TOKEN = `ghp_${'Abc123'.repeat(6)}`;
 
+export const PIPELINE_TOKEN = `bkua_${'Abc12'.repeat(8)}`;
+
 export enum METRICS_TITLE {
   VELOCITY = 'Velocity',
   CYCLE_TIME = 'Cycle Time',

--- a/frontend/src/constants/commons.ts
+++ b/frontend/src/constants/commons.ts
@@ -2,7 +2,7 @@ import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks
 
 export const PROJECT_NAME = 'Heartbeat';
 
-export const DEFAULT_HELPER_TEXT = ' ';
+export const DEFAULT_HELPER_TEXT = '';
 
 export const FIVE_HUNDRED = 500;
 

--- a/frontend/src/containers/ConfigStep/Board/index.tsx
+++ b/frontend/src/containers/ConfigStep/Board/index.tsx
@@ -17,7 +17,7 @@ import { FormEvent, useMemo } from 'react';
 
 export const Board = () => {
   const isVerified = useAppSelector(selectIsBoardVerified);
-  const { verifyJira, isLoading, fields, updateField, resetFields } = useVerifyBoardEffect();
+  const { verifyJira, isLoading, fields, updateField, validateField, resetFields } = useVerifyBoardEffect();
 
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -25,7 +25,7 @@ export const Board = () => {
   };
 
   const isDisableVerifyButton = useMemo(
-    () => isLoading || !fields.every((field) => !!field.value && !field.validatedError && !field.verifiedError),
+    () => isLoading || fields.some((field) => !field.value || field.validatedError || field.verifiedError),
     [fields, isLoading],
   );
 
@@ -54,8 +54,9 @@ export const Board = () => {
               label={key}
               variant='standard'
               value={value}
+              onFocus={() => validateField(key)}
               onChange={(e) => updateField(key, e.target.value)}
-              error={!value || !!validatedError || !!verifiedError}
+              error={!!validatedError || !!verifiedError}
               type={key === 'Token' ? 'password' : 'text'}
               helperText={validatedError || verifiedError}
               sx={{ gridColumn: `span ${col}` }}

--- a/frontend/src/containers/ConfigStep/Board/index.tsx
+++ b/frontend/src/containers/ConfigStep/Board/index.tsx
@@ -25,7 +25,7 @@ export const Board = () => {
   };
 
   const isDisableVerifyButton = useMemo(
-    () => isLoading || !fields.every((field) => !!field.value && !field.errorMessage),
+    () => isLoading || !fields.every((field) => !!field.value && !field.validatedError && !field.verifiedError),
     [fields, isLoading],
   );
 
@@ -34,7 +34,7 @@ export const Board = () => {
       {isLoading && <Loading />}
       <ConfigSelectionTitle>{CONFIG_TITLE.BOARD}</ConfigSelectionTitle>
       <StyledForm onSubmit={onSubmit} onReset={resetFields}>
-        {fields.map(({ key, value, errorMessage, col }, index) =>
+        {fields.map(({ key, value, validatedError, verifiedError, col }, index) =>
           !index ? (
             <StyledTypeSelections variant='standard' required key={index}>
               <InputLabel id='board-type-checkbox-label'>Board</InputLabel>
@@ -55,9 +55,9 @@ export const Board = () => {
               variant='standard'
               value={value}
               onChange={(e) => updateField(key, e.target.value)}
-              error={!value || !!errorMessage}
+              error={!value || !!validatedError || !!verifiedError}
               type={key === 'Token' ? 'password' : 'text'}
-              helperText={errorMessage}
+              helperText={validatedError || verifiedError}
               sx={{ gridColumn: `span ${col}` }}
             />
           ),

--- a/frontend/src/containers/ConfigStep/Board/index.tsx
+++ b/frontend/src/containers/ConfigStep/Board/index.tsx
@@ -5,11 +5,11 @@ import {
   StyledTextField,
   StyledTypeSelections,
 } from '@src/components/Common/ConfigForms';
+import { KEYS, useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect';
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons';
 import { InputLabel, ListItemText, MenuItem, Select } from '@mui/material';
 import { ConfigSelectionTitle } from '@src/containers/MetricsStep/style';
 import { selectIsBoardVerified } from '@src/context/config/configSlice';
-import { useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect';
 import { BOARD_TYPES, CONFIG_TITLE } from '@src/constants/resources';
 import { useAppSelector } from '@src/hooks/useAppDispatch';
 import { Loading } from '@src/components/Loading';
@@ -57,7 +57,7 @@ export const Board = () => {
               onFocus={() => validateField(key)}
               onChange={(e) => updateField(key, e.target.value)}
               error={!!validatedError || !!verifiedError}
-              type={key === 'Token' ? 'password' : 'text'}
+              type={key === KEYS.TOKEN ? 'password' : 'text'}
               helperText={validatedError || verifiedError}
               sx={{ gridColumn: `span ${col}` }}
             />

--- a/frontend/src/containers/ConfigStep/Board/index.tsx
+++ b/frontend/src/containers/ConfigStep/Board/index.tsx
@@ -5,115 +5,40 @@ import {
   StyledTextField,
   StyledTypeSelections,
 } from '@src/components/Common/ConfigForms';
-import {
-  selectDateRange,
-  selectIsBoardVerified,
-  updateBoard,
-  updateBoardVerifyState,
-} from '@src/context/config/configSlice';
-import { updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons';
-import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';
 import { InputLabel, ListItemText, MenuItem, Select } from '@mui/material';
 import { ConfigSelectionTitle } from '@src/containers/MetricsStep/style';
+import { selectIsBoardVerified } from '@src/context/config/configSlice';
 import { useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect';
 import { BOARD_TYPES, CONFIG_TITLE } from '@src/constants/resources';
-import { FormEvent, useEffect, useState } from 'react';
+import { useAppSelector } from '@src/hooks/useAppDispatch';
 import { Loading } from '@src/components/Loading';
-import dayjs from 'dayjs';
+import { FormEvent, useMemo } from 'react';
 
 export const Board = () => {
-  const dispatch = useAppDispatch();
   const isVerified = useAppSelector(selectIsBoardVerified);
-  const DateRange = useAppSelector(selectDateRange);
-  const {
-    verifyJira,
-    isLoading: verifyLoading,
-    formFields: fields,
-    updateField,
-    resetFormFields,
-  } = useVerifyBoardEffect();
-  const [isDisableVerifyButton, setIsDisableVerifyButton] = useState(
-    !fields.every((field) => field.value && field.isValid),
+  const { verifyJira, isLoading, fields, updateField, resetFields } = useVerifyBoardEffect();
+
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    await verifyJira();
+  };
+
+  const isDisableVerifyButton = useMemo(
+    () => isLoading || !fields.every((field) => !!field.value && !field.errorMessage),
+    [fields, isLoading],
   );
-
-  const initBoardFields = () => {
-    resetFormFields();
-    dispatch(updateBoardVerifyState(false));
-  };
-
-  useEffect(() => {
-    const invalidFields = fields.filter(({ value, isRequired, isValid }) => !value || !isRequired || !isValid);
-    setIsDisableVerifyButton(!!invalidFields.length);
-  }, [fields]);
-
-  const onFormUpdate = (name: string, value: string) => {
-    updateField(name, value);
-    dispatch(updateBoardVerifyState(false));
-  };
-
-  const updateBoardFields = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    dispatch(
-      updateBoard({
-        type: fields[0].value,
-        boardId: fields[1].value,
-        email: fields[2].value,
-        site: fields[3].value,
-        token: fields[4].value,
-      }),
-    );
-  };
-
-  const handleSubmitBoardFields = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    dispatch(updateTreatFlagCardAsBlock(true));
-    const params = {
-      type: fields[0].value,
-      boardId: fields[1].value,
-      email: fields[2].value,
-      site: fields[3].value,
-      token: fields[4].value,
-    };
-    await verifyJira({
-      ...params,
-      startTime: dayjs(DateRange.startDate).valueOf(),
-      endTime: dayjs(DateRange.endDate).valueOf(),
-    }).then((res) => {
-      if (res?.response) {
-        dispatch(updateBoardVerifyState(true));
-        dispatch(updateBoard({ ...params, projectKey: res.response.projectKey }));
-      }
-    });
-  };
-
-  const handleResetBoardFields = () => {
-    initBoardFields();
-    setIsDisableVerifyButton(true);
-    dispatch(updateBoardVerifyState(false));
-  };
 
   return (
     <ConfigSectionContainer aria-label='Board Config'>
-      {verifyLoading && <Loading />}
+      {isLoading && <Loading />}
       <ConfigSelectionTitle>{CONFIG_TITLE.BOARD}</ConfigSelectionTitle>
-      <StyledForm
-        onSubmit={(e) => handleSubmitBoardFields(e)}
-        onChange={(e) => updateBoardFields(e)}
-        onReset={handleResetBoardFields}
-      >
-        {fields.map((field, index) =>
+      <StyledForm onSubmit={onSubmit} onReset={resetFields}>
+        {fields.map(({ key, value, errorMessage, col }, index) =>
           !index ? (
             <StyledTypeSelections variant='standard' required key={index}>
               <InputLabel id='board-type-checkbox-label'>Board</InputLabel>
-              <Select
-                name={field.name}
-                labelId='board-type-checkbox-label'
-                value={field.value}
-                onChange={({ target: { name, value } }) => {
-                  onFormUpdate(name, value);
-                }}
-              >
+              <Select labelId='board-type-checkbox-label' value={value}>
                 {Object.values(BOARD_TYPES).map((data) => (
                   <MenuItem key={data} value={data}>
                     <ListItemText primary={data} />
@@ -123,33 +48,29 @@ export const Board = () => {
             </StyledTypeSelections>
           ) : (
             <StyledTextField
-              data-testid={field.key}
-              name={field.name}
+              data-testid={key}
               key={index}
               required
-              label={field.key}
+              label={key}
               variant='standard'
-              value={field.value}
-              onChange={({ target: { name, value } }) => {
-                onFormUpdate(name, value);
-              }}
-              error={!field.isRequired || !field.isValid}
-              type={field.key === 'Token' ? 'password' : 'text'}
-              helperText={field.errorMessage}
-              sx={{ gridColumn: `span ${field.col}` }}
+              value={value}
+              onChange={(e) => updateField(key, e.target.value)}
+              error={!value || !!errorMessage}
+              type={key === 'Token' ? 'password' : 'text'}
+              helperText={errorMessage}
+              sx={{ gridColumn: `span ${col}` }}
             />
           ),
         )}
         <StyledButtonGroup>
-          {isVerified && !verifyLoading ? (
+          {isVerified && !isLoading ? (
             <VerifyButton disabled>Verified</VerifyButton>
           ) : (
-            <VerifyButton type='submit' disabled={isDisableVerifyButton || verifyLoading}>
+            <VerifyButton type='submit' disabled={isDisableVerifyButton}>
               Verify
             </VerifyButton>
           )}
-
-          {isVerified && !verifyLoading && <ResetButton type='reset'>Reset</ResetButton>}
+          {isVerified && !isLoading && <ResetButton type='reset'>Reset</ResetButton>}
         </StyledButtonGroup>
       </StyledForm>
     </ConfigSectionContainer>

--- a/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
@@ -13,13 +13,13 @@ import {
 } from '@src/context/config/configSlice';
 import { CONFIG_TITLE, PIPELINE_TOOL_TYPES, TOKEN_HELPER_TEXT } from '@src/constants/resources';
 import { useVerifyPipelineToolEffect } from '@src/hooks/useVerifyPipelineToolEffect';
-import { DEFAULT_HELPER_TEXT, EMPTY_STRING, ZERO } from '@src/constants/commons';
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons';
 import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';
+import { DEFAULT_HELPER_TEXT, EMPTY_STRING } from '@src/constants/commons';
 import { InputLabel, ListItemText, MenuItem, Select } from '@mui/material';
 import { ConfigSelectionTitle } from '@src/containers/MetricsStep/style';
-import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { findCaseInsensitiveType } from '@src/utils/util';
+import { FormEvent, useEffect, useState } from 'react';
 import { Loading } from '@src/components/Loading';
 import { REGEX } from '@src/constants/regex';
 
@@ -29,66 +29,28 @@ export const PipelineTool = () => {
   const isVerified = useAppSelector(isPipelineToolVerified);
   const { verifyPipelineTool, isLoading, errorMessage, clearErrorMessage } = useVerifyPipelineToolEffect();
   const type = findCaseInsensitiveType(Object.values(PIPELINE_TOOL_TYPES), pipelineToolFields.type);
-  const FIELDS_LIST = useMemo(() => {
-    return [
-      {
-        key: 'PipelineTool',
-        value: type,
-        isValid: true,
-        isRequired: true,
-      },
-      {
-        key: 'Token',
-        value: pipelineToolFields.token,
-        isValid: true,
-        isRequired: true,
-      },
-    ];
-  }, [type, pipelineToolFields]);
-  const [fields, setFields] = useState(FIELDS_LIST);
-  const [isDisableVerifyButton, setIsDisableVerifyButton] = useState(!(fields[1].isValid && fields[1].value));
-
-  const initPipeLineFields = () => {
-    const newFields = fields.map((field, index) => {
-      field.value = !index ? PIPELINE_TOOL_TYPES.BUILD_KITE : EMPTY_STRING;
-      return field;
-    });
-    setFields(newFields);
-    dispatch(updatePipelineToolVerifyState(false));
-  };
+  const [fields, setFields] = useState([
+    {
+      key: 'PipelineTool',
+      value: type,
+      isValid: true,
+    },
+    {
+      key: 'Token',
+      value: pipelineToolFields.token,
+      isValid: true,
+    },
+  ]);
+  const [isDisableVerifyButton, setIsDisableVerifyButton] = useState(true);
 
   useEffect(() => {
-    const isFieldValid = (field: { key: string; value: string; isRequired: boolean; isValid: boolean }) =>
-      field.isRequired && field.isValid && !!field.value;
-
-    const isAllFieldsValid = (fields: { key: string; value: string; isRequired: boolean; isValid: boolean }[]) =>
-      fields.every((field) => isFieldValid(field));
+    const isAllFieldsValid = (fields: { key: string; value: string; isValid: boolean }[]) =>
+      fields.every((field) => field.isValid && !!field.value && !errorMessage);
     setIsDisableVerifyButton(!isAllFieldsValid(fields));
-  }, [fields]);
+  }, [clearErrorMessage, errorMessage, fields]);
 
-  useEffect(() => {
-    if (errorMessage) {
-      const newFields = FIELDS_LIST.map((field, index) => (index ? { ...field, isValid: false } : { ...field }));
-      setFields(newFields);
-    }
-  }, [errorMessage, FIELDS_LIST]);
-
-  const onFormUpdate = (index: number, value: string) => {
-    clearErrorMessage();
-    const newFieldsValue = fields.map((field, fieldIndex) => {
-      if (!index) {
-        field.value = !fieldIndex ? value : EMPTY_STRING;
-      } else if (!!index && !!fieldIndex) {
-        return {
-          ...field,
-          value,
-          isRequired: !!value,
-          isValid: REGEX.BUILDKITE_TOKEN.test(value),
-        };
-      }
-      return field;
-    });
-    setFields(newFieldsValue);
+  const handleUpdate = (fields: { key: string; value: string; isValid: boolean }[]) => {
+    setFields(fields);
     dispatch(updatePipelineToolVerifyState(false));
     dispatch(
       updatePipelineTool({
@@ -98,62 +60,73 @@ export const PipelineTool = () => {
     );
   };
 
+  const onSelectUpdate = (value: string) => {
+    clearErrorMessage();
+    const newFields = fields.map(({ key }, index) => ({
+      key,
+      value: index === 0 ? value : EMPTY_STRING,
+      isValid: true,
+    }));
+    handleUpdate(newFields);
+  };
+
+  const onInputUpdate = (value: string) => {
+    clearErrorMessage();
+    const newFields = fields.map((field, index) =>
+      index === 0
+        ? field
+        : {
+            key: field.key,
+            value: value.trim(),
+            isValid: REGEX.BUILDKITE_TOKEN.test(value.trim()),
+          },
+    );
+    handleUpdate(newFields);
+  };
+
   const updateFieldHelpText = () => {
-    const { isRequired, isValid } = fields[1];
-    if (!isRequired) {
+    const { value, isValid } = fields[1];
+    if (!value) {
       return TOKEN_HELPER_TEXT.RequiredTokenText;
     }
-    if (!isValid) {
-      if (!errorMessage) {
-        return TOKEN_HELPER_TEXT.InvalidTokenText;
-      }
+    if (errorMessage) {
       return errorMessage;
+    }
+    if (!isValid) {
+      return TOKEN_HELPER_TEXT.InvalidTokenText;
     }
     return DEFAULT_HELPER_TEXT;
   };
 
-  const updatePipelineToolFields = (e: FormEvent<HTMLFormElement>) => {
+  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    dispatch(
-      updatePipelineTool({
-        type: fields[0].value,
-        token: fields[1].value,
-      }),
-    );
-  };
-
-  const handleSubmitPipelineToolFields = async (e: FormEvent<HTMLFormElement>) => {
-    updatePipelineToolFields(e);
-    const params = {
+    await verifyPipelineTool({
       type: fields[0].value,
       token: fields[1].value,
-    };
-
-    verifyPipelineTool(params);
+    });
   };
 
-  const handleResetPipelineToolFields = () => {
-    initPipeLineFields();
-    setIsDisableVerifyButton(true);
-    dispatch(updatePipelineToolVerifyState(false));
+  const onReset = () => {
+    const newFields = fields.map(({ key }, index) => ({
+      key,
+      value: index === 0 ? PIPELINE_TOOL_TYPES.BUILD_KITE : EMPTY_STRING,
+      isValid: true,
+    }));
+    handleUpdate(newFields);
   };
 
   return (
     <ConfigSectionContainer aria-label='Pipeline Tool Config'>
       {isLoading && <Loading />}
       <ConfigSelectionTitle>{CONFIG_TITLE.PIPELINE_TOOL}</ConfigSelectionTitle>
-      <StyledForm
-        onSubmit={handleSubmitPipelineToolFields}
-        onChange={updatePipelineToolFields}
-        onReset={handleResetPipelineToolFields}
-      >
+      <StyledForm onSubmit={onSubmit} onReset={onReset}>
         <StyledTypeSelections variant='standard' required>
           <InputLabel id='pipelineTool-type-checkbox-label'>Pipeline Tool</InputLabel>
           <Select
             labelId='pipelineTool-type-checkbox-label'
             aria-label='Pipeline Tool type select'
             value={fields[0].value}
-            onChange={(e) => onFormUpdate(ZERO, e.target.value)}
+            onChange={(e) => onSelectUpdate(e.target.value)}
           >
             {Object.values(PIPELINE_TOOL_TYPES).map((toolType) => (
               <MenuItem key={toolType} value={toolType}>
@@ -173,8 +146,8 @@ export const PipelineTool = () => {
             'aria-label': `input ${fields[1].key}`,
           }}
           value={fields[1].value}
-          onChange={(e) => onFormUpdate(1, e.target.value)}
-          error={!fields[1].isValid || !fields[1].isRequired}
+          onChange={(e) => onInputUpdate(e.target.value)}
+          error={!fields[1].isValid || !fields[1].value || !!errorMessage}
           helperText={updateFieldHelpText()}
         />
         <StyledButtonGroup>

--- a/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
@@ -142,9 +142,7 @@ export const PipelineTool = () => {
           label={fields[FIELD_KEY.TOKEN].key}
           variant='standard'
           type='password'
-          inputProps={{
-            'aria-label': `input ${fields[FIELD_KEY.TOKEN].key}`,
-          }}
+          inputProps={{ 'aria-label': `input ${fields[FIELD_KEY.TOKEN].key}` }}
           value={fields[FIELD_KEY.TOKEN].value}
           onFocus={(e) => onInputFocus(e.target.value)}
           onChange={(e) => onInputUpdate(e.target.value)}

--- a/frontend/src/containers/ConfigStep/SourceControl/index.tsx
+++ b/frontend/src/containers/ConfigStep/SourceControl/index.tsx
@@ -128,6 +128,7 @@ export const SourceControl = () => {
           label={fields[FIELD_KEY.TOKEN].key}
           variant='standard'
           type='password'
+          inputProps={{ 'aria-label': `input ${fields[FIELD_KEY.TOKEN].key}` }}
           value={fields[FIELD_KEY.TOKEN].value}
           onFocus={(e) => onInputFocus(e.target.value)}
           onChange={(e) => onInputChange(e.target.value)}

--- a/frontend/src/hooks/useVerifyBoardEffect.ts
+++ b/frontend/src/hooks/useVerifyBoardEffect.ts
@@ -41,7 +41,7 @@ const VALIDATOR = {
   TOKEN: (value: string) => REGEX.BOARD_TOKEN.test(value),
 };
 
-const KEYS = {
+export const KEYS = {
   BOARD: 'Board',
   BOARD_ID: 'Board Id',
   EMAIL: 'Email',

--- a/frontend/src/hooks/useVerifyBoardEffect.ts
+++ b/frontend/src/hooks/useVerifyBoardEffect.ts
@@ -1,36 +1,32 @@
+import { selectBoard, selectDateRange, updateBoard, updateBoardVerifyState } from '@src/context/config/configSlice';
+import { findCaseInsensitiveType, getJiraBoardToken } from '@src/utils/util';
+import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';
 import { DEFAULT_HELPER_TEXT, EMPTY_STRING } from '@src/constants/commons';
+import { IHeartBeatException } from '@src/exceptions/ExceptionType';
 import { BoardRequestDTO } from '@src/clients/board/dto/request';
-import { selectBoard } from '@src/context/config/configSlice';
+import { BOARD_TYPES, MESSAGE } from '@src/constants/resources';
 import { boardClient } from '@src/clients/board/BoardClient';
-import { useAppSelector } from '@src/hooks/useAppDispatch';
-import { findCaseInsensitiveType } from '@src/utils/util';
-import { BOARD_TYPES } from '@src/constants/resources';
-import { getJiraBoardToken } from '@src/utils/util';
-import { MESSAGE } from '@src/constants/resources';
+import { isHeartBeatException } from '@src/exceptions';
 import { REGEX } from '@src/constants/regex';
 import { HttpStatusCode } from 'axios';
 import { useState } from 'react';
+import dayjs from 'dayjs';
+import { updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
 
-export interface FormField {
+export interface Field {
   key: string;
-  name: string;
   value: string;
-  defaultValue: string;
-  isRequired: boolean;
-  isValid: boolean;
   validRule?: (value: string) => boolean;
   errorMessage: string;
   col: number;
 }
+
 export interface useVerifyBoardStateInterface {
-  verifyJira: (params: BoardRequestDTO) => Promise<{
-    response: Record<string, string>;
-  }>;
+  verifyJira: () => Promise<void>;
   isLoading: boolean;
-  formFields: FormField[];
-  updateField: (name: string, value: string) => void;
-  resetFormFields: () => void;
-  clearError: () => void;
+  fields: Field[];
+  updateField: (key: string, value: string) => void;
+  resetFields: () => void;
 }
 
 const ERROR_INFO = {
@@ -38,155 +34,154 @@ const ERROR_INFO = {
   BOARD_NOT_FOUND: 'boardId is incorrect',
 };
 
+const VALIDATOR = {
+  EMAIL: (value: string) => REGEX.EMAIL.test(value),
+  TOKEN: (value: string) => REGEX.BOARD_TOKEN.test(value),
+};
+
+const KEYS = {
+  BOARD: 'Board',
+  BOARD_ID: 'Board Id',
+  EMAIL: 'Email',
+  SITE: 'Site',
+  TOKEN: 'Token',
+};
+
+const getErrorMessage = (key: string, value: string, validRule?: (value: string) => boolean) => {
+  if (!value) {
+    return `${key} is required!`;
+  }
+  if (validRule && !validRule(value)) {
+    return `${key} is invalid!`;
+  }
+  return DEFAULT_HELPER_TEXT;
+};
+
 export const useVerifyBoardEffect = (): useVerifyBoardStateInterface => {
   const [isLoading, setIsLoading] = useState(false);
   const boardFields = useAppSelector(selectBoard);
+  const dateRange = useAppSelector(selectDateRange);
+  const dispatch = useAppDispatch();
   const type = findCaseInsensitiveType(Object.values(BOARD_TYPES), boardFields.type);
-  const [formFields, setFormFields] = useState<FormField[]>([
+  const [fields, setFields] = useState<Field[]>([
     {
-      key: 'Board',
-      name: 'boardType',
+      key: KEYS.BOARD,
       value: type,
-      defaultValue: BOARD_TYPES.JIRA,
-      isRequired: true,
-      isValid: true,
-      errorMessage: '',
+      errorMessage: getErrorMessage(KEYS.BOARD, type),
       col: 1,
     },
     {
-      key: 'Board Id',
-      name: 'boardId',
+      key: KEYS.BOARD_ID,
       value: boardFields.boardId,
-      defaultValue: EMPTY_STRING,
-      isRequired: true,
-      isValid: true,
-      errorMessage: '',
+      errorMessage: getErrorMessage(KEYS.BOARD_ID, boardFields.boardId),
       col: 1,
     },
     {
-      key: 'Email',
-      name: 'email',
+      key: KEYS.EMAIL,
       value: boardFields.email,
-      defaultValue: EMPTY_STRING,
-      isRequired: true,
-      isValid: true,
-      validRule: (value: string) => REGEX.EMAIL.test(value),
-      errorMessage: '',
+      validRule: VALIDATOR.EMAIL,
+      errorMessage: getErrorMessage(KEYS.EMAIL, boardFields.email, VALIDATOR.EMAIL),
       col: 1,
     },
     {
-      key: 'Site',
-      name: 'site',
+      key: KEYS.SITE,
       value: boardFields.site,
-      defaultValue: EMPTY_STRING,
-      isRequired: true,
-      isValid: true,
-      errorMessage: '',
+      errorMessage: getErrorMessage(KEYS.SITE, boardFields.site),
       col: 1,
     },
     {
-      key: 'Token',
-      name: 'token',
+      key: KEYS.TOKEN,
       value: boardFields.token,
-      defaultValue: EMPTY_STRING,
-      isRequired: true,
-      isValid: true,
-      validRule: (value: string) => REGEX.BOARD_TOKEN.test(value),
-      errorMessage: '',
+      validRule: VALIDATOR.TOKEN,
+      errorMessage: getErrorMessage(KEYS.TOKEN, boardFields.token, VALIDATOR.TOKEN),
       col: 2,
     },
   ]);
 
-  const resetFormFields = () =>
-    setFormFields(
-      formFields.map((field) => {
-        return { ...field, value: EMPTY_STRING, isRequired: true, isValid: true };
-      }),
-    );
-
-  const clearError = () => {
-    return setFormFields(formFields.map(clearErrorField));
+  const getBoardInfo = (fields: Field[]) => {
+    const keys = ['type', 'boardId', 'email', 'site', 'token'];
+    return keys.reduce((board, key, index) => ({ ...board, [key]: fields[index].value }), {});
   };
 
-  const setErrorField = (names: string[], messages: string[]) => {
-    setFormFields(
-      formFields.map((field) => {
-        return names.includes(field.name)
-          ? { ...field, isValid: false, errorMessage: messages[names.findIndex((name) => name === field.name)] }
+  const handleUpdate = (fields: Field[]) => {
+    setFields(fields);
+    dispatch(updateBoardVerifyState(false));
+    dispatch(updateBoard(getBoardInfo(fields)));
+  };
+
+  const resetFields = () => {
+    const newFields = fields.map((field) =>
+      field.key === KEYS.BOARD
+        ? field
+        : {
+            ...field,
+            value: EMPTY_STRING,
+            errorMessage: getErrorMessage(field.key, EMPTY_STRING, field.validRule),
+          },
+    );
+    handleUpdate(newFields);
+  };
+
+  const updateField = (key: string, value: string) => {
+    const newFields = fields.map((field) => {
+      return field.key === key
+        ? {
+            ...field,
+            value: value.trim(),
+            errorMessage: getErrorMessage(field.key, value.trim(), field.validRule),
+          }
+        : field;
+    });
+    handleUpdate(newFields);
+  };
+
+  const setErrorMessage = (keys: string[], messages: string[]) => {
+    setFields(
+      fields.map((field) => {
+        return keys.includes(field.key)
+          ? { ...field, errorMessage: messages[keys.findIndex((key) => key === field.key)] }
           : field;
       }),
     );
   };
 
-  const clearErrorField = (field: FormField) => {
-    return {
-      ...field,
-      isValid: true,
-      isRequired: true,
-      errorMessage: '',
-    };
-  };
-
-  const validField = (field: FormField, inputValue: string) => {
-    const value = inputValue.trim();
-    const isRequired = !!value;
-    const isValid = !field.validRule || field.validRule(value);
-    const errorMessage = !isRequired
-      ? `${field.key} is required!`
-      : !isValid
-        ? `${field.key} is invalid!`
-        : DEFAULT_HELPER_TEXT;
-
-    return {
-      ...field,
-      value,
-      isRequired,
-      isValid,
-      errorMessage,
-    };
-  };
-
-  const updateField = (name: string, value: string) => {
-    setFormFields(
-      formFields.map((field) => {
-        return field.name === name ? validField(field, value) : clearErrorField(field);
-      }),
-    );
-  };
-
-  const verifyJira = (params: BoardRequestDTO) => {
+  const verifyJira = async () => {
     setIsLoading(true);
-    return boardClient
-      .getVerifyBoard({
-        ...params,
-        token: getJiraBoardToken(params.token, params.email),
-      })
-      .then((result) => {
-        clearError();
-        return result;
-      })
-      .catch((e) => {
-        const { description, code } = e;
+    dispatch(updateTreatFlagCardAsBlock(true));
+    const boardInfo = getBoardInfo(fields) as BoardRequestDTO;
+    try {
+      const res: { response: Record<string, string> } = await boardClient.getVerifyBoard({
+        ...boardInfo,
+        startTime: dayjs(dateRange.startDate).valueOf(),
+        endTime: dayjs(dateRange.endDate).valueOf(),
+        token: getJiraBoardToken(boardInfo.token, boardInfo.email),
+      });
+      if (res?.response) {
+        dispatch(updateBoardVerifyState(true));
+        dispatch(updateBoard({ ...boardInfo, projectKey: res.response.projectKey }));
+      }
+    } catch (e) {
+      if (isHeartBeatException(e)) {
+        const { description, code } = e as IHeartBeatException;
         if (code === HttpStatusCode.Unauthorized) {
-          setErrorField(['email', 'token'], [MESSAGE.VERIFY_MAIL_FAILED_ERROR, MESSAGE.VERIFY_TOKEN_FAILED_ERROR]);
+          setErrorMessage([KEYS.TOKEN], [MESSAGE.VERIFY_TOKEN_FAILED_ERROR]);
         }
         if (code === HttpStatusCode.NotFound && description === ERROR_INFO.SITE_NOT_FOUND) {
-          setErrorField(['site'], [MESSAGE.VERIFY_SITE_FAILED_ERROR]);
+          setErrorMessage([KEYS.SITE], [MESSAGE.VERIFY_SITE_FAILED_ERROR]);
         }
         if (code === HttpStatusCode.NotFound && description === ERROR_INFO.BOARD_NOT_FOUND) {
-          setErrorField(['boardId'], [MESSAGE.VERIFY_BOARD_FAILED_ERROR]);
+          setErrorMessage([KEYS.BOARD_ID], [MESSAGE.VERIFY_BOARD_FAILED_ERROR]);
         }
-        return e;
-      })
-      .finally(() => setIsLoading(false));
+      }
+    }
+    setIsLoading(false);
   };
 
   return {
     verifyJira,
     isLoading,
-    formFields,
+    fields,
     updateField,
-    clearError,
-    resetFormFields,
+    resetFields,
   };
 };

--- a/frontend/src/hooks/useVerifyPipelineToolEffect.ts
+++ b/frontend/src/hooks/useVerifyPipelineToolEffect.ts
@@ -8,7 +8,7 @@ import { useState } from 'react';
 
 export const useVerifyPipelineToolEffect = () => {
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState('');
+  const [verifiedError, setVerifiedError] = useState('');
   const dispatch = useAppDispatch();
 
   const verifyPipelineTool = async (params: IPipelineVerifyRequestDTO): Promise<void> => {
@@ -18,19 +18,19 @@ export const useVerifyPipelineToolEffect = () => {
       dispatch(updatePipelineToolVerifyState(true));
       dispatch(initDeploymentFrequencySettings());
     } else {
-      setErrorMessage(response.errorTitle);
+      setVerifiedError(response.errorTitle);
     }
     setIsLoading(false);
   };
 
-  const clearErrorMessage = () => {
-    if (errorMessage) setErrorMessage('');
+  const clearVerifiedError = () => {
+    if (verifiedError) setVerifiedError('');
   };
 
   return {
     verifyPipelineTool,
     isLoading,
-    errorMessage,
-    clearErrorMessage,
+    verifiedError,
+    clearVerifiedError,
   };
 };

--- a/frontend/src/hooks/useVerifySourceControlTokenEffect.ts
+++ b/frontend/src/hooks/useVerifySourceControlTokenEffect.ts
@@ -8,7 +8,7 @@ import { HttpStatusCode } from 'axios';
 export const useVerifySourceControlTokenEffect = () => {
   const dispatch = useAppDispatch();
   const [isLoading, setIsLoading] = useState(false);
-  const [errorMessage, setErrorMessage] = useState<string>();
+  const [verifiedError, setVerifiedError] = useState<string>();
 
   const verifyToken = async (params: SourceControlVerifyRequestDTO) => {
     setIsLoading(true);
@@ -17,20 +17,20 @@ export const useVerifySourceControlTokenEffect = () => {
       dispatch(updateSourceControlVerifyState(true));
     } else {
       dispatch(updateSourceControlVerifyState(false));
-      setErrorMessage(response.errorTitle);
+      setVerifiedError(response.errorTitle);
     }
     setIsLoading(false);
     return response;
   };
 
-  const clearErrorMessage = useCallback(() => {
-    setErrorMessage('');
+  const clearVerifiedError = useCallback(() => {
+    setVerifiedError('');
   }, []);
 
   return {
     verifyToken,
     isLoading,
-    errorMessage,
-    clearErrorMessage,
+    verifiedError,
+    clearVerifiedError,
   };
 };


### PR DESCRIPTION
## Summary

Reference: https://dorametrics.atlassian.net/browse/ADM-783

1. refactor config for board/pipeline/source 
2. fix board/pipeline/source input change strategy
3. update validation strategy

## Before

https://github.com/au-heartbeat/Heartbeat/assets/17806850/c33a2f99-7cda-4c0f-8c5a-af93cd12a825

## After

board/pipeline/source control of config page will keep user's input