### PR TITLE
ADM-800:[frontend][backend]fix: fix the issue of Roboto font not displaying

### DIFF
--- a/ops/infra/nginx.conf
+++ b/ops/infra/nginx.conf
@@ -28,5 +28,8 @@ http {
     location /api {
       proxy_pass http://backend:4322;
     }
+    location ~ \.(woff|woff2)$ {
+      add_header Content-Type “font/woff2”;
+    }
   }
 }


### PR DESCRIPTION
## Summary

... Our report page numbers are not displaying in Roboto font. We need to fix the issue with Roboto font not displaying.

## Before

<img width="1347" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/45ef858b-ac7e-4a3f-9def-2a724f2f0679">

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
