### PR TITLE
ADM-791:[backend][docs]: Fix the atomicity issue, add more tests and update docs

### DIFF
--- a/backend/src/main/java/heartbeat/controller/report/ReportController.java
+++ b/backend/src/main/java/heartbeat/controller/report/ReportController.java
@@ -52,10 +52,8 @@ public class ReportController {
 
 	@GetMapping("/{reportId}")
 	public ResponseEntity<ReportResponse> generateReport(@PathVariable String reportId) {
-		boolean generateReportIsOver = generateReporterService.checkGenerateReportIsDone(reportId);
-		ReportResponse reportResponse = generateReporterService.getComposedReportResponse(reportId,
-				generateReportIsOver);
-		if (generateReportIsOver) {
+		ReportResponse reportResponse = generateReporterService.getComposedReportResponse(reportId);
+		if (reportResponse.isAllMetricsCompleted()) {
 			log.info("Successfully generate Report_reportId: {}, reports: {}", reportId, reportResponse);
 			generateReporterService.generateCSVForMetric(reportResponse, reportId);
 			return ResponseEntity.status(HttpStatus.CREATED).body(reportResponse);

--- a/backend/src/main/java/heartbeat/controller/report/dto/request/GenerateReportRequest.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/request/GenerateReportRequest.java
@@ -2,7 +2,6 @@ package heartbeat.controller.report.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import heartbeat.controller.report.dto.response.MetricsDataCompleted;
 import heartbeat.util.IdUtil;
 import heartbeat.util.MetricsUtil;
 import jakarta.validation.constraints.NotBlank;
@@ -10,7 +9,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.apache.commons.collections.CollectionUtils;
 
 import java.util.List;
 
@@ -72,15 +70,6 @@ public class GenerateReportRequest {
 	@JsonIgnore
 	public String getBoardReportId() {
 		return IdUtil.getBoardReportId(this.csvTimeStamp);
-	}
-
-	@JsonIgnore
-	public MetricsDataCompleted getMetricsStatus(Boolean flag) {
-		return MetricsDataCompleted.builder()
-			.boardMetricsCompleted(CollectionUtils.isNotEmpty(getBoardMetrics()) ? flag : null)
-			.pipelineMetricsCompleted(CollectionUtils.isNotEmpty(getPipelineMetrics()) ? flag : null)
-			.sourceControlMetricsCompleted(CollectionUtils.isNotEmpty(getSourceControlMetrics()) ? flag : null)
-			.build();
 	}
 
 	@JsonIgnore

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/MetricsDataCompleted.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/MetricsDataCompleted.java
@@ -6,6 +6,9 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.util.Objects;
+import java.util.stream.Stream;
+
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -15,20 +18,20 @@ public class MetricsDataCompleted {
 
 	private Boolean boardMetricsCompleted;
 
-	private Boolean pipelineMetricsCompleted;
-
-	private Boolean sourceControlMetricsCompleted;
+	private Boolean doraMetricsCompleted;
 
 	public Boolean boardMetricsCompleted() {
 		return boardMetricsCompleted;
 	}
 
-	public Boolean pipelineMetricsCompleted() {
-		return pipelineMetricsCompleted;
+	public Boolean doraMetricsCompleted() {
+		return doraMetricsCompleted;
 	}
 
-	public Boolean sourceControlMetricsCompleted() {
-		return sourceControlMetricsCompleted;
+	public boolean isAllMetricsCompleted() {
+		return Stream.of(boardMetricsCompleted, doraMetricsCompleted)
+			.filter(Objects::nonNull)
+			.allMatch(Boolean::booleanValue);
 	}
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/response/ReportResponse.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/response/ReportResponse.java
@@ -6,11 +6,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.util.List;
-import java.util.function.Function;
-
-import static heartbeat.util.ValueUtil.getValueOrNull;
-
-import static heartbeat.util.ValueUtil.getValueOrNull;
 
 @Data
 @Builder
@@ -36,13 +31,11 @@ public class ReportResponse {
 
 	private Long exportValidityTime;
 
-	private Boolean boardMetricsCompleted;
+	private boolean boardMetricsCompleted;
 
-	private Boolean pipelineMetricsCompleted;
+	private boolean doraMetricsCompleted;
 
-	private Boolean sourceControlMetricsCompleted;
-
-	private Boolean allMetricsCompleted;
+	private boolean allMetricsCompleted;
 
 	public ReportResponse(Long exportValidityTime) {
 		this.exportValidityTime = exportValidityTime;

--- a/backend/src/main/java/heartbeat/handler/AsyncMetricsDataHandler.java
+++ b/backend/src/main/java/heartbeat/handler/AsyncMetricsDataHandler.java
@@ -49,6 +49,8 @@ public class AsyncMetricsDataHandler extends AsyncDataBaseHandler {
 		switch (metricType) {
 			case BOARD -> previousMetricsCompleted.setBoardMetricsCompleted(true);
 			case DORA -> previousMetricsCompleted.setDoraMetricsCompleted(true);
+			default -> {
+			}
 		}
 		putMetricsDataCompleted(timeStamp, previousMetricsCompleted);
 	}

--- a/backend/src/main/java/heartbeat/handler/AsyncMetricsDataHandler.java
+++ b/backend/src/main/java/heartbeat/handler/AsyncMetricsDataHandler.java
@@ -1,17 +1,18 @@
 package heartbeat.handler;
 
 import com.google.gson.Gson;
+import heartbeat.controller.report.dto.request.MetricType;
 import heartbeat.controller.report.dto.response.MetricsDataCompleted;
 import heartbeat.exception.GenerateReportException;
 import heartbeat.handler.base.AsyncDataBaseHandler;
+import heartbeat.service.report.MetricsDataDTO;
+import heartbeat.util.ValueUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.Synchronized;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 import static heartbeat.handler.base.FIleType.METRICS_DATA_COMPLETED;
 
@@ -34,23 +35,33 @@ public class AsyncMetricsDataHandler extends AsyncDataBaseHandler {
 		return readFileByType(METRICS_DATA_COMPLETED, timeStamp, MetricsDataCompleted.class);
 	}
 
-	public boolean isReportReady(String timeStamp) {
-		MetricsDataCompleted metricsDataCompleted = getMetricsDataCompleted(timeStamp);
+	public void deleteExpireMetricsDataCompletedFile(long currentTimeStamp, File directory) {
+		deleteExpireFileByType(METRICS_DATA_COMPLETED, currentTimeStamp, directory);
+	}
+
+	@Synchronized
+	public void updateMetricsDataCompletedInHandler(String timeStamp, MetricType metricType) {
+		MetricsDataCompleted previousMetricsCompleted = getMetricsDataCompleted(timeStamp);
+		if (previousMetricsCompleted == null) {
+			log.error("Failed to update metrics data completed through this timestamp.");
+			throw new GenerateReportException("Failed to update metrics data completed through this timestamp.");
+		}
+		switch (metricType) {
+			case BOARD -> previousMetricsCompleted.setBoardMetricsCompleted(true);
+			case DORA -> previousMetricsCompleted.setDoraMetricsCompleted(true);
+		}
+		putMetricsDataCompleted(timeStamp, previousMetricsCompleted);
+	}
+
+	public MetricsDataDTO getReportReadyStatusByTimeStamp(String reportTimeStamp) {
+		MetricsDataCompleted metricsDataCompleted = getMetricsDataCompleted(reportTimeStamp);
 		if (metricsDataCompleted == null) {
 			throw new GenerateReportException("Failed to locate the report using this report ID.");
 		}
-
-		List<Boolean> metricsReady = Stream
-			.of(metricsDataCompleted.boardMetricsCompleted(), metricsDataCompleted.pipelineMetricsCompleted(),
-					metricsDataCompleted.sourceControlMetricsCompleted())
-			.filter(Objects::nonNull)
-			.toList();
-
-		return metricsReady.stream().allMatch(Boolean::valueOf);
-	}
-
-	public void deleteExpireMetricsDataCompletedFile(long currentTimeStamp, File directory) {
-		deleteExpireFileByType(METRICS_DATA_COMPLETED, currentTimeStamp, directory);
+		boolean isBoardReady = ValueUtil.valueOrDefault(false, metricsDataCompleted.boardMetricsCompleted());
+		boolean isDoraReady = ValueUtil.valueOrDefault(false, metricsDataCompleted.doraMetricsCompleted());
+		boolean isReportReady = metricsDataCompleted.isAllMetricsCompleted();
+		return new MetricsDataDTO(isBoardReady, isDoraReady, isReportReady);
 	}
 
 }

--- a/backend/src/main/java/heartbeat/handler/base/AsyncDataBaseHandler.java
+++ b/backend/src/main/java/heartbeat/handler/base/AsyncDataBaseHandler.java
@@ -28,6 +28,8 @@ public class AsyncDataBaseHandler {
 
 	public static final String SUFFIX_LOCK = ".lock";
 
+	public static final String FILENAME_SPLIT_PATTERN = "\\s*\\-|\\.\\s*";
+
 	protected synchronized void createFileByType(FIleType fIleType, String fileId, String json) {
 		createDirToConvertData(fIleType);
 		String fileName = OUTPUT_FILE_PATH + fIleType.getPath() + fileId;
@@ -157,7 +159,7 @@ public class AsyncDataBaseHandler {
 		if (!ObjectUtils.isEmpty(files)) {
 			for (File file : files) {
 				String fileName = file.getName();
-				String[] splitResult = fileName.split("\\s*\\-|\\.\\s*");
+				String[] splitResult = fileName.split(FILENAME_SPLIT_PATTERN);
 				String timeStamp = METRICS_DATA_COMPLETED == fIleType ? splitResult[0] : splitResult[1];
 				if (validateExpire(currentTimeStamp, Long.parseLong(timeStamp)) && !file.delete() && file.exists()) {
 					log.error("Failed to deleted expired fIleType: {} file, file name: {}", fIleType.getType(),

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -99,12 +99,16 @@ public class GenerateReporterService {
 	public void generateDoraReport(GenerateReportRequest request) {
 		removePreviousAsyncException(request.getPipelineReportId());
 		removePreviousAsyncException(request.getSourceControlReportId());
-		FetchedData fetchedData = fetchOriginalData(request, new FetchedData());
-		if (CollectionUtils.isNotEmpty(request.getPipelineMetrics())) {
-			generatePipelineReport(request.toPipelineRequest(), fetchedData);
-		}
+		FetchedData fetchedData = new FetchedData();
 		if (CollectionUtils.isNotEmpty(request.getSourceControlMetrics())) {
-			generateSourceControlReport(request.toSourceControlRequest(), fetchedData);
+			GenerateReportRequest sourceControlRequest = request.toSourceControlRequest();
+			fetchOriginalData(sourceControlRequest, fetchedData);
+			generateSourceControlReport(sourceControlRequest, fetchedData);
+		}
+		if (CollectionUtils.isNotEmpty(request.getPipelineMetrics())) {
+			GenerateReportRequest pipelineRequest = request.toPipelineRequest();
+			fetchOriginalData(pipelineRequest, fetchedData);
+			generatePipelineReport(pipelineRequest, fetchedData);
 		}
 		generateCSVForPipeline(request, fetchedData.getBuildKiteData());
 		asyncMetricsDataHandler.updateMetricsDataCompletedInHandler(request.getCsvTimeStamp(), DORA);

--- a/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
+++ b/backend/src/main/java/heartbeat/service/report/GenerateReporterService.java
@@ -100,15 +100,15 @@ public class GenerateReporterService {
 		removePreviousAsyncException(request.getPipelineReportId());
 		removePreviousAsyncException(request.getSourceControlReportId());
 		FetchedData fetchedData = new FetchedData();
-		if (CollectionUtils.isNotEmpty(request.getSourceControlMetrics())) {
-			GenerateReportRequest sourceControlRequest = request.toSourceControlRequest();
-			fetchOriginalData(sourceControlRequest, fetchedData);
-			generateSourceControlReport(sourceControlRequest, fetchedData);
-		}
 		if (CollectionUtils.isNotEmpty(request.getPipelineMetrics())) {
 			GenerateReportRequest pipelineRequest = request.toPipelineRequest();
 			fetchOriginalData(pipelineRequest, fetchedData);
 			generatePipelineReport(pipelineRequest, fetchedData);
+		}
+		if (CollectionUtils.isNotEmpty(request.getSourceControlMetrics())) {
+			GenerateReportRequest sourceControlRequest = request.toSourceControlRequest();
+			fetchOriginalData(sourceControlRequest, fetchedData);
+			generateSourceControlReport(sourceControlRequest, fetchedData);
 		}
 		generateCSVForPipeline(request, fetchedData.getBuildKiteData());
 		asyncMetricsDataHandler.updateMetricsDataCompletedInHandler(request.getCsvTimeStamp(), DORA);
@@ -243,13 +243,7 @@ public class GenerateReporterService {
 		if (CollectionUtils.isNotEmpty(request.getPipelineMetrics())) {
 			if (request.getBuildKiteSetting() == null)
 				throw new BadRequestException("Failed to fetch BuildKite info due to BuildKite setting is null.");
-			FetchedData.BuildKiteData buildKiteData = pipelineService.fetchBuildKiteInfo(request);
-			BuildKiteData cachedBuildKiteData = fetchedData.getBuildKiteData();
-			if (cachedBuildKiteData != null) {
-				List<PipelineLeadTime> pipelineLeadTimes = cachedBuildKiteData.getPipelineLeadTimes();
-				buildKiteData.setPipelineLeadTimes(pipelineLeadTimes);
-			}
-			fetchedData.setBuildKiteData(buildKiteData);
+			fetchedData.setBuildKiteData(pipelineService.fetchBuildKiteInfo(request));
 		}
 
 		return fetchedData;

--- a/backend/src/main/java/heartbeat/service/report/MetricsDataDTO.java
+++ b/backend/src/main/java/heartbeat/service/report/MetricsDataDTO.java
@@ -1,0 +1,16 @@
+package heartbeat.service.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class MetricsDataDTO {
+
+	boolean isBoardReady;
+
+	boolean isDoraReady;
+
+	boolean isAllMetricsReady;
+
+}

--- a/backend/src/test/java/heartbeat/controller/report/ReporterControllerTest.java
+++ b/backend/src/test/java/heartbeat/controller/report/ReporterControllerTest.java
@@ -24,9 +24,12 @@ import org.springframework.test.web.servlet.MockMvc;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 
+import static heartbeat.service.report.scheduler.DeleteExpireCSVScheduler.EXPORT_CSV_VALIDITY_TIME;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.times;
@@ -57,12 +60,10 @@ class ReporterControllerTest {
 	private final ObjectMapper mapper = new ObjectMapper();
 
 	@Test
-	void shouldReturnCreatedStatusWhenCheckGenerateReportIsTrue() throws Exception {
+	void shouldReturnCreatedStatusWhenAllMetricsCompletedIsTrue() throws Exception {
 		String reportId = Long.toString(System.currentTimeMillis());
 		ReportResponse expectedReportResponse = mapper.readValue(new File(RESPONSE_FILE_PATH), ReportResponse.class);
-
-		when(generateReporterService.checkGenerateReportIsDone(reportId)).thenReturn(true);
-		when(generateReporterService.getComposedReportResponse(reportId, true)).thenReturn(expectedReportResponse);
+		when(generateReporterService.getComposedReportResponse(reportId)).thenReturn(expectedReportResponse);
 
 		MockHttpServletResponse response = mockMvc
 			.perform(get("/reports/{reportId}", reportId).contentType(MediaType.APPLICATION_JSON))
@@ -76,15 +77,14 @@ class ReporterControllerTest {
 	}
 
 	@Test
-	void shouldReturnOkStatusWhenCheckGenerateReportIsFalse() throws Exception {
+	void shouldReturnOkStatusWhenAllMetricsCompletedIsFalse() throws Exception {
 		String reportId = Long.toString(System.currentTimeMillis());
 		ReportResponse reportResponse = ReportResponse.builder()
 			.boardMetricsCompleted(false)
 			.allMetricsCompleted(false)
 			.build();
 
-		when(generateReporterService.checkGenerateReportIsDone(reportId)).thenReturn(false);
-		when(generateReporterService.getComposedReportResponse(reportId, false)).thenReturn(reportResponse);
+		when(generateReporterService.getComposedReportResponse(reportId)).thenReturn(reportResponse);
 
 		mockMvc.perform(get("/reports/{reportId}", reportId).contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -94,16 +94,15 @@ class ReporterControllerTest {
 	}
 
 	@Test
-	void shouldReturnInternalServerErrorStatusWhenCheckGenerateReportThrowException() throws Exception {
-		String reportId = Long.toString(System.currentTimeMillis());
-
-		when(generateReporterService.checkGenerateReportIsDone(reportId))
-			.thenThrow(new GenerateReportException("Report time expires"));
+	void shouldReturn500StatusWhenReportTimeIsExpired() throws Exception {
+		String reportId = Long.toString(System.currentTimeMillis() - EXPORT_CSV_VALIDITY_TIME - 200L);
+		doThrow(new GenerateReportException("Failed to get report due to report time expires"))
+			.when(generateReporterService)
+			.getComposedReportResponse(any());
 
 		mockMvc.perform(get("/reports/{reportId}", reportId).contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isInternalServerError())
-			.andExpect(jsonPath("$.message").value("Report time expires"))
-			.andExpect(jsonPath("$.hintInfo").value("Failed to generate report"))
+			.andExpect(jsonPath("$.message").value("Failed to get report due to report time expires"))
 			.andReturn()
 			.getResponse();
 	}

--- a/backend/src/test/java/heartbeat/controller/report/ReporterControllerTest.java
+++ b/backend/src/test/java/heartbeat/controller/report/ReporterControllerTest.java
@@ -91,6 +91,7 @@ class ReporterControllerTest {
 			.andExpect(jsonPath("$.allMetricsCompleted").value(false))
 			.andReturn()
 			.getResponse();
+		verify(generateReporterService).getComposedReportResponse(any());
 	}
 
 	@Test
@@ -105,6 +106,7 @@ class ReporterControllerTest {
 			.andExpect(jsonPath("$.message").value("Failed to get report due to report time expires"))
 			.andReturn()
 			.getResponse();
+		verify(generateReporterService).getComposedReportResponse(any());
 	}
 
 	@Test

--- a/backend/src/test/java/heartbeat/controller/report/reportResponse.json
+++ b/backend/src/test/java/heartbeat/controller/report/reportResponse.json
@@ -145,7 +145,6 @@
   },
   "exportValidityTime": 1800000,
   "boardMetricsCompleted": true,
-  "pipelineMetricsCompleted": true,
-  "sourceControlMetricsCompleted": true,
+  "doraMetricsCompleted": true,
   "allMetricsCompleted": true
 }

--- a/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
@@ -6,6 +6,7 @@ import heartbeat.controller.report.dto.request.BuildKiteSetting;
 import heartbeat.controller.report.dto.request.CodebaseSetting;
 import heartbeat.controller.report.dto.request.GenerateReportRequest;
 import heartbeat.controller.report.dto.request.JiraBoardSetting;
+import heartbeat.controller.report.dto.request.MetricType;
 import heartbeat.controller.report.dto.response.ChangeFailureRate;
 import heartbeat.controller.report.dto.response.Classification;
 import heartbeat.controller.report.dto.response.CycleTime;
@@ -32,6 +33,8 @@ import heartbeat.service.report.calculator.LeadTimeForChangesCalculator;
 import heartbeat.service.report.calculator.MeanToRecoveryCalculator;
 import heartbeat.service.report.calculator.VelocityCalculator;
 import heartbeat.service.report.calculator.model.FetchedData;
+import heartbeat.util.ValueUtil;
+import lombok.val;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -60,7 +63,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -150,6 +155,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
 			generateReporterService.generateBoardReport(request);
 
 			verify(kanbanService, never()).fetchDataFromKanban(eq(request));
@@ -157,15 +164,12 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getBoardReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertNull(response.getCycleTime());
 			assertNull(response.getVelocity());
 			assertNull(response.getClassificationList());
-
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 		@Test
@@ -177,8 +181,14 @@ class GenerateReporterServiceTest {
 				.csvTimeStamp(TIMESTAMP)
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any())).thenReturn(null);
+			doAnswer(invocation -> null).when(asyncReportRequestHandler).putReport(any(), any());
+			doThrow(new GenerateReportException("Failed to update metrics data completed through this timestamp."))
+				.when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
+
 			generateReporterService.generateBoardReport(request);
 
+			verify(asyncExceptionHandler).remove(eq(request.getBoardReportId()));
 			verify(asyncExceptionHandler).put(eq(request.getBoardReportId()), exceptionCaptor.capture());
 			assertEquals("Failed to update metrics data completed through this timestamp.",
 					exceptionCaptor.getValue().getMessage());
@@ -187,12 +197,10 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getBoardReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertNull(response.getCycleTime());
-
-			verify(asyncMetricsDataHandler, never()).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 		@Test
@@ -205,6 +213,9 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
+
 			generateReporterService.generateBoardReport(request);
 
 			verify(asyncExceptionHandler).put(eq(request.getBoardReportId()), exceptionCaptor.capture());
@@ -214,7 +225,8 @@ class GenerateReporterServiceTest {
 			verify(kanbanService, never()).fetchDataFromKanban(eq(request));
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler, never()).putReport(eq(request.getBoardReportId()), any());
-			verify(asyncMetricsDataHandler, never()).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler, never()).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()),
+					any());
 		}
 
 		@Test
@@ -228,11 +240,14 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
 			when(velocityCalculator.calculateVelocity(any()))
 				.thenReturn(Velocity.builder().velocityForSP(10).velocityForCards(20).build());
 			when(kanbanService.fetchDataFromKanban(request)).thenReturn(FetchedData.CardCollectionInfo.builder()
 				.realDoneCardCollection(CardCollection.builder().build())
 				.build());
+
 			generateReporterService.generateBoardReport(request);
 
 			verify(asyncExceptionHandler).remove(request.getBoardReportId());
@@ -241,14 +256,11 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getBoardReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertEquals(10, response.getVelocity().getVelocityForSP());
 			assertEquals(20, response.getVelocity().getVelocityForCards());
-
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 		@Test
@@ -262,6 +274,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().boardMetricsCompleted(true).build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
 			when(cycleTimeCalculator.calculateCycleTime(any(), any())).thenReturn(CycleTime.builder()
 				.averageCycleTimePerSP(10)
 				.totalTimeForCards(15)
@@ -270,6 +284,7 @@ class GenerateReporterServiceTest {
 			when(kanbanService.fetchDataFromKanban(request)).thenReturn(FetchedData.CardCollectionInfo.builder()
 				.realDoneCardCollection(CardCollection.builder().build())
 				.build());
+
 			generateReporterService.generateBoardReport(request);
 
 			verify(pipelineService, never()).fetchGithubData(any());
@@ -277,15 +292,12 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getBoardReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertEquals(10, response.getCycleTime().getAverageCycleTimePerSP());
 			assertEquals(20, response.getCycleTime().getAverageCycleTimePerCard());
 			assertEquals(15, response.getCycleTime().getTotalTimeForCards());
-
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 		@Test
@@ -299,11 +311,14 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
 			List<Classification> classifications = List.of(Classification.builder().build());
 			when(classificationCalculator.calculate(any(), any())).thenReturn(classifications);
 			when(kanbanService.fetchDataFromKanban(request)).thenReturn(FetchedData.CardCollectionInfo.builder()
 				.realDoneCardCollection(CardCollection.builder().build())
 				.build());
+
 			generateReporterService.generateBoardReport(request);
 
 			verify(pipelineService, never()).fetchGithubData(any());
@@ -311,13 +326,10 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getBoardReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertEquals(classifications, response.getClassificationList());
-
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 		@Test
@@ -332,11 +344,13 @@ class GenerateReporterServiceTest {
 			when(kanbanService.fetchDataFromKanban(request)).thenThrow(new NotFoundException(""));
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.BOARD);
 
 			generateReporterService.generateBoardReport(request);
 
 			verify(asyncExceptionHandler).put(eq(request.getBoardReportId()), any());
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()), any());
 		}
 
 	}
@@ -354,9 +368,12 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
+
 			generateReporterService.generateDoraReport(request);
 
 			verify(asyncExceptionHandler).remove(request.getPipelineReportId());
@@ -375,9 +392,12 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
+
 			try {
 				generateReporterService.generateDoraReport(request);
 				fail();
@@ -402,9 +422,12 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
+
 			try {
 				generateReporterService.generateDoraReport(request);
 				fail();
@@ -433,6 +456,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
@@ -474,6 +499,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
@@ -484,7 +511,8 @@ class GenerateReporterServiceTest {
 			generateReporterService.generateDoraReport(request);
 
 			verify(asyncExceptionHandler).put(eq(request.getPipelineReportId()), any());
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler, times(2)).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()),
+					any());
 		}
 
 		@Test
@@ -500,6 +528,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
@@ -513,12 +543,9 @@ class GenerateReporterServiceTest {
 			verify(workDay).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getSourceControlReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertEquals(fakeLeadTimeForChange, response.getLeadTimeForChanges());
-
 			verify(csvFileGenerator).convertPipelineDataToCSV(eq(pipelineCSVInfos), eq(request.getCsvTimeStamp()));
 		}
 
@@ -535,6 +562,8 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
@@ -550,12 +579,9 @@ class GenerateReporterServiceTest {
 			verify(workDay, times(2)).changeConsiderHolidayMode(false);
 			verify(asyncReportRequestHandler).putReport(eq(request.getSourceControlReportId()),
 					responseArgumentCaptor.capture());
-
 			ReportResponse response = responseArgumentCaptor.getValue();
-
 			assertEquals(1800000L, response.getExportValidityTime());
 			assertEquals(fakeLeadTimeForChange, response.getLeadTimeForChanges());
-
 			verify(csvFileGenerator).convertPipelineDataToCSV(eq(pipelineCSVInfos), eq(request.getCsvTimeStamp()));
 		}
 
@@ -572,17 +598,20 @@ class GenerateReporterServiceTest {
 				.build();
 			when(asyncMetricsDataHandler.getMetricsDataCompleted(any()))
 				.thenReturn(MetricsDataCompleted.builder().build());
+			doAnswer(invocation -> null).when(asyncMetricsDataHandler)
+				.updateMetricsDataCompletedInHandler(TIMESTAMP, MetricType.DORA);
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
 			when(pipelineService.fetchGithubData(request)).thenReturn(
 					FetchedData.BuildKiteData.builder().pipelineLeadTimes(List.of()).buildInfosList(List.of()).build());
-			when(leadTimeForChangesCalculator.calculate(any())).thenThrow(new NotFoundException(""));
+			doThrow(new NotFoundException("")).when(leadTimeForChangesCalculator).calculate(any());
 
 			generateReporterService.generateDoraReport(request);
 
 			verify(asyncExceptionHandler).put(eq(request.getSourceControlReportId()), any());
-			verify(asyncMetricsDataHandler).putMetricsDataCompleted(eq(request.getCsvTimeStamp()), any());
+			verify(asyncMetricsDataHandler, times(2)).updateMetricsDataCompletedInHandler(eq(request.getCsvTimeStamp()),
+					any());
 		}
 
 	}
@@ -601,12 +630,12 @@ class GenerateReporterServiceTest {
 	}
 
 	@Nested
-	class CheckGenerateReportIsDone {
+	class CheckReportReadyStatus {
 
 		@Test
-		void shouldThrowErrorWhenTimestampIsInvalid() {
+		void shouldThrowErrorWhenTimeStampIsInvalid() {
 			try {
-				generateReporterService.checkGenerateReportIsDone(
+				generateReporterService.checkReportReadyStatus(
 						String.valueOf(System.currentTimeMillis() - EXPORT_CSV_VALIDITY_TIME - 200));
 				fail();
 			}
@@ -619,9 +648,12 @@ class GenerateReporterServiceTest {
 		@Test
 		void shouldReturnMetricStatus() {
 			String timeStamp = String.valueOf(System.currentTimeMillis() - EXPORT_CSV_VALIDITY_TIME + 200);
-			when(asyncMetricsDataHandler.isReportReady(timeStamp)).thenReturn(true);
+			MetricsDataDTO metricsDataDTO = new MetricsDataDTO(true, true, true);
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(timeStamp)).thenReturn(metricsDataDTO);
 
-			assertTrue(generateReporterService.checkGenerateReportIsDone(timeStamp));
+			MetricsDataDTO readyStatus = generateReporterService.checkReportReadyStatus(timeStamp);
+
+			assertEquals(metricsDataDTO, readyStatus);
 		}
 
 	}
@@ -629,105 +661,49 @@ class GenerateReporterServiceTest {
 	@Nested
 	class GetComposedReportResponse {
 
+		String reportId = String.valueOf(System.currentTimeMillis() - EXPORT_CSV_VALIDITY_TIME + 200);
+
+		MetricsDataDTO metricsDataDTO = new MetricsDataDTO(false, true, false);
+
 		@Test
 		void shouldGetDataFromCache() {
-			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId))
-				.thenReturn(MetricsDataCompleted.builder().build());
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(reportId))
+				.thenReturn(metricsDataDTO);
 			when(asyncExceptionHandler.get(any())).thenReturn(null);
 
-			ReportResponse res = generateReporterService.getComposedReportResponse(reportId, true);
+			ReportResponse res = generateReporterService.getComposedReportResponse(reportId);
 
 			assertEquals(EXPORT_CSV_VALIDITY_TIME, res.getExportValidityTime());
-			assertEquals(true, res.getAllMetricsCompleted());
-			assertNull(res.getReportMetricsError().getBoardMetricsError());
-		}
-
-		@Test
-		void shouldReturnCompletedFalseGivenResponseNullMetricsDataCompletedFalseWhenGetDataFromCache() {
-			String reportId = "reportId";
-			when(asyncReportRequestHandler.getReport(any())).thenReturn(null);
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId)).thenReturn(MetricsDataCompleted.builder()
-				.boardMetricsCompleted(false)
-				.pipelineMetricsCompleted(false)
-				.sourceControlMetricsCompleted(false)
-				.build());
-			when(asyncExceptionHandler.get(any())).thenReturn(null);
-
-			ReportResponse res = generateReporterService.getComposedReportResponse(reportId, false);
-
-			assertEquals(EXPORT_CSV_VALIDITY_TIME, res.getExportValidityTime());
-			assertEquals(false, res.getAllMetricsCompleted());
-			assertEquals(false, res.getBoardMetricsCompleted());
-			assertEquals(false, res.getPipelineMetricsCompleted());
-			assertEquals(false, res.getSourceControlMetricsCompleted());
-			assertNull(res.getReportMetricsError().getBoardMetricsError());
-		}
-
-		@Test
-		void shouldReturnCompletedTrueGivenResponseNonNullMetricsDataCompletedFalseWhenGetDataFromCache() {
-			String reportId = "reportId";
-			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId)).thenReturn(MetricsDataCompleted.builder()
-				.boardMetricsCompleted(false)
-				.pipelineMetricsCompleted(false)
-				.sourceControlMetricsCompleted(false)
-				.build());
-			when(asyncExceptionHandler.get(any())).thenReturn(null);
-
-			ReportResponse res = generateReporterService.getComposedReportResponse(reportId, true);
-
-			assertEquals(EXPORT_CSV_VALIDITY_TIME, res.getExportValidityTime());
-			assertEquals(true, res.getAllMetricsCompleted());
-			assertEquals(true, res.getBoardMetricsCompleted());
-			assertEquals(true, res.getPipelineMetricsCompleted());
-			assertEquals(true, res.getSourceControlMetricsCompleted());
-			assertNull(res.getReportMetricsError().getBoardMetricsError());
-		}
-
-		@Test
-		void shouldReturnMetricsCompletedStatusIsNullWhenAsyncMetricsStatusIsNull() {
-			String reportId = "reportId";
-			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId)).thenReturn(null);
-			when(asyncExceptionHandler.get(any())).thenReturn(null);
-
-			ReportResponse res = generateReporterService.getComposedReportResponse(reportId, false);
-
-			assertEquals(EXPORT_CSV_VALIDITY_TIME, res.getExportValidityTime());
-			assertEquals(false, res.getAllMetricsCompleted());
-			assertNull(res.getBoardMetricsCompleted());
-			assertNull(res.getPipelineMetricsCompleted());
-			assertNull(res.getSourceControlMetricsCompleted());
+			assertEquals(false, res.isBoardMetricsCompleted());
+			assertEquals(true, res.isDoraMetricsCompleted());
+			assertEquals(false, res.isAllMetricsCompleted());
 			assertNull(res.getReportMetricsError().getBoardMetricsError());
 		}
 
 		@Test
 		void shouldReturnErrorDataWhenExceptionIs404Or403Or401() {
-			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId))
-				.thenReturn(MetricsDataCompleted.builder().build());
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(reportId))
+				.thenReturn(metricsDataDTO);
 			when(asyncExceptionHandler.get(any())).thenReturn(new NotFoundException("error"));
 
-			ReportResponse res = generateReporterService.getComposedReportResponse(reportId, true);
+			ReportResponse res = generateReporterService.getComposedReportResponse(reportId);
 
 			assertEquals(EXPORT_CSV_VALIDITY_TIME, res.getExportValidityTime());
-			assertEquals(true, res.getAllMetricsCompleted());
+			assertEquals(false, res.isAllMetricsCompleted());
 			assertEquals(404, res.getReportMetricsError().getBoardMetricsError().getStatus());
 		}
 
 		@Test
 		void shouldThrowGenerateReportExceptionWhenErrorIs500() {
-			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId))
-				.thenReturn(MetricsDataCompleted.builder().build());
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(reportId))
+				.thenReturn(metricsDataDTO);
 			when(asyncExceptionHandler.get(any())).thenReturn(new GenerateReportException("errorMessage"));
 
 			try {
-				generateReporterService.getComposedReportResponse(reportId, true);
+				generateReporterService.getComposedReportResponse(reportId);
 				fail();
 			}
 			catch (BaseException e) {
@@ -738,14 +714,13 @@ class GenerateReporterServiceTest {
 
 		@Test
 		void shouldThrowServiceUnavailableExceptionWhenErrorIs503() {
-			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId))
-				.thenReturn(MetricsDataCompleted.builder().build());
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(reportId))
+				.thenReturn(metricsDataDTO);
 			when(asyncExceptionHandler.get(any())).thenReturn(new ServiceUnavailableException("errorMessage"));
 
 			try {
-				generateReporterService.getComposedReportResponse(reportId, true);
+				generateReporterService.getComposedReportResponse(reportId);
 				fail();
 			}
 			catch (BaseException e) {
@@ -756,14 +731,13 @@ class GenerateReporterServiceTest {
 
 		@Test
 		void shouldThrowRequestFailedExceptionWhenErrorIsDefault() {
-			String reportId = "reportId";
 			when(asyncReportRequestHandler.getReport(any())).thenReturn(ReportResponse.builder().build());
-			when(asyncMetricsDataHandler.getMetricsDataCompleted(reportId))
-				.thenReturn(MetricsDataCompleted.builder().build());
+			when(asyncMetricsDataHandler.getReportReadyStatusByTimeStamp(reportId))
+				.thenReturn(metricsDataDTO);
 			when(asyncExceptionHandler.get(any())).thenReturn(new BadRequestException("error"));
 
 			try {
-				generateReporterService.getComposedReportResponse(reportId, true);
+				generateReporterService.getComposedReportResponse(reportId);
 				fail();
 			}
 			catch (BaseException e) {
@@ -833,40 +807,6 @@ class GenerateReporterServiceTest {
 			Boolean deleteStatus = generateReporterService.deleteExpireCSV(System.currentTimeMillis(), directory);
 
 			assertTrue(deleteStatus);
-		}
-
-		@Test
-		void shouldReturnTrueWhenReportIsReady() {
-
-			String fileTimeStamp = Long.toString(System.currentTimeMillis());
-
-			when(asyncMetricsDataHandler.isReportReady(fileTimeStamp)).thenReturn(true);
-			boolean generateReportIsOver = generateReporterService.checkGenerateReportIsDone(fileTimeStamp);
-
-			assertTrue(generateReportIsOver);
-		}
-
-		@Test
-		void shouldReturnFalseWhenReportIsNotReady() {
-
-			String fileTimeStamp = Long.toString(System.currentTimeMillis());
-			asyncReportRequestHandler.putReport("111111111", MetricCsvFixture.MOCK_METRIC_CSV_DATA_WITH_ONE_PIPELINE());
-
-			boolean generateReportIsOver = generateReporterService.checkGenerateReportIsDone(fileTimeStamp);
-
-			assertFalse(generateReportIsOver);
-
-		}
-
-		@Test
-		void shouldThrowExceptionWhenTimeOutOf30m() {
-			String fileExpiredTimeStamp = Long.toString(System.currentTimeMillis() - 1900000L);
-
-			var generateReportException = assertThrows(GenerateReportException.class,
-					() -> generateReporterService.checkGenerateReportIsDone(fileExpiredTimeStamp));
-
-			assertEquals(500, generateReportException.getStatus());
-			assertEquals("Failed to get report due to report time expires", generateReportException.getMessage());
 		}
 
 		@Test

--- a/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
+++ b/backend/src/test/java/heartbeat/service/report/GenerateReporterServiceTest.java
@@ -6,6 +6,7 @@ import heartbeat.controller.report.dto.request.BuildKiteSetting;
 import heartbeat.controller.report.dto.request.CodebaseSetting;
 import heartbeat.controller.report.dto.request.GenerateReportRequest;
 import heartbeat.controller.report.dto.request.JiraBoardSetting;
+import heartbeat.controller.report.dto.request.MetricEnum;
 import heartbeat.controller.report.dto.request.MetricType;
 import heartbeat.controller.report.dto.response.ChangeFailureRate;
 import heartbeat.controller.report.dto.response.Classification;
@@ -555,7 +556,8 @@ class GenerateReporterServiceTest {
 				.considerHoliday(false)
 				.startTime("10000")
 				.endTime("20000")
-				.metrics(List.of("lead time for changes", "change failure rate"))
+				.metrics(
+						List.of(MetricEnum.LEAD_TIME_FOR_CHANGES.getValue(), MetricEnum.CHANGE_FAILURE_RATE.getValue()))
 				.codebaseSetting(CodebaseSetting.builder().build())
 				.buildKiteSetting(BuildKiteSetting.builder().build())
 				.csvTimeStamp(TIMESTAMP)
@@ -567,9 +569,9 @@ class GenerateReporterServiceTest {
 			List<PipelineCSVInfo> pipelineCSVInfos = List.of();
 			when(pipelineService.generateCSVForPipelineWithCodebase(any(), any(), any(), any(), any()))
 				.thenReturn(pipelineCSVInfos);
-			when(pipelineService.fetchGithubData(request))
+			when(pipelineService.fetchGithubData(any()))
 				.thenReturn(FetchedData.BuildKiteData.builder().buildInfosList(List.of()).build());
-			when(pipelineService.fetchBuildKiteInfo(request))
+			when(pipelineService.fetchBuildKiteInfo(any()))
 				.thenReturn(FetchedData.BuildKiteData.builder().buildInfosList(List.of()).build());
 			LeadTimeForChanges fakeLeadTimeForChange = LeadTimeForChanges.builder().build();
 			when(leadTimeForChangesCalculator.calculate(any())).thenReturn(fakeLeadTimeForChange);
@@ -591,7 +593,7 @@ class GenerateReporterServiceTest {
 				.considerHoliday(false)
 				.startTime("10000")
 				.endTime("20000")
-				.metrics(List.of("lead time for changes"))
+				.metrics(List.of(MetricEnum.LEAD_TIME_FOR_CHANGES.getValue()))
 				.codebaseSetting(CodebaseSetting.builder().build())
 				.buildKiteSetting(BuildKiteSetting.builder().build())
 				.csvTimeStamp(TIMESTAMP)

--- a/docs/src/content/docs/en/designs/refinement-on-generate-report.mdx
+++ b/docs/src/content/docs/en/designs/refinement-on-generate-report.mdx
@@ -212,6 +212,7 @@ group async process board related metrics
     Backend -> Backend: generate board report csv
     deactivate Backend
     note left
+        response.boardMetricsCompleted is true
         board metrics are ready for display
         board csv is ready for download
     end note
@@ -244,6 +245,7 @@ group async process pipeline and sourcecontrol related metrics
     end
     Backend -> Backend: generate pipeline report csv with github data if required
     note left
+        response.doraMetricsCompleted is true
         pipeline report is ready for download
     end note
     deactivate Backend
@@ -493,10 +495,9 @@ Response:
         "errorMessage": "string"
       },
     } <could be null if not required>,
-    "boardMetricsCompleted": Boolean <default is null>, 
-    "pipelineMetricsCompleted": Boolean <default is null>, 
-    "sourceControlMetricsCompleted": Boolean <default is null>,
-    "allMetricsCompleted": Boolean <default is null>,
+    "boardMetricsCompleted": boolean <default is false>, 
+    "doraMetricsCompleted": boolean <default is false>, 
+    "allMetricsCompleted": boolean <default is false>,
     "exportValidityTime": 0
 }
 ```


### PR DESCRIPTION
## Summary
### Issue description

1.click ‘next’  to the report page

2.click ‘export  pipeline data’ button

3.failed to export file and show 
<img width="977" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/52806477/375bbed7-1bd2-4e53-aa96-57bbbf056209">


After some research we found out the root cause of this kind of issue is that our backend doesn't keep the atomicity consistency. So I refactor our code and change the design of status life cycle.

## Before

When we click `export pipeline data`, sometimes we will encounter error and direct us to error page.

<img width="1757" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/52806477/3f90e68b-6daa-4329-92cf-9bf0994d67c6">

## After

As long as the button is clickable, clicking it will export regarding file.
<img width="1272" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/52806477/f3451e39-aa63-4ea2-9de9-aa011a954bad">


## Note

_Null_
