### PR TITLE
ADM-813[frontend/backend]: add Advance field in metrics page

### DIFF
--- a/backend/src/main/java/heartbeat/controller/board/dto/request/StoryPointsAndCycleTimeRequest.java
+++ b/backend/src/main/java/heartbeat/controller/board/dto/request/StoryPointsAndCycleTimeRequest.java
@@ -32,6 +32,8 @@ public class StoryPointsAndCycleTimeRequest {
 
 	private List<TargetField> targetFields;
 
+	private List<TargetField> overrideFields;
+
 	private boolean treatFlagCardAsBlock;
 
 }

--- a/backend/src/main/java/heartbeat/controller/report/dto/request/JiraBoardSetting.java
+++ b/backend/src/main/java/heartbeat/controller/report/dto/request/JiraBoardSetting.java
@@ -37,4 +37,6 @@ public class JiraBoardSetting {
 
 	private List<TargetField> targetFields;
 
+	private List<TargetField> overrideFields;
+
 }

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -909,7 +909,8 @@ public class JiraService {
 					+ "') ORDER BY updated DESC";
 		}
 
-		return getCardList(baseUrl, boardRequestParam, jql, NONE_DONE_CARD_TAG, overrideFields, NONE_DONE_MAX_QUERY_COUNT);
+		return getCardList(baseUrl, boardRequestParam, jql, NONE_DONE_CARD_TAG, overrideFields,
+				NONE_DONE_MAX_QUERY_COUNT);
 	}
 
 	private JiraCardWithFields getAllNonDoneCardsForKanBan(URI baseUrl, List<String> status,
@@ -921,7 +922,8 @@ public class JiraService {
 		else {
 			jql = "status not in ('" + String.join("','", status) + "') ORDER BY updated DESC";
 		}
-		return getCardList(baseUrl, boardRequestParam, jql, NONE_DONE_CARD_TAG, overrideFields, NONE_DONE_MAX_QUERY_COUNT);
+		return getCardList(baseUrl, boardRequestParam, jql, NONE_DONE_CARD_TAG, overrideFields,
+				NONE_DONE_MAX_QUERY_COUNT);
 	}
 
 	private JiraCardWithFields getCardList(URI baseUrl, BoardRequestParam boardRequestParam, String jql,

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -421,7 +421,8 @@ public class JiraService {
 		return allCardsResponseDTO;
 	}
 
-	private static Map<String, JsonElement> getCustomfieldMap(Gson gson, Map<String, Sprint> sprintMap, Map<String, String> resultMap, JsonElement element, JsonObject jsonElement) {
+	private static Map<String, JsonElement> getCustomfieldMap(Gson gson, Map<String, Sprint> sprintMap,
+			Map<String, String> resultMap, JsonElement element, JsonObject jsonElement) {
 		Map<String, JsonElement> customFieldMap = new HashMap<>();
 		for (Map.Entry<String, String> entry : resultMap.entrySet()) {
 			String customFieldKey = entry.getKey();
@@ -449,8 +450,7 @@ public class JiraService {
 						fieldValue = new JsonPrimitive(doubleValue);
 					}
 				}
-				else if (customFieldValue.equals("Flagged") && !fieldValue.isJsonNull()
-						&& fieldValue.isJsonArray()) {
+				else if (customFieldValue.equals("Flagged") && !fieldValue.isJsonNull() && fieldValue.isJsonArray()) {
 					JsonArray jsonArray = fieldValue.getAsJsonArray();
 					if (!jsonArray.isJsonNull() && !jsonArray.isEmpty()) {
 						JsonElement targetField = jsonArray.get(jsonArray.size() - 1);
@@ -729,7 +729,7 @@ public class JiraService {
 		double total = 0;
 		for (CycleTimeInfo cycleTimeInfo : cycleTimeInfos) {
 			String swimLane = cycleTimeInfo.getColumn();
-			if (swimLane.equals(CardStepsEnum.BLOCK.getValue().toUpperCase())) {
+			if (swimLane.equalsIgnoreCase(CardStepsEnum.BLOCK.getValue())) {
 				boardMap.put(swimLane, CardStepsEnum.BLOCK);
 			}
 			if (boardMap.containsKey(swimLane)) {

--- a/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
+++ b/backend/src/main/java/heartbeat/service/board/jira/JiraService.java
@@ -725,7 +725,7 @@ public class JiraService {
 		double total = 0;
 		for (CycleTimeInfo cycleTimeInfo : cycleTimeInfos) {
 			String swimLane = cycleTimeInfo.getColumn();
-			if (swimLane.equals("FLAG")) {
+			if (swimLane.equals(CardStepsEnum.BLOCK.getValue().toUpperCase())) {
 				boardMap.put(swimLane, CardStepsEnum.BLOCK);
 			}
 			if (boardMap.containsKey(swimLane)) {

--- a/backend/src/main/java/heartbeat/service/report/KanbanService.java
+++ b/backend/src/main/java/heartbeat/service/report/KanbanService.java
@@ -58,6 +58,7 @@ public class KanbanService {
 			.startTime(startTime)
 			.endTime(endTime)
 			.targetFields(jiraBoardSetting.getTargetFields())
+			.overrideFields(jiraBoardSetting.getOverrideFields())
 			.treatFlagCardAsBlock(jiraBoardSetting.getTreatFlagCardAsBlock())
 			.build();
 	}

--- a/backend/src/test/java/heartbeat/service/jira/JiraBoardConfigDTOFixture.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraBoardConfigDTOFixture.java
@@ -348,6 +348,24 @@ public class JiraBoardConfigDTOFixture {
 		return FieldResponseDTO.builder().projects(List.of(new Project(List.of(new Issuetype(issueFieldMap)))));
 	}
 
+	public static FieldResponseDTO.FieldResponseDTOBuilder ALL_FIELD_RESPONSE_BUILDER_HAS_STORY_POINT() {
+		IssueField timetrackingIssueField = new IssueField("timetracking", "Time tracking");
+		IssueField summaryIssueField = new IssueField("summary", "Summary");
+		IssueField descriptionIssueField = new IssueField("description", "Description");
+		IssueField priorityIssueField = new IssueField("priority", "Priority");
+		IssueField flaggedIssueField = new IssueField("customfield_10021", "Flagged");
+		IssueField storyPointIssueField = new IssueField("customfield_10006", "story points");
+		HashMap<String, IssueField> issueFieldMap = new HashMap<>();
+		issueFieldMap.put("timetracking", timetrackingIssueField);
+		issueFieldMap.put("summary", summaryIssueField);
+		issueFieldMap.put("description", descriptionIssueField);
+		issueFieldMap.put("priority", priorityIssueField);
+		issueFieldMap.put("customfield_10021", flaggedIssueField);
+		issueFieldMap.put("customfield_10006", storyPointIssueField);
+
+		return FieldResponseDTO.builder().projects(List.of(new Project(List.of(new Issuetype(issueFieldMap)))));
+	}
+
 	public static FieldResponseDTO.FieldResponseDTOBuilder INCLUDE_UNREASONABLE_FIELD_RESPONSE_BUILDER() {
 		IssueField timetrackingIssueField = new IssueField("timetracking", "Time tracking");
 		IssueField priorityIssueField = new IssueField("priority", "Priority");

--- a/backend/src/test/java/heartbeat/service/jira/JiraBoardConfigDTOFixture.java
+++ b/backend/src/test/java/heartbeat/service/jira/JiraBoardConfigDTOFixture.java
@@ -588,7 +588,7 @@ public class JiraBoardConfigDTOFixture {
 				CycleTimeInfo.builder().column("REVIEW").day(4.0).build(),
 				CycleTimeInfo.builder().column("ANALYSIS").day(9.0).build(),
 				CycleTimeInfo.builder().column(UNKNOWN).day(5.0).build(),
-				CycleTimeInfo.builder().column(FLAG).day(6.0).build());
+				CycleTimeInfo.builder().column("BLOCK").day(6.0).build());
 	}
 
 	public static JiraBoardSetting.JiraBoardSettingBuilder JIRA_BOARD_SETTING_WITH_HISTORICAL_ASSIGNEE_FILTER_METHOD() {

--- a/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
@@ -41,7 +41,7 @@ describe('Advance', () => {
     });
 
     await waitFor(() => {
-      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings({ storyPoint: '', flag: '' }));
+      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings(null));
     });
   });
 
@@ -58,7 +58,7 @@ describe('Advance', () => {
     });
   });
 
-  it('should input Advanced setting value after click check box', async () => {
+  it('should input Advanced setting value after click check box when value are not all empty', async () => {
     setup();
 
     await act(async () => {
@@ -73,6 +73,27 @@ describe('Advance', () => {
 
     await waitFor(() => {
       expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings({ flag: '456', storyPoint: '123' }));
+    });
+  });
+
+  it('should clear Advanced setting value when value are all empty', async () => {
+    setup();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('checkbox'));
+      const storyPointInput = within(screen.getByTestId('Story Point')).getByLabelText(
+        'input Story Point',
+      ) as HTMLInputElement;
+      const flagInput = within(screen.getByTestId('Flag')).getByLabelText('input Flag') as HTMLInputElement;
+      await userEvent.type(storyPointInput, '123');
+      await userEvent.type(flagInput, '4');
+
+      await userEvent.clear(storyPointInput);
+      await userEvent.clear(flagInput);
+    });
+
+    await waitFor(() => {
+      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings(null));
     });
   });
 });

--- a/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
@@ -12,10 +12,9 @@ jest.mock('@src/hooks/useAppDispatch', () => ({
   useAppDispatch: () => mockedUseAppDispatch,
 }));
 
-let store = null;
+let store = setupStore();
 
 describe('Advance', () => {
-  store = setupStore();
   const setup = () => {
     store = setupStore();
     render(
@@ -25,22 +24,37 @@ describe('Advance', () => {
     );
   };
   afterEach(() => {
-    store = null;
+    jest.clearAllMocks();
   });
 
   it('should show Advanced setting title when render Advance component', () => {
     setup();
+
     expect(screen.getByText(ADVANCED_SETTINGS_TITLE)).toBeInTheDocument();
   });
 
   it('should show Advanced setting input when click check box', async () => {
     setup();
+
     await act(async () => {
       await userEvent.click(screen.getByRole('checkbox'));
     });
 
     await waitFor(() => {
       expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings({ storyPoint: '', flag: '' }));
+    });
+  });
+
+  it('should show Advanced setting input when Advanced settings not null', async () => {
+    setup();
+    store.dispatch(updateAdvancedSettings({ storyPoint: '', flag: '' }));
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('checkbox'));
+    });
+
+    await waitFor(() => {
+      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings(null));
     });
   });
 

--- a/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/Advance.test.tsx
@@ -1,0 +1,64 @@
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { updateAdvancedSettings } from '@src/context/Metrics/metricsSlice';
+import { Advance } from '@src/containers/MetricsStep/Advance/Advance';
+import { ADVANCED_SETTINGS_TITLE } from '../../fixtures';
+import { setupStore } from '../../utils/setupStoreUtil';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import React from 'react';
+
+const mockedUseAppDispatch = jest.fn();
+jest.mock('@src/hooks/useAppDispatch', () => ({
+  useAppDispatch: () => mockedUseAppDispatch,
+}));
+
+let store = null;
+
+describe('Advance', () => {
+  store = setupStore();
+  const setup = () => {
+    store = setupStore();
+    render(
+      <Provider store={store}>
+        <Advance />
+      </Provider>,
+    );
+  };
+  afterEach(() => {
+    store = null;
+  });
+
+  it('should show Advanced setting title when render Advance component', () => {
+    setup();
+    expect(screen.getByText(ADVANCED_SETTINGS_TITLE)).toBeInTheDocument();
+  });
+
+  it('should show Advanced setting input when click check box', async () => {
+    setup();
+    await act(async () => {
+      await userEvent.click(screen.getByRole('checkbox'));
+    });
+
+    await waitFor(() => {
+      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings({ storyPoint: '', flag: '' }));
+    });
+  });
+
+  it('should input Advanced setting value after click check box', async () => {
+    setup();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('checkbox'));
+      const storyPointInput = within(screen.getByTestId('Story Point')).getByLabelText(
+        'input Story Point',
+      ) as HTMLInputElement;
+      const flagInput = within(screen.getByTestId('Flag')).getByLabelText('input Flag') as HTMLInputElement;
+      await userEvent.type(storyPointInput, '123');
+      await userEvent.type(flagInput, '456');
+    });
+
+    await waitFor(() => {
+      expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAdvancedSettings({ flag: '456', storyPoint: '123' }));
+    });
+  });
+});

--- a/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
@@ -334,6 +334,7 @@ describe('MetricsStepper', () => {
   it('should export json file when click save button in metrics page given all content is empty', async () => {
     const expectedFileName = 'config';
     const expectedJson = {
+      advancedSettings: null,
       assigneeFilter: ASSIGNEE_FILTER_TYPES.LAST_ASSIGNEE,
       board: { boardId: '', email: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',
@@ -364,6 +365,7 @@ describe('MetricsStepper', () => {
   it('should export json file when click save button in report page given all content is empty', async () => {
     const expectedFileName = 'config';
     const expectedJson = {
+      advancedSettings: null,
       assigneeFilter: ASSIGNEE_FILTER_TYPES.LAST_ASSIGNEE,
       board: { boardId: '', email: '', site: '', token: '', type: 'Jira' },
       calendarType: 'Regular Calendar(Weekend Considered)',

--- a/frontend/__tests__/context/metricsSlice.test.ts
+++ b/frontend/__tests__/context/metricsSlice.test.ts
@@ -48,6 +48,7 @@ const initState = {
     importedClassification: [],
     importedDeployment: [],
     importedLeadTime: [],
+    importedAdvancedSettings: null,
   },
   cycleTimeWarningMessage: null,
   classificationWarningMessage: null,
@@ -108,6 +109,7 @@ describe('saveMetricsSetting reducer', () => {
       importedClassification: [],
       importedDeployment: [],
       importedPipelineCrews: [],
+      importedAdvancedSettings: null,
     });
   });
 
@@ -186,6 +188,10 @@ describe('saveMetricsSetting reducer', () => {
       deployment: [{ id: 0, organization: 'organization', pipelineName: 'pipelineName', step: 'step' }],
       leadTime: [],
       pipelineCrews: [],
+      advancedSettings: {
+        storyPoint: '1',
+        flag: '2',
+      },
     };
     const savedMetricsSetting = saveMetricsSettingReducer(
       initState,
@@ -204,6 +210,7 @@ describe('saveMetricsSetting reducer', () => {
       importedClassification: mockMetricsImportedData.classification,
       importedDeployment: mockMetricsImportedData.deployment,
       importedLeadTime: mockMetricsImportedData.leadTime,
+      advancedSettings: mockMetricsImportedData.advancedSettings,
     });
   });
 

--- a/frontend/__tests__/context/metricsSlice.test.ts
+++ b/frontend/__tests__/context/metricsSlice.test.ts
@@ -210,7 +210,7 @@ describe('saveMetricsSetting reducer', () => {
       importedClassification: mockMetricsImportedData.classification,
       importedDeployment: mockMetricsImportedData.deployment,
       importedLeadTime: mockMetricsImportedData.leadTime,
-      advancedSettings: mockMetricsImportedData.advancedSettings,
+      importedAdvancedSettings: mockMetricsImportedData.advancedSettings,
     });
   });
 

--- a/frontend/__tests__/fixtures.ts
+++ b/frontend/__tests__/fixtures.ts
@@ -204,6 +204,7 @@ export const MOCK_GENERATE_REPORT_REQUEST_PARAMS: ReportRequestDTO = {
     assigneeFilter: 'lastAssignee',
     targetFields: [{ key: 'parent', name: 'Parent', flag: false }],
     doneColumn: ['Done'],
+    overrideFields: [{ key: '123', name: 'Story Point', flag: true }],
   },
 };
 
@@ -740,3 +741,5 @@ export const MOCK_SOURCE_CONTROL_VERIFY_ERROR_CASE_TEXT = 'Token is incorrect!';
 export const FAKE_TOKEN = 'fake-token';
 
 export const FAKE_PIPELINE_TOKEN = 'bkua_mockTokenMockTokenMockTokenMockToken1234';
+
+export const ADVANCED_SETTINGS_TITLE = 'Advanced settings';

--- a/frontend/src/clients/report/dto/request.ts
+++ b/frontend/src/clients/report/dto/request.ts
@@ -46,6 +46,7 @@ export interface ReportRequestDTO {
     doneColumn: string[];
   };
   csvTimeStamp?: number;
+  advancedSettings: { key: string; name: string; flag: boolean }[];
 }
 
 export interface BoardReportRequestDTO {

--- a/frontend/src/clients/report/dto/request.ts
+++ b/frontend/src/clients/report/dto/request.ts
@@ -47,7 +47,6 @@ export interface ReportRequestDTO {
     doneColumn: string[];
   };
   csvTimeStamp?: number;
-  advancedSettings: { key: string; name: string; flag: boolean }[];
 }
 
 export interface BoardReportRequestDTO {

--- a/frontend/src/clients/report/dto/request.ts
+++ b/frontend/src/clients/report/dto/request.ts
@@ -43,6 +43,7 @@ export interface ReportRequestDTO {
     users: string[];
     assigneeFilter: string;
     targetFields: { key: string; name: string; flag: boolean }[];
+    overrideFields: { key: string; name: string; flag: boolean }[];
     doneColumn: string[];
   };
   csvTimeStamp?: number;
@@ -65,6 +66,7 @@ export interface BoardReportRequestDTO {
     users: string[];
     assigneeFilter: string;
     targetFields: { key: string; name: string; flag: boolean }[];
+    overrideFields: { key: string; name: string; flag: boolean }[];
     doneColumn: string[];
   };
   csvTimeStamp?: number;

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -155,6 +155,8 @@ export const TIPS = {
   SAVE_CONFIG:
     'Note: When you save the settings, some tokens might be saved, please save it safely (e.g. by 1 password, vault), Rotate the tokens regularly. (e.g. every 3 months)',
   CYCLE_TIME: 'The report page will sum all the status in the column for cycletime calculation',
+  ADVANCE:
+    'If the story point and block related values in the board data are 0 due to token permissions or other reasons, please manually enter the corresponding customized field key.Otherwise, please ignore it.',
 };
 
 export enum VELOCITY_METRICS_NAME {

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -74,9 +74,7 @@ export const Advance = () => {
               </IconButton>
             </StyledTooltip>
           </TooltipContainer>
-          <Link href='#' underline='none'>
-            how to set up?
-          </Link>
+          <Link underline='none'>how to set up?</Link>
         </TitleAndTooltipContainer>
       </AdvancedContainer>
 

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -35,6 +35,17 @@ export const Advance = () => {
     // dispatch(updateAdvancedSettings(newAdvancedSettings));
   };
 
+  function getAdvancedStettings(fields: Field[]) {
+    const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
+    const flag = fields.find((item) => item.key === 'Flag')?.value;
+    return { storyPoint, flag };
+  }
+
+  const handleUpdate = (fields: Field[]) => {
+    setFields(fields);
+    dispatch(updateAdvancedSettings(getAdvancedStettings(fields)));
+  };
+
   const updateField = (key: string, value: string) => {
     const newFields = fields.map((field) =>
       field.key === key
@@ -45,14 +56,6 @@ export const Advance = () => {
         : field,
     );
     handleUpdate(newFields);
-  };
-
-  const handleUpdate = (fields: Field[]) => {
-    setFields(fields);
-    const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
-    const flag = fields.find((item) => item.key === 'Flag')?.value;
-    const newAdvancedSettings = { storyPoint, flag };
-    dispatch(updateAdvancedSettings(newAdvancedSettings));
   };
 
   return (

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -14,28 +14,31 @@ export const Advance = () => {
   const [fields, setFields] = useState<Field[]>([
     {
       key: 'Story Point',
-      value: advancedSettings.storyPoint,
+      value: advancedSettings?.storyPoint ?? '',
       validatedError: '',
       verifiedError: '',
       col: 2,
     },
     {
       key: 'Flag',
-      value: advancedSettings.flag,
+      value: advancedSettings?.flag ?? '',
       validatedError: '',
       verifiedError: '',
       col: 2,
     },
   ]);
 
-  const handleAdvancedSettings = () => {
-    // const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
-    // const flag = fields.find((item) => item.key === 'Flag')?.value;
-    // const newAdvancedSettings = { storyPoint, flag };
-    // dispatch(updateAdvancedSettings(newAdvancedSettings));
+  const toggleAdvancedSettings = () => {
+    const newFields = fields.map((field) => ({
+      ...field,
+      value: '',
+    }));
+    setFields(newFields);
+    const newAdvancedStettings = advancedSettings ? null : { storyPoints: '', flag: '' };
+    dispatch(updateAdvancedSettings(newAdvancedStettings));
   };
 
-  function getAdvancedStettings(fields: Field[]) {
+  function getAdvancedSettings(fields: Field[]) {
     const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
     const flag = fields.find((item) => item.key === 'Flag')?.value;
     return { storyPoint, flag };
@@ -43,7 +46,7 @@ export const Advance = () => {
 
   const handleUpdate = (fields: Field[]) => {
     setFields(fields);
-    dispatch(updateAdvancedSettings(getAdvancedStettings(fields)));
+    dispatch(updateAdvancedSettings(getAdvancedSettings(fields)));
   };
 
   const updateField = (key: string, value: string) => {
@@ -60,7 +63,7 @@ export const Advance = () => {
 
   return (
     <>
-      <AdvancedContainer onClick={handleAdvancedSettings}>
+      <AdvancedContainer onClick={toggleAdvancedSettings}>
         <ItemCheckbox checked={!!advancedSettings} />
         <TitleAndTooltipContainer>
           <AdvancedTitleContainer>Advanced settings</AdvancedTitleContainer>
@@ -77,19 +80,21 @@ export const Advance = () => {
         </TitleAndTooltipContainer>
       </AdvancedContainer>
 
-      <AdvancedForm>
-        {fields.map(({ key, col, value }, index) => (
-          <TextField
-            id='standard-basic'
-            variant='standard'
-            sx={{ gridColumn: `span ${col}` }}
-            key={index}
-            label={key}
-            value={value}
-            onChange={(e) => updateField(key, e.target.value)}
-          />
-        ))}
-      </AdvancedForm>
+      {advancedSettings && (
+        <AdvancedForm>
+          {fields.map(({ key, col, value }, index) => (
+            <TextField
+              id='standard-basic'
+              variant='standard'
+              sx={{ gridColumn: `span ${col}` }}
+              key={index}
+              label={key}
+              value={value}
+              onChange={(e) => updateField(key, e.target.value)}
+            />
+          ))}
+        </AdvancedForm>
+      )}
     </>
   );
 };

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -1,0 +1,73 @@
+import {
+  ItemCheckbox,
+  StyledTooltip,
+  TitleAndTooltipContainer,
+  TooltipContainer
+} from '../CycleTime/style';
+import { selectTreatFlagCardAsBlock, updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
+import { AdvancedContainer, AdvancedForm, AdvancedTitleContainer } from './style';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import { IconButton, Link, TextField } from '@mui/material';
+import { useAppDispatch, useAppSelector } from '@src/hooks';
+import { Field } from '@src/hooks/useVerifyBoardEffect';
+import { TIPS } from '@src/constants/resources';
+import { useState } from 'react';
+
+export const Advance = () => {
+  const dispatch = useAppDispatch();
+  const flagCardAsBlock = useAppSelector(selectTreatFlagCardAsBlock);
+
+  const handleFlagCardAsBlock = () => {
+    dispatch(updateTreatFlagCardAsBlock(!flagCardAsBlock));
+  };
+
+  const [fields, setFields] = useState<Field[]>([
+    {
+      key: 'Story Point',
+      value: '',
+      validatedError: '',
+      verifiedError: '',
+      col: 2,
+    },
+    {
+      key: 'Flag',
+      value: '',
+      validatedError: '',
+      verifiedError: '',
+      col: 2,
+    },
+  ]);
+
+  return (
+    <>
+      <AdvancedContainer onClick={handleFlagCardAsBlock}>
+        <ItemCheckbox checked={flagCardAsBlock} />
+        <TitleAndTooltipContainer>
+          <AdvancedTitleContainer>Advanced settings</AdvancedTitleContainer>
+          <TooltipContainer data-test-id={'tooltip'}>
+            <StyledTooltip arrow title={TIPS.ADVANCE} placement='top-start'>
+              <IconButton aria-label='info'>
+                <InfoOutlinedIcon />
+              </IconButton>
+            </StyledTooltip>
+          </TooltipContainer>
+          <Link href='#' underline='none'>
+            how to set up?
+          </Link>
+        </TitleAndTooltipContainer>
+      </AdvancedContainer>
+
+      <AdvancedForm>
+        {fields.map(({ key, col }, index) => (
+          <TextField
+            id='standard-basic'
+            variant='standard'
+            sx={{ gridColumn: `span ${col}` }}
+            key={index}
+            label={key}
+          />
+        ))}
+      </AdvancedForm>
+    </>
+  );
+};

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -29,6 +29,26 @@ export const Advance = () => {
   ]);
 
   const handleAdvancedSettings = () => {
+    // const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
+    // const flag = fields.find((item) => item.key === 'Flag')?.value;
+    // const newAdvancedSettings = { storyPoint, flag };
+    // dispatch(updateAdvancedSettings(newAdvancedSettings));
+  };
+
+  const updateField = (key: string, value: string) => {
+    const newFields = fields.map((field) =>
+      field.key === key
+        ? {
+            ...field,
+            value: value.trim(),
+          }
+        : field,
+    );
+    handleUpdate(newFields);
+  };
+
+  const handleUpdate = (fields: Field[]) => {
+    setFields(fields);
     const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
     const flag = fields.find((item) => item.key === 'Flag')?.value;
     const newAdvancedSettings = { storyPoint, flag };
@@ -63,6 +83,7 @@ export const Advance = () => {
             key={index}
             label={key}
             value={value}
+            onChange={(e) => updateField(key, e.target.value)}
           />
         ))}
       </AdvancedForm>

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -3,14 +3,16 @@ import { selectAdvancedSettings, updateAdvancedSettings } from '@src/context/Met
 import { AdvancedContainer, AdvancedForm, AdvancedTitleContainer } from './style';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { IconButton, Link, TextField } from '@mui/material';
-import { useAppDispatch, useAppSelector } from '@src/hooks';
+import { useAppDispatch } from '@src/hooks/useAppDispatch';
 import { Field } from '@src/hooks/useVerifyBoardEffect';
 import { TIPS } from '@src/constants/resources';
+import { useAppSelector } from '@src/hooks';
 import { useState } from 'react';
 
 export const Advance = () => {
   const dispatch = useAppDispatch();
   const advancedSettings = useAppSelector(selectAdvancedSettings);
+  const [open, setOpen] = useState(!!advancedSettings);
   const [fields, setFields] = useState<Field[]>([
     {
       key: 'Story Point',
@@ -33,8 +35,9 @@ export const Advance = () => {
       ...field,
       value: '',
     }));
+    setOpen(!open);
     setFields(newFields);
-    const newAdvancedSettings = advancedSettings ? null : { storyPoints: '', flag: '' };
+    const newAdvancedSettings = advancedSettings ? null : { storyPoint: '', flag: '' };
     dispatch(updateAdvancedSettings(newAdvancedSettings));
   };
 
@@ -78,16 +81,17 @@ export const Advance = () => {
         </TitleAndTooltipContainer>
       </AdvancedContainer>
 
-      {advancedSettings && (
+      {open && (
         <AdvancedForm>
           {fields.map(({ key, col, value }, index) => (
             <TextField
-              id='standard-basic'
               variant='standard'
               sx={{ gridColumn: `span ${col}` }}
               key={index}
               label={key}
               value={value}
+              data-testid={key}
+              inputProps={{ 'aria-label': `input ${key}` }}
               onChange={(e) => updateField(key, e.target.value)}
             />
           ))}

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -34,8 +34,8 @@ export const Advance = () => {
       value: '',
     }));
     setFields(newFields);
-    const newAdvancedStettings = advancedSettings ? null : { storyPoints: '', flag: '' };
-    dispatch(updateAdvancedSettings(newAdvancedStettings));
+    const newAdvancedSettings = advancedSettings ? null : { storyPoints: '', flag: '' };
+    dispatch(updateAdvancedSettings(newAdvancedSettings));
   };
 
   function getAdvancedSettings(fields: Field[]) {

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -37,13 +37,13 @@ export const Advance = () => {
     }));
     setOpen(!open);
     setFields(newFields);
-    const newAdvancedSettings = advancedSettings ? null : { storyPoint: '', flag: '' };
-    dispatch(updateAdvancedSettings(newAdvancedSettings));
+    dispatch(updateAdvancedSettings(null));
   };
 
   function getAdvancedSettings(fields: Field[]) {
     const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
     const flag = fields.find((item) => item.key === 'Flag')?.value;
+    if (storyPoint === '' && flag === '') return null;
     return { storyPoint, flag };
   }
 
@@ -67,7 +67,7 @@ export const Advance = () => {
   return (
     <>
       <AdvancedContainer onClick={toggleAdvancedSettings}>
-        <ItemCheckbox checked={!!advancedSettings} />
+        <ItemCheckbox checked={open} />
         <TitleAndTooltipContainer>
           <AdvancedTitleContainer>Advanced settings</AdvancedTitleContainer>
           <TooltipContainer data-test-id={'tooltip'}>

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -1,11 +1,7 @@
-import {
-  ItemCheckbox,
-  StyledTooltip,
-  TitleAndTooltipContainer,
-  TooltipContainer
-} from '../CycleTime/style';
+import { ItemCheckbox, StyledTooltip, TitleAndTooltipContainer, TooltipContainer } from '../CycleTime/style';
 import { selectTreatFlagCardAsBlock, updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
 import { AdvancedContainer, AdvancedForm, AdvancedTitleContainer } from './style';
+import { selectAdvancedSettings } from '@src/context/Metrics/metricsSlice';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { IconButton, Link, TextField } from '@mui/material';
 import { useAppDispatch, useAppSelector } from '@src/hooks';
@@ -15,33 +11,33 @@ import { useState } from 'react';
 
 export const Advance = () => {
   const dispatch = useAppDispatch();
-  const flagCardAsBlock = useAppSelector(selectTreatFlagCardAsBlock);
-
-  const handleFlagCardAsBlock = () => {
-    dispatch(updateTreatFlagCardAsBlock(!flagCardAsBlock));
-  };
-
+  const advancedSettings = useAppSelector(selectAdvancedSettings);
   const [fields, setFields] = useState<Field[]>([
     {
       key: 'Story Point',
-      value: '',
+      value: advancedSettings.storyPoint,
       validatedError: '',
       verifiedError: '',
       col: 2,
     },
     {
       key: 'Flag',
-      value: '',
+      value: advancedSettings.flag,
       validatedError: '',
       verifiedError: '',
       col: 2,
     },
   ]);
 
+  const handleAdvancedSettings = () => {
+    // dispatch(updateTreatFlagCardAsBlock(!flagCardAsBlock));
+    dispatch(updateAdvancedSettings(!flagCardAsBlock));
+  };
+
   return (
     <>
-      <AdvancedContainer onClick={handleFlagCardAsBlock}>
-        <ItemCheckbox checked={flagCardAsBlock} />
+      <AdvancedContainer onClick={handleAdvancedSettings}>
+        <ItemCheckbox checked={!!advancedSettings} />
         <TitleAndTooltipContainer>
           <AdvancedTitleContainer>Advanced settings</AdvancedTitleContainer>
           <TooltipContainer data-test-id={'tooltip'}>
@@ -58,13 +54,14 @@ export const Advance = () => {
       </AdvancedContainer>
 
       <AdvancedForm>
-        {fields.map(({ key, col }, index) => (
+        {fields.map(({ key, col, value }, index) => (
           <TextField
             id='standard-basic'
             variant='standard'
             sx={{ gridColumn: `span ${col}` }}
             key={index}
             label={key}
+            value={value}
           />
         ))}
       </AdvancedForm>

--- a/frontend/src/containers/MetricsStep/Advance/Advance.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/Advance.tsx
@@ -1,7 +1,6 @@
 import { ItemCheckbox, StyledTooltip, TitleAndTooltipContainer, TooltipContainer } from '../CycleTime/style';
-import { selectTreatFlagCardAsBlock, updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
+import { selectAdvancedSettings, updateAdvancedSettings } from '@src/context/Metrics/metricsSlice';
 import { AdvancedContainer, AdvancedForm, AdvancedTitleContainer } from './style';
-import { selectAdvancedSettings } from '@src/context/Metrics/metricsSlice';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import { IconButton, Link, TextField } from '@mui/material';
 import { useAppDispatch, useAppSelector } from '@src/hooks';
@@ -30,8 +29,10 @@ export const Advance = () => {
   ]);
 
   const handleAdvancedSettings = () => {
-    // dispatch(updateTreatFlagCardAsBlock(!flagCardAsBlock));
-    dispatch(updateAdvancedSettings(!flagCardAsBlock));
+    const storyPoint = fields.find((item) => item.key === 'Story Point')?.value;
+    const flag = fields.find((item) => item.key === 'Flag')?.value;
+    const newAdvancedSettings = { storyPoint, flag };
+    dispatch(updateAdvancedSettings(newAdvancedSettings));
   };
 
   return (

--- a/frontend/src/containers/MetricsStep/Advance/style.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/style.tsx
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+import { theme } from '@src/theme';
+
+export const AdvancedTitleContainer = styled.div({
+  fontSize: '1rem',
+  lineHeight: '1.25rem',
+  fontWeight: '600',
+});
+
+
+export const AdvancedContainer = styled('div')({
+  display: 'flex',
+  margin: '1.75rem 0 0.375rem',
+});
+
+export const AdvancedForm = styled('form')({
+  display: 'grid',
+  gridTemplateColumns: 'repeat(2, 1fr)',
+  gap: '1rem',
+  marginTop: '1rem',
+  marginBottom: '1rem',
+  width: '100%',
+  [theme.breakpoints.down('md')]: {
+    gridTemplateColumns: '1fr',
+  },
+});

--- a/frontend/src/containers/MetricsStep/Advance/style.tsx
+++ b/frontend/src/containers/MetricsStep/Advance/style.tsx
@@ -7,7 +7,6 @@ export const AdvancedTitleContainer = styled.div({
   fontWeight: '600',
 });
 
-
 export const AdvancedContainer = styled('div')({
   display: 'flex',
   margin: '1.75rem 0 0.375rem',

--- a/frontend/src/containers/MetricsStep/index.tsx
+++ b/frontend/src/containers/MetricsStep/index.tsx
@@ -30,6 +30,7 @@ import { useAppSelector, useAppDispatch } from '@src/hooks';
 import { Crews } from '@src/containers/MetricsStep/Crews';
 import { useCallback, useLayoutEffect } from 'react';
 import { Loading } from '@src/components/Loading';
+import { Advance } from './Advance/Advance';
 import isEmpty from 'lodash/isEmpty';
 import merge from 'lodash/merge';
 import dayjs from 'dayjs';
@@ -108,6 +109,7 @@ const MetricsStep = () => {
                   label={'Distinguished By'}
                 />
               )}
+              <Advance />
             </>
           ) : (
             <EmptyContent

--- a/frontend/src/containers/MetricsStepper/index.tsx
+++ b/frontend/src/containers/MetricsStepper/index.tsx
@@ -205,6 +205,7 @@ const MetricsStepper = () => {
       cycleTimeSettingsType,
       treatFlagCardAsBlock,
       assigneeFilter,
+      importedData,
     } = filterMetricsConfig(metricsConfig);
 
     const metricsData = {
@@ -231,10 +232,7 @@ const MetricsStepper = () => {
       classification: targetFields
         ?.filter((item: { name: string; key: string; flag: boolean }) => item.flag)
         ?.map((item: { name: string; key: string; flag: boolean }) => item.key),
-      advancedSettings: {
-        storyPoint: '1',
-        flag: '2',
-      },
+      advancedSettings: importedData.importedAdvancedSettings,
       deployment: deploymentFrequencySettings,
       leadTime: leadTimeForChanges,
     };

--- a/frontend/src/containers/MetricsStepper/index.tsx
+++ b/frontend/src/containers/MetricsStepper/index.tsx
@@ -231,6 +231,10 @@ const MetricsStepper = () => {
       classification: targetFields
         ?.filter((item: { name: string; key: string; flag: boolean }) => item.flag)
         ?.map((item: { name: string; key: string; flag: boolean }) => item.key),
+      advancedSettings: {
+        storyPoint: '1',
+        flag: '2',
+      },
       deployment: deploymentFrequencySettings,
       leadTime: leadTimeForChanges,
     };

--- a/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
@@ -64,6 +64,7 @@ const BoardMetrics = ({
     targetFields,
     doneColumn,
     assigneeFilter,
+    importedData: { importedAdvancedSettings },
   } = useAppSelector(selectMetricsContent);
 
   const { metrics, calendarType } = configData.basic;
@@ -95,6 +96,18 @@ const BoardMetrics = ({
         doneColumn: getRealDoneStatus(cycleTimeSettings, cycleTimeSettingsType, doneColumn),
       },
       csvTimeStamp: csvTimeStamp,
+      advancedSettings: [
+        {
+          name: 'Story Point',
+          key: importedAdvancedSettings?.storyPoint ?? '',
+          flag: true,
+        },
+        {
+          name: 'Flag',
+          key: importedAdvancedSettings?.flag ?? '',
+          flag: true,
+        },
+      ],
     };
   };
 

--- a/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
@@ -94,6 +94,18 @@ const BoardMetrics = ({
         assigneeFilter,
         targetFields: formatDuplicatedNameWithSuffix(targetFields),
         doneColumn: getRealDoneStatus(cycleTimeSettings, cycleTimeSettingsType, doneColumn),
+        overrideFields: [
+          {
+            name: 'Story Points',
+            key: importedAdvancedSettings?.storyPoint ?? '',
+            flag: true,
+          },
+          {
+            name: 'Flagged',
+            key: importedAdvancedSettings?.flag ?? '',
+            flag: true,
+          },
+        ],
       },
       csvTimeStamp: csvTimeStamp,
       advancedSettings: [

--- a/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetrics/index.tsx
@@ -108,18 +108,6 @@ const BoardMetrics = ({
         ],
       },
       csvTimeStamp: csvTimeStamp,
-      advancedSettings: [
-        {
-          name: 'Story Point',
-          key: importedAdvancedSettings?.storyPoint ?? '',
-          flag: true,
-        },
-        {
-          name: 'Flag',
-          key: importedAdvancedSettings?.flag ?? '',
-          flag: true,
-        },
-      ],
     };
   };
 

--- a/frontend/src/context/Metrics/metricsSlice.ts
+++ b/frontend/src/context/Metrics/metricsSlice.ts
@@ -469,7 +469,12 @@ export const metricsSlice = createSlice({
     updateAssigneeFilter: (state, action) => {
       state.assigneeFilter = action.payload;
     },
+
     resetMetricData: () => initialState,
+
+    updateAdvancedSettings: (state, action) => {
+      state.importedData.importedAdvancedSettings = action.payload;
+    },
   },
 });
 
@@ -491,6 +496,7 @@ export const {
   updatePipelineStep,
   setCycleTimeSettingsType,
   resetMetricData,
+  updateAdvancedSettings,
   updateMetricsBoardDirtyStatus,
 } = metricsSlice.actions;
 

--- a/frontend/src/context/Metrics/metricsSlice.ts
+++ b/frontend/src/context/Metrics/metricsSlice.ts
@@ -269,7 +269,7 @@ export const metricsSlice = createSlice({
       state.importedData.importedDoneStatus = doneStatus || state.importedData.importedDoneStatus;
       state.importedData.importedClassification = classification || state.importedData.importedClassification;
       state.importedData.importedDeployment = deployment || leadTime || state.importedData.importedDeployment;
-      state.importedData.importedAdvancedSettings = advancedSettings || state.importedData.importedAdvanceSettings;
+      state.importedData.importedAdvancedSettings = advancedSettings || state.importedData.importedAdvancedSettings;
     },
 
     updateMetricsState: (state, action) => {

--- a/frontend/src/context/Metrics/metricsSlice.ts
+++ b/frontend/src/context/Metrics/metricsSlice.ts
@@ -57,6 +57,7 @@ export interface savedMetricsSettingState {
     importedDoneStatus: string[];
     importedClassification: string[];
     importedDeployment: IPipelineConfig[];
+    importedAdvancedSettings: { storyPoint: string; flag: string };
   };
   cycleTimeWarningMessage: string | null;
   classificationWarningMessage: string | null;
@@ -88,6 +89,7 @@ const initialState: savedMetricsSettingState = {
     importedDoneStatus: [],
     importedClassification: [],
     importedDeployment: [],
+    importedAdvancedSettings: { storyPoint: '', flag: '' },
   },
   cycleTimeWarningMessage: null,
   classificationWarningMessage: null,
@@ -246,8 +248,17 @@ export const metricsSlice = createSlice({
     },
 
     updateMetricsImportedData: (state, action) => {
-      const { crews, cycleTime, doneStatus, classification, deployment, leadTime, assigneeFilter, pipelineCrews } =
-        action.payload;
+      const {
+        crews,
+        cycleTime,
+        doneStatus,
+        classification,
+        deployment,
+        advancedSettings,
+        leadTime,
+        assigneeFilter,
+        pipelineCrews,
+      } = action.payload;
       state.importedData.importedCrews = crews || state.importedData.importedCrews;
       state.importedData.importedPipelineCrews = pipelineCrews || state.importedData.importedPipelineCrews;
       state.importedData.importedCycleTime.importedCycleTimeSettings =
@@ -258,6 +269,7 @@ export const metricsSlice = createSlice({
       state.importedData.importedDoneStatus = doneStatus || state.importedData.importedDoneStatus;
       state.importedData.importedClassification = classification || state.importedData.importedClassification;
       state.importedData.importedDeployment = deployment || leadTime || state.importedData.importedDeployment;
+      state.importedData.importedAdvancedSettings = advancedSettings || state.importedData.importedAdvanceSettings;
     },
 
     updateMetricsState: (state, action) => {
@@ -488,6 +500,7 @@ export const selectDeploymentFrequencySettings = (state: RootState) => state.met
 
 export const selectCycleTimeSettings = (state: RootState) => state.metrics.cycleTimeSettings;
 export const selectMetricsContent = (state: RootState) => state.metrics;
+export const selectAdvancedSettings = (state: RootState) => state.metrics.importedData.importedAdvancedSettings;
 export const selectTreatFlagCardAsBlock = (state: RootState) => state.metrics.treatFlagCardAsBlock;
 export const selectAssigneeFilter = (state: RootState) => state.metrics.assigneeFilter;
 export const selectCycleTimeWarningMessage = (state: RootState) => state.metrics.cycleTimeWarningMessage;

--- a/frontend/src/context/Metrics/metricsSlice.ts
+++ b/frontend/src/context/Metrics/metricsSlice.ts
@@ -57,7 +57,7 @@ export interface savedMetricsSettingState {
     importedDoneStatus: string[];
     importedClassification: string[];
     importedDeployment: IPipelineConfig[];
-    importedAdvancedSettings: { storyPoint: string; flag: string };
+    importedAdvancedSettings: { storyPoint: string; flag: string } | null;
   };
   cycleTimeWarningMessage: string | null;
   classificationWarningMessage: string | null;
@@ -89,7 +89,7 @@ const initialState: savedMetricsSettingState = {
     importedDoneStatus: [],
     importedClassification: [],
     importedDeployment: [],
-    importedAdvancedSettings: { storyPoint: '', flag: '' },
+    importedAdvancedSettings: null,
   },
   cycleTimeWarningMessage: null,
   classificationWarningMessage: null,


### PR DESCRIPTION
## Summary

Due to board token permissions, data for 'story point' and 'block' cannot be fetched from the target field returned by the Jira API call using their token (in the covertCustomFieldKey method). Hence, the key for the corresponding custom field for story points is allowed to be set via environment variables beforehand, and the key record of the respective custom field will then be found in the return value of get real done.

## Before

Could not set `Advance` field.

**Screenshots**
<img width="1294" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/7afb5490-5fc3-4a75-8817-97e77af1134c">

## After

Could set `Advance` field.

**Screenshots**
<img width="1241" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/113588395/11b477aa-1b89-4ff3-a430-1d3c1378ea81">

## Note

_Null_
