### PR TITLE
[Frontend] Fix/adm 718 fix style issues for desk check

### DIFF
--- a/frontend/__tests__/containers/MetricsStep/MetricsStep.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/MetricsStep.test.tsx
@@ -331,7 +331,7 @@ describe('MetricsStep', () => {
       setup();
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+        expect(screen.getByText(/try again/i)).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/components/Common/EmptyContent/styles.tsx
+++ b/frontend/src/components/Common/EmptyContent/styles.tsx
@@ -6,10 +6,11 @@ export const StyledErrorSection = styled.div({
   flexDirection: 'column',
   alignItems: 'center',
   justifyContent: 'center',
+  padding: '1.5rem 0',
 });
 
 export const StyledImgSection = styled.img({
-  height: '3.8rem',
+  height: '5.75rem',
   marginBottom: '1rem',
 });
 

--- a/frontend/src/containers/MetricsStep/index.tsx
+++ b/frontend/src/containers/MetricsStep/index.tsx
@@ -15,11 +15,11 @@ import {
 } from '@src/containers/MetricsStep/style';
 import { DeploymentFrequencySettings } from '@src/containers/MetricsStep/DeploymentFrequencySettings';
 import { selectMetricsContent, updateMetricsState } from '@src/context/Metrics/metricsSlice';
+import { StyledRetryButton, StyledErrorMessage } from '@src/containers/MetricsStep/style';
 import { CYCLE_TIME_SETTINGS_TYPES, DONE, REQUIRED_DATA } from '@src/constants/resources';
 import { closeAllNotifications } from '@src/context/notification/NotificationSlice';
 import { Classification } from '@src/containers/MetricsStep/Classification';
 import { shouldMetricsLoad } from '@src/context/stepper/StepperSlice';
-import { StyledRetryButton } from '@src/containers/MetricsStep/style';
 import DateRangeViewer from '@src/components/Common/DateRangeViewer';
 import { HEARTBEAT_EXCEPTION_CODE } from '@src/constants/resources';
 import { useGetBoardInfoEffect } from '@src/hooks/useGetBoardInfo';
@@ -89,10 +89,9 @@ const MetricsStep = () => {
       {isShowCrewsAndRealDone && (
         <MetricSelectionWrapper>
           {isLoading && <Loading />}
+          <MetricsSelectionTitle>Board configuration</MetricsSelectionTitle>
           {isEmpty(errorMessage) ? (
             <>
-              <MetricsSelectionTitle>Board configuration</MetricsSelectionTitle>
-
               <Crews options={users} title={'Crew settings'} label={'Included Crews'} />
 
               {requiredData.includes(REQUIRED_DATA.CYCLE_TIME) && <CycleTime />}
@@ -117,12 +116,8 @@ const MetricsStep = () => {
                   errorMessage.message
                 ) : (
                   <>
-                    {errorMessage.message}
-                    {
-                      <StyledRetryButton variant='text' disabled={isLoading} onClick={getInfo}>
-                        Retry
-                      </StyledRetryButton>
-                    }
+                    <StyledErrorMessage>{errorMessage.message}</StyledErrorMessage>
+                    {<StyledRetryButton onClick={getInfo}>try again</StyledRetryButton>}
                   </>
                 )
               }

--- a/frontend/src/containers/MetricsStep/style.tsx
+++ b/frontend/src/containers/MetricsStep/style.tsx
@@ -1,6 +1,6 @@
 import { Divider } from '@src/components/Common/MetricsSettingTitle/style';
 import { styled } from '@mui/material/styles';
-import { Button } from '@mui/material';
+import { Link } from '@mui/material';
 import { theme } from '@src/theme';
 
 export const MetricSelectionHeader = styled('div')({
@@ -37,8 +37,14 @@ export const ReportSelectionTitle = styled(MetricsSelectionTitle)({
 
 export const ConfigSelectionTitle = styled(ReportSelectionTitle)({});
 
-export const StyledRetryButton = styled(Button)({
+export const StyledErrorMessage = styled('span')({
+  fontSize: '1.25rem',
+});
+
+export const StyledRetryButton = styled(Link)({
+  marginLeft: '.5rem',
   fontWeight: '700',
-  minWidth: '3.4rem',
-  padding: '0',
+  fontSize: '1.25rem',
+  textDecoration: 'none',
+  cursor: 'pointer',
 });

--- a/frontend/src/containers/MetricsStep/style.tsx
+++ b/frontend/src/containers/MetricsStep/style.tsx
@@ -43,7 +43,7 @@ export const StyledErrorMessage = styled('span')({
 
 export const StyledRetryButton = styled(Link)({
   marginLeft: '.5rem',
-  fontWeight: '700',
+  fontWeight: '900',
   fontSize: '1.25rem',
   textDecoration: 'none',
   cursor: 'pointer',


### PR DESCRIPTION
## Summary

...

## Before

1.not show board config title in metics page
2. wrong button text 'retry'
3. wrong styles about retry message 

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

1. show board config title when board config context is empty
2. replace 'retry' button text to 'try again'
3. fix the font-size ,  image size for retry content

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
