### PR TITLE
ADM-812: [frontend]: only call get board info and pipeline info when user trigger verify

### DIFF
--- a/frontend/__tests__/containers/MetricsStep/Crews.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/Crews.test.tsx
@@ -145,7 +145,7 @@ describe('Crew', () => {
     await userEvent.click(screen.getByRole('radio', { name: assigneeFilterLabels[1] }));
 
     await waitFor(() => {
-      expect(mockedUseAppDispatch).toHaveBeenCalledTimes(3);
+      expect(mockedUseAppDispatch).toHaveBeenCalledTimes(2);
       expect(mockedUseAppDispatch).toHaveBeenCalledWith(updateAssigneeFilter(assigneeFilterValues[1]));
     });
   });

--- a/frontend/__tests__/containers/MetricsStep/CycleTime.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/CycleTime.test.tsx
@@ -320,7 +320,7 @@ describe('CycleTime', () => {
     setup();
     await userEvent.click(screen.getByRole('radio', { name: cycleTimeTypeLabels[1] }));
 
-    expect(mockedUseAppDispatch).toHaveBeenCalledTimes(4);
+    expect(mockedUseAppDispatch).toHaveBeenCalledTimes(3);
     expect(mockedUseAppDispatch).toHaveBeenCalledWith(setCycleTimeSettingsType(CYCLE_TIME_SETTINGS_TYPES.BY_STATUS));
     expect(mockedUseAppDispatch).toHaveBeenCalledWith(
       updateCycleTimeSettings(

--- a/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/DeploymentFrequencySettings.test.tsx
@@ -29,6 +29,7 @@ jest.mock('@src/context/Metrics/metricsSlice', () => ({
   selectPipelineNameWarningMessage: jest.fn().mockReturnValue(null),
   selectStepWarningMessage: jest.fn().mockReturnValue(null),
   selectMetricsContent: jest.fn().mockReturnValue({ pipelineCrews: [], users: [] }),
+  selectShouldGetPipelineConfig: jest.fn().mockReturnValue(true),
 }));
 
 jest.mock('@src/context/config/configSlice', () => ({

--- a/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection.test.tsx
@@ -10,9 +10,8 @@ import {
   STEP,
 } from '@test/fixtures';
 import { PipelineMetricSelection } from '@src/containers/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection';
-import { updatePipelineToolVerifyResponseSteps } from '@src/context/config/configSlice';
+import { IPipelineConfig, updateShouldGetPipelineConfig } from '@src/context/Metrics/metricsSlice';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
-import { IPipelineConfig } from '@src/context/Metrics/metricsSlice';
 import { metricsClient } from '@src/clients/MetricsClient';
 import { setupStore } from '@test/utils/setupStoreUtil';
 import userEvent from '@testing-library/user-event';
@@ -75,6 +74,7 @@ describe('PipelineMetricSelection', () => {
     isDuplicated: boolean,
   ) => {
     const store = setupStore();
+    store.dispatch(updateShouldGetPipelineConfig(true));
     return render(
       <Provider store={store}>
         <PipelineMetricSelection
@@ -218,7 +218,6 @@ describe('PipelineMetricSelection', () => {
     );
 
     await waitFor(() => {
-      expect(updatePipelineToolVerifyResponseSteps).toHaveBeenCalledTimes(1);
       expect(getByText(STEP)).toBeInTheDocument();
     });
 
@@ -245,7 +244,6 @@ describe('PipelineMetricSelection', () => {
     );
 
     await waitFor(() => {
-      expect(updatePipelineToolVerifyResponseSteps).toHaveBeenCalledTimes(1);
       expect(getByText(BRANCH)).toBeInTheDocument();
     });
 

--- a/frontend/__tests__/containers/MetricsStep/MetricsStep.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/MetricsStep.test.tsx
@@ -21,7 +21,12 @@ import {
   REQUIRED_DATA_LIST,
   SELECT_CONSIDER_AS_DONE_MESSAGE,
 } from '../../fixtures';
-import { updateCycleTimeSettings, saveDoneColumn, setCycleTimeSettingsType } from '@src/context/Metrics/metricsSlice';
+import {
+  updateCycleTimeSettings,
+  saveDoneColumn,
+  setCycleTimeSettingsType,
+  updateShouldGetBoardConfig,
+} from '@src/context/Metrics/metricsSlice';
 import { updateJiraVerifyResponse, updateMetrics } from '@src/context/config/configSlice';
 import { closeAllNotifications } from '@src/context/notification/NotificationSlice';
 import { backStep, nextStep } from '@src/context/stepper/StepperSlice';
@@ -80,7 +85,6 @@ describe('MetricsStep', () => {
   it('should not show Real done when only one value is done for cycle time', async () => {
     store.dispatch(updateMetrics([REQUIRED_DATA_LIST[1]]));
     store.dispatch(updateCycleTimeSettings([{ column: 'Testing', status: 'testing', value: 'Done' }]));
-
     setup();
 
     expect(screen.getByText(CREWS_SETTING)).toBeInTheDocument();
@@ -191,6 +195,7 @@ describe('MetricsStep', () => {
         { key: 'done', value: { name: 'Done', statuses: ['PRE-DONE,', 'DONE', 'CANCEL'] } },
       ];
 
+      store.dispatch(updateShouldGetBoardConfig(true));
       store.dispatch(updateMetrics(REQUIRED_DATA_LIST));
       store.dispatch(updateCycleTimeSettings(cycleTimeSettingsWithTwoDoneValue));
       store.dispatch(saveDoneColumn(doneColumn));

--- a/frontend/__tests__/context/metricsSlice.test.ts
+++ b/frontend/__tests__/context/metricsSlice.test.ts
@@ -23,8 +23,8 @@ import { setupStore } from '../utils/setupStoreUtil';
 import { store } from '@src/store';
 
 const initState = {
-  shouldGetBoardConfig: false,
-  shouldGetPipeLineConfig: false,
+  shouldGetBoardConfig: true,
+  shouldGetPipeLineConfig: true,
   jiraColumns: [],
   targetFields: [],
   users: [],

--- a/frontend/__tests__/context/metricsSlice.test.ts
+++ b/frontend/__tests__/context/metricsSlice.test.ts
@@ -23,7 +23,8 @@ import { setupStore } from '../utils/setupStoreUtil';
 import { store } from '@src/store';
 
 const initState = {
-  isBoarConfigDirty: false,
+  shouldGetBoardConfig: false,
+  shouldGetPipeLineConfig: false,
   jiraColumns: [],
   targetFields: [],
   users: [],

--- a/frontend/src/containers/ConfigStep/Board/index.tsx
+++ b/frontend/src/containers/ConfigStep/Board/index.tsx
@@ -5,7 +5,7 @@ import {
   StyledTextField,
   StyledTypeSelections,
 } from '@src/components/Common/ConfigForms';
-import { updateMetricsBoardDirtyStatus } from '@src/context/Metrics/metricsSlice';
+import { updateShouldGetBoardConfig } from '@src/context/Metrics/metricsSlice';
 import { KEYS, useVerifyBoardEffect } from '@src/hooks/useVerifyBoardEffect';
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons';
 import { useAppSelector, useAppDispatch } from '@src/hooks/useAppDispatch';
@@ -24,7 +24,7 @@ export const Board = () => {
   const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     await verifyJira();
-    dispatch(updateMetricsBoardDirtyStatus(false));
+    dispatch(updateShouldGetBoardConfig(true));
   };
 
   const isDisableVerifyButton = useMemo(

--- a/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
@@ -13,6 +13,7 @@ import {
 } from '@src/context/config/configSlice';
 import { CONFIG_TITLE, PIPELINE_TOOL_TYPES, TOKEN_HELPER_TEXT } from '@src/constants/resources';
 import { useVerifyPipelineToolEffect } from '@src/hooks/useVerifyPipelineToolEffect';
+import { updateShouldGetPipelineConfig } from '@src/context/Metrics/metricsSlice';
 import { ResetButton, VerifyButton } from '@src/components/Common/Buttons';
 import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';
 import { DEFAULT_HELPER_TEXT, EMPTY_STRING } from '@src/constants/commons';
@@ -108,6 +109,7 @@ export const PipelineTool = () => {
       type: fields[FIELD_KEY.TYPE].value,
       token: fields[FIELD_KEY.TOKEN].value,
     });
+    dispatch(updateShouldGetPipelineConfig(true));
   };
 
   const isDisableVerifyButton = useMemo(

--- a/frontend/src/containers/MetricsStep/Classification/index.tsx
+++ b/frontend/src/containers/MetricsStep/Classification/index.tsx
@@ -1,9 +1,5 @@
-import {
-  saveTargetFields,
-  selectClassificationWarningMessage,
-  updateMetricsBoardDirtyStatus,
-} from '@src/context/Metrics/metricsSlice';
 import { TypedStyledAutocompleted, ITargetFieldType } from '@src/components/Common/MultiAutoComplete/styles';
+import { saveTargetFields, selectClassificationWarningMessage } from '@src/context/Metrics/metricsSlice';
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle';
 import { WarningNotification } from '@src/components/Common/WarningNotification';
 import { Checkbox, createFilterOptions, TextField } from '@mui/material';
@@ -41,7 +37,6 @@ export const Classification = ({ targetFields, title, label }: classificationPro
       ...targetField,
       flag: !!nextSelectedOptions.find((option) => option.key === targetField.key),
     }));
-    dispatch(updateMetricsBoardDirtyStatus(true));
     dispatch(saveTargetFields(updatedTargetFields));
   };
 

--- a/frontend/src/containers/MetricsStep/Crews/AssigneeFilter.tsx
+++ b/frontend/src/containers/MetricsStep/Crews/AssigneeFilter.tsx
@@ -1,8 +1,4 @@
-import {
-  selectAssigneeFilter,
-  updateAssigneeFilter,
-  updateMetricsBoardDirtyStatus,
-} from '@src/context/Metrics/metricsSlice';
+import { selectAssigneeFilter, updateAssigneeFilter } from '@src/context/Metrics/metricsSlice';
 import { StyledRadioGroup } from '@src/containers/MetricsStep/Crews/style';
 import { useAppDispatch } from '@src/hooks/useAppDispatch';
 import { FormControlLabel, Radio } from '@mui/material';
@@ -15,7 +11,6 @@ export const AssigneeFilter = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     dispatch(updateAssigneeFilter(event.target.value));
-    dispatch(updateMetricsBoardDirtyStatus(true));
   };
 
   return (

--- a/frontend/src/containers/MetricsStep/Crews/index.tsx
+++ b/frontend/src/containers/MetricsStep/Crews/index.tsx
@@ -1,9 +1,4 @@
-import {
-  saveUsers,
-  selectMetricsContent,
-  savePipelineCrews,
-  updateMetricsBoardDirtyStatus,
-} from '@src/context/Metrics/metricsSlice';
+import { saveUsers, selectMetricsContent, savePipelineCrews } from '@src/context/Metrics/metricsSlice';
 import { AssigneeFilter } from '@src/containers/MetricsStep/Crews/AssigneeFilter';
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle';
 import MultiAutoComplete from '@src/components/Common/MultiAutoComplete';
@@ -41,9 +36,6 @@ export const Crews = ({ options, title, label, type = 'board' }: crewsProps) => 
     if (value[value.length - 1] === 'All') {
       setSelectedCrews(selectedCrews.length === options.length ? [] : options);
       return;
-    }
-    if (isBoardCrews) {
-      dispatch(updateMetricsBoardDirtyStatus(true));
     }
     setSelectedCrews([...value]);
   };

--- a/frontend/src/containers/MetricsStep/CycleTime/FlagCard.tsx
+++ b/frontend/src/containers/MetricsStep/CycleTime/FlagCard.tsx
@@ -1,8 +1,4 @@
-import {
-  selectTreatFlagCardAsBlock,
-  updateTreatFlagCardAsBlock,
-  updateMetricsBoardDirtyStatus,
-} from '@src/context/Metrics/metricsSlice';
+import { selectTreatFlagCardAsBlock, updateTreatFlagCardAsBlock } from '@src/context/Metrics/metricsSlice';
 import { FlagCardItem, ItemCheckbox, ItemText } from '@src/containers/MetricsStep/CycleTime/style';
 import { useAppDispatch } from '@src/hooks/useAppDispatch';
 import { useAppSelector } from '@src/hooks';
@@ -14,7 +10,6 @@ const FlagCard = () => {
 
   const handleFlagCardAsBlock = () => {
     dispatch(updateTreatFlagCardAsBlock(!flagCardAsBlock));
-    dispatch(updateMetricsBoardDirtyStatus(true));
   };
 
   return (

--- a/frontend/src/containers/MetricsStep/CycleTime/Table/index.tsx
+++ b/frontend/src/containers/MetricsStep/CycleTime/Table/index.tsx
@@ -10,7 +10,6 @@ import {
   saveDoneColumn,
   selectMetricsContent,
   setCycleTimeSettingsType,
-  updateMetricsBoardDirtyStatus,
 } from '@src/context/Metrics/metricsSlice';
 import {
   StyledRadioGroup,
@@ -57,7 +56,6 @@ const CycleTimeTable = () => {
       );
       isColumnAsKey && resetRealDoneColumn(name, value);
       dispatch(updateCycleTimeSettings(newCycleTimeSettings));
-      dispatch(updateMetricsBoardDirtyStatus(true));
     },
     [cycleTimeSettings, dispatch, isColumnAsKey, resetRealDoneColumn],
   );
@@ -89,7 +87,6 @@ const CycleTimeTable = () => {
       ),
     );
     dispatch(saveDoneColumn([]));
-    dispatch(updateMetricsBoardDirtyStatus(true));
   };
 
   return (

--- a/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
+++ b/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/PipelineMetricSelection/index.tsx
@@ -1,16 +1,19 @@
 import {
+  selectOrganizationWarningMessage,
+  selectPipelineNameWarningMessage,
+  selectStepWarningMessage,
+  updatePipelineStep,
+  updateShouldGetPipelineConfig,
+  selectShouldGetPipelineConfig,
+} from '@src/context/Metrics/metricsSlice';
+import {
   selectPipelineNames,
   selectPipelineOrganizations,
   selectSteps,
   selectStepsParams,
   updatePipelineToolVerifyResponseSteps,
 } from '@src/context/config/configSlice';
-import {
-  selectOrganizationWarningMessage,
-  selectPipelineNameWarningMessage,
-  selectStepWarningMessage,
-  updatePipelineStep,
-} from '@src/context/Metrics/metricsSlice';
+
 import { SingleSelection } from '@src/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection';
 import { BranchSelection } from '@src/containers/MetricsStep/DeploymentFrequencySettings/BranchSelection';
 import { ButtonWrapper, PipelineMetricSelectionWrapper, RemoveButton, WarningMessage } from './style';
@@ -60,15 +63,16 @@ export const PipelineMetricSelection = ({
   const stepWarningMessage = selectStepWarningMessage(store.getState(), id);
   const [isShowNoStepWarning, setIsShowNoStepWarning] = useState(false);
   const shouldLoad = useAppSelector(shouldMetricsLoad);
+  const shouldGetPipelineConfig = useAppSelector(selectShouldGetPipelineConfig);
 
   const handleRemoveClick = () => {
     onRemovePipeline(id);
   };
 
   useEffect(() => {
-    !isInfoLoading && shouldLoad && pipelineName && handleGetPipelineData(pipelineName);
+    !isInfoLoading && shouldLoad && shouldGetPipelineConfig && pipelineName && handleGetPipelineData(pipelineName);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [shouldLoad, pipelineName, isInfoLoading]);
+  }, [shouldLoad, pipelineName, isInfoLoading, shouldGetPipelineConfig]);
 
   const handleGetPipelineData = (_pipelineName: string) => {
     const { params, buildId, organizationId, pipelineType, token } = selectStepsParams(
@@ -93,6 +97,7 @@ export const PipelineMetricSelection = ({
           }),
         );
         res?.haveStep && dispatch(updatePipelineStep({ steps, id, type, branches, pipelineCrews }));
+        dispatch(updateShouldGetPipelineConfig(false));
       }
       res && setIsShowNoStepWarning(!res.haveStep);
     });

--- a/frontend/src/containers/MetricsStep/RealDone/index.tsx
+++ b/frontend/src/containers/MetricsStep/RealDone/index.tsx
@@ -3,7 +3,6 @@ import {
   selectCycleTimeSettings,
   selectMetricsContent,
   selectRealDoneWarningMessage,
-  updateMetricsBoardDirtyStatus,
 } from '@src/context/Metrics/metricsSlice';
 import { MetricsSettingTitle } from '@src/components/Common/MetricsSettingTitle';
 import { WarningNotification } from '@src/components/Common/WarningNotification';
@@ -43,7 +42,6 @@ export const RealDone = ({ columns, title, label }: realDoneProps) => {
     }
 
     setSelectedDoneStatus([...value]);
-    dispatch(updateMetricsBoardDirtyStatus(true));
     dispatch(saveDoneColumn([...value]));
   };
 

--- a/frontend/src/containers/MetricsStep/index.tsx
+++ b/frontend/src/containers/MetricsStep/index.tsx
@@ -9,11 +9,16 @@ import {
   selectJiraColumns,
 } from '@src/context/config/configSlice';
 import {
+  selectMetricsContent,
+  updateMetricsState,
+  selectShouldGetBoardConfig,
+  updateShouldGetBoardConfig,
+} from '@src/context/Metrics/metricsSlice';
+import {
   MetricSelectionHeader,
   MetricSelectionWrapper,
   MetricsSelectionTitle,
 } from '@src/containers/MetricsStep/style';
-import { selectMetricsContent, updateMetricsState, selectMetricsBoardIsDirty } from '@src/context/Metrics/metricsSlice';
 import { DeploymentFrequencySettings } from '@src/containers/MetricsStep/DeploymentFrequencySettings';
 import { StyledRetryButton, StyledErrorMessage } from '@src/containers/MetricsStep/style';
 import { CYCLE_TIME_SETTINGS_TYPES, DONE, REQUIRED_DATA } from '@src/constants/resources';
@@ -54,7 +59,7 @@ const MetricsStep = () => {
     cycleTimeSettings.filter((e) => e.value === DONE).length > 1;
   const { getBoardInfo, isLoading, errorMessage } = useGetBoardInfoEffect();
   const shouldLoad = useAppSelector(shouldMetricsLoad);
-  const isBoarConfigDirty = useAppSelector(selectMetricsBoardIsDirty);
+  const shouldGetBoardConfig = useAppSelector(selectShouldGetBoardConfig);
 
   const getInfo = useCallback(
     () =>
@@ -67,6 +72,7 @@ const MetricsStep = () => {
           dispatch(updateBoardVerifyState(true));
           dispatch(updateJiraVerifyResponse(res.data));
           dispatch(updateMetricsState(merge(res.data, { isProjectCreated: isProjectCreated })));
+          dispatch(updateShouldGetBoardConfig(false));
         }
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -76,9 +82,9 @@ const MetricsStep = () => {
   useLayoutEffect(() => {
     if (!shouldLoad) return;
     dispatch(closeAllNotifications());
-    if (!shouldLoad || !isShowCrewsAndRealDone || isBoarConfigDirty) return;
+    if (!isShowCrewsAndRealDone || !shouldGetBoardConfig) return;
     getInfo();
-  }, [shouldLoad, isShowCrewsAndRealDone, isBoarConfigDirty, dispatch, getInfo]);
+  }, [shouldLoad, isShowCrewsAndRealDone, shouldGetBoardConfig, dispatch, getInfo]);
 
   return (
     <>

--- a/frontend/src/context/Metrics/metricsSlice.ts
+++ b/frontend/src/context/Metrics/metricsSlice.ts
@@ -34,7 +34,8 @@ export interface ICycleTimeSetting {
 }
 
 export interface savedMetricsSettingState {
-  isBoarConfigDirty: boolean;
+  shouldGetBoardConfig: boolean;
+  shouldGetPipeLineConfig: boolean;
   jiraColumns: { key: string; value: { name: string; statuses: string[] } }[];
   targetFields: { name: string; key: string; flag: boolean }[];
   users: string[];
@@ -66,7 +67,8 @@ export interface savedMetricsSettingState {
 }
 
 const initialState: savedMetricsSettingState = {
-  isBoarConfigDirty: false,
+  shouldGetBoardConfig: false,
+  shouldGetPipeLineConfig: false,
   jiraColumns: [],
   targetFields: [],
   users: [],
@@ -243,8 +245,12 @@ export const metricsSlice = createSlice({
       });
     },
 
-    updateMetricsBoardDirtyStatus: (state, action) => {
-      state.isBoarConfigDirty = action.payload;
+    updateShouldGetBoardConfig: (state, action) => {
+      state.shouldGetBoardConfig = action.payload;
+    },
+
+    updateShouldGetPipelineConfig: (state, action) => {
+      state.shouldGetPipeLineConfig = action.payload;
     },
 
     updateMetricsImportedData: (state, action) => {
@@ -364,7 +370,9 @@ export const metricsSlice = createSlice({
       const { pipelineList, isProjectCreated, pipelineCrews } = action.payload;
       const { importedDeployment, importedPipelineCrews } = state.importedData;
 
-      state.pipelineCrews = setPipelineCrews(isProjectCreated, pipelineCrews, importedPipelineCrews);
+      if (pipelineCrews) {
+        state.pipelineCrews = setPipelineCrews(isProjectCreated, pipelineCrews, importedPipelineCrews);
+      }
       const orgNames: Array<string> = _.uniq(pipelineList.map((item: pipeline) => item.orgName));
       const filteredPipelineNames = (organization: string) =>
         pipelineList
@@ -497,10 +505,12 @@ export const {
   setCycleTimeSettingsType,
   resetMetricData,
   updateAdvancedSettings,
-  updateMetricsBoardDirtyStatus,
+  updateShouldGetBoardConfig,
+  updateShouldGetPipelineConfig,
 } = metricsSlice.actions;
 
-export const selectMetricsBoardIsDirty = (state: RootState) => state.metrics.isBoarConfigDirty;
+export const selectShouldGetBoardConfig = (state: RootState) => state.metrics.shouldGetBoardConfig;
+export const selectShouldGetPipelineConfig = (state: RootState) => state.metrics.shouldGetPipeLineConfig;
 
 export const selectDeploymentFrequencySettings = (state: RootState) => state.metrics.deploymentFrequencySettings;
 


### PR DESCRIPTION
## Summary

...

## Before

call get board Info and pipeline info every time when enter metrics page

## After

only call get board info and pipeline info when trigger verify call



