### PR TITLE
[frontend]ADM-767: make disable for pipeline name

### DIFF
--- a/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection.test.tsx
+++ b/frontend/__tests__/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection.test.tsx
@@ -17,6 +17,14 @@ jest.mock('react', () => ({
   ...jest.requireActual('react'),
   useEffect: jest.fn(),
 }));
+jest.mock('@src/context/Metrics/metricsSlice', () => ({
+  ...jest.requireActual('@src/context/Metrics/metricsSlice'),
+  selectDeploymentFrequencySettings: jest.fn().mockReturnValue([]),
+}));
+jest.mock('@src/utils/util', () => ({
+  ...jest.requireActual('@src/utils/util'),
+  getDisabledOptions: jest.fn(),
+}));
 let store = setupStore();
 
 describe('SingleSelection', () => {

--- a/frontend/__tests__/utils/Util.test.tsx
+++ b/frontend/__tests__/utils/Util.test.tsx
@@ -8,9 +8,11 @@ import {
   getRealDoneStatus,
   transformToCleanedBuildKiteEmoji,
   formatDuplicatedNameWithSuffix,
+  getDisabledOptions,
 } from '@src/utils/util';
 import { CleanedBuildKiteEmoji, OriginBuildKiteEmoji } from '@src/constants/emojis/emoji';
 import { CYCLE_TIME_SETTINGS_TYPES } from '@src/constants/resources';
+import { IPipelineConfig } from '@src/context/Metrics/metricsSlice';
 import { EMPTY_STRING } from '@src/constants/commons';
 import { PIPELINE_TOOL_TYPES } from '../fixtures';
 
@@ -42,6 +44,34 @@ describe('transformToCleanedBuildKiteEmoji function', () => {
     const [result] = transformToCleanedBuildKiteEmoji([mockOriginEmoji]);
 
     expect(result).toEqual(expectedCleanedEmoji);
+  });
+});
+
+describe('getDisabledOptions function', () => {
+  it('should return true when option is includes', () => {
+    const mockDeploymentFrequencySettings: IPipelineConfig[] = [
+      { id: 0, organization: '', pipelineName: 'mock 1', step: '', branches: [] },
+      { id: 1, organization: '', pipelineName: 'mock 2', step: '', branches: [] },
+    ];
+
+    const mockOption: string = 'mock 1';
+
+    const result = getDisabledOptions(mockDeploymentFrequencySettings, mockOption);
+
+    expect(result).toBeTruthy();
+  });
+
+  it('should return true when option is not includes', () => {
+    const mockDeploymentFrequencySettings: IPipelineConfig[] = [
+      { id: 0, organization: '', pipelineName: 'mock 1', step: '', branches: [] },
+      { id: 1, organization: '', pipelineName: 'mock 2', step: '', branches: [] },
+    ];
+
+    const mockOption: string = 'mock 3';
+
+    const result = getDisabledOptions(mockDeploymentFrequencySettings, mockOption);
+
+    expect(result).toBeFalsy();
   });
 });
 

--- a/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
+++ b/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
@@ -2,11 +2,11 @@ import { selectDeploymentFrequencySettings } from '@src/context/Metrics/metricsS
 import { getEmojiUrls, removeExtraEmojiName } from '@src/constants/emojis/emoji';
 import { Autocomplete, Box, ListItemText, TextField } from '@mui/material';
 import { EmojiWrap, StyledAvatar } from '@src/constants/emojis/style';
+import { getDisabledOptions } from '@src/utils/util';
 import { Z_INDEX } from '@src/constants/commons';
 import { FormControlWrapper } from './style';
 import { useAppSelector } from '@src/hooks';
 import React, { useState } from 'react';
-import { includes } from 'lodash';
 
 interface Props {
   options: string[];
@@ -35,16 +35,6 @@ export const SingleSelection = ({ options, label, value, id, onGetSteps, onUpDat
     return emojiUrls.map((url) => <StyledAvatar key={url} src={url} />);
   };
 
-  const getPipelineNameOptionDisabled = (option: string) => {
-    if (label === 'Pipeline Name') {
-      return includes(
-        deploymentFrequencySettings.map((item) => item.pipelineName),
-        option,
-      );
-    }
-    return false;
-  };
-
   return (
     <>
       <FormControlWrapper variant='standard' required>
@@ -52,7 +42,9 @@ export const SingleSelection = ({ options, label, value, id, onGetSteps, onUpDat
           disableClearable
           data-test-id={labelId}
           options={options}
-          getOptionDisabled={(option: string) => getPipelineNameOptionDisabled(option)}
+          getOptionDisabled={(option: string) =>
+            label === 'Pipeline Name' && getDisabledOptions(deploymentFrequencySettings, option)
+          }
           getOptionLabel={(option: string) => removeExtraEmojiName(option).trim()}
           renderOption={(props, option: string) => (
             <Box component='li' {...props}>

--- a/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
+++ b/frontend/src/containers/MetricsStep/DeploymentFrequencySettings/SingleSelection/index.tsx
@@ -1,9 +1,12 @@
+import { selectDeploymentFrequencySettings } from '@src/context/Metrics/metricsSlice';
 import { getEmojiUrls, removeExtraEmojiName } from '@src/constants/emojis/emoji';
 import { Autocomplete, Box, ListItemText, TextField } from '@mui/material';
 import { EmojiWrap, StyledAvatar } from '@src/constants/emojis/style';
 import { Z_INDEX } from '@src/constants/commons';
 import { FormControlWrapper } from './style';
+import { useAppSelector } from '@src/hooks';
 import React, { useState } from 'react';
+import { includes } from 'lodash';
 
 interface Props {
   options: string[];
@@ -17,6 +20,7 @@ interface Props {
 export const SingleSelection = ({ options, label, value, id, onGetSteps, onUpDatePipeline }: Props) => {
   const labelId = `single-selection-${label.toLowerCase().replace(' ', '-')}`;
   const [inputValue, setInputValue] = useState<string>(value);
+  const deploymentFrequencySettings = useAppSelector(selectDeploymentFrequencySettings);
 
   const handleSelectedOptionsChange = (value: string) => {
     if (onGetSteps) {
@@ -31,6 +35,16 @@ export const SingleSelection = ({ options, label, value, id, onGetSteps, onUpDat
     return emojiUrls.map((url) => <StyledAvatar key={url} src={url} />);
   };
 
+  const getPipelineNameOptionDisabled = (option: string) => {
+    if (label === 'Pipeline Name') {
+      return includes(
+        deploymentFrequencySettings.map((item) => item.pipelineName),
+        option,
+      );
+    }
+    return false;
+  };
+
   return (
     <>
       <FormControlWrapper variant='standard' required>
@@ -38,6 +52,7 @@ export const SingleSelection = ({ options, label, value, id, onGetSteps, onUpDat
           disableClearable
           data-test-id={labelId}
           options={options}
+          getOptionDisabled={(option: string) => getPipelineNameOptionDisabled(option)}
           getOptionLabel={(option: string) => removeExtraEmojiName(option).trim()}
           renderOption={(props, option: string) => (
             <Box component='li' {...props}>

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -1,9 +1,10 @@
 import { CleanedBuildKiteEmoji, OriginBuildKiteEmoji } from '@src/constants/emojis/emoji';
 import { CYCLE_TIME_SETTINGS_TYPES, METRICS_CONSTANTS } from '@src/constants/resources';
+import { ICycleTimeSetting, IPipelineConfig } from '@src/context/Metrics/metricsSlice';
 import { ITargetFieldType } from '@src/components/Common/MultiAutoComplete/styles';
-import { ICycleTimeSetting } from '@src/context/Metrics/metricsSlice';
 import { DATE_FORMAT_TEMPLATE } from '@src/constants/template';
 import duration from 'dayjs/plugin/duration';
+import { includes } from 'lodash';
 import dayjs from 'dayjs';
 
 dayjs.extend(duration);
@@ -70,6 +71,13 @@ export const getRealDoneStatus = (
 export const findCaseInsensitiveType = (option: string[], value: string): string => {
   const newValue = option.find((item) => value.toLowerCase() === item.toLowerCase());
   return newValue ? newValue : value;
+};
+
+export const getDisabledOptions = (deploymentFrequencySettings: IPipelineConfig[], option: string) => {
+  return includes(
+    deploymentFrequencySettings.map((item) => item.pipelineName),
+    option,
+  );
 };
 
 export const formatDate = (date: Date | string) => {


### PR DESCRIPTION
## Summary
pipeline name can not be repeatable selection

## Before

_Description_

**Screenshots**
<img width="843" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/7be1c591-c2b2-41a0-a3fb-8002765529a2">

## After

_Description_

**Screenshots**
<img width="882" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/33832990/bdbffac8-4e30-49da-9a08-5a7882984853">

## Note

_Null_
