### PR TITLE
chore: extend the timeout of e2e local assertion because of the poor condition of local env.

### DIFF
--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -4,4 +4,5 @@ export const E2E_PROJECT_NAME = 'E2EProjectName';
 
 export const CONFIG_STEP_SAVING_FILENAME = 'config-step.json';
 export const METRICS_STEP_SAVING_FILENAME = 'metrics-step.json';
-export const E2E_EXPECT_TIMEOUT = 30 * 1000;
+export const E2E_EXPECT_LOCAL_TIMEOUT = 30 * 1000;
+export const E2E_EXPECT_CI_TIMEOUT = 30 * 3 * 1000;

--- a/frontend/e2e/fixtures/index.ts
+++ b/frontend/e2e/fixtures/index.ts
@@ -4,5 +4,5 @@ export const E2E_PROJECT_NAME = 'E2EProjectName';
 
 export const CONFIG_STEP_SAVING_FILENAME = 'config-step.json';
 export const METRICS_STEP_SAVING_FILENAME = 'metrics-step.json';
-export const E2E_EXPECT_LOCAL_TIMEOUT = 30 * 1000;
-export const E2E_EXPECT_CI_TIMEOUT = 30 * 3 * 1000;
+export const E2E_EXPECT_LOCAL_TIMEOUT = 30 * 3 * 1000;
+export const E2E_EXPECT_CI_TIMEOUT = 30 * 1000;

--- a/frontend/e2e/pages/metrics/ReportStep.ts
+++ b/frontend/e2e/pages/metrics/ReportStep.ts
@@ -1,7 +1,7 @@
 import { checkDownloadReport, downloadFileAndCheck } from 'e2e/utils/download';
 import { expect, Locator, Page } from '@playwright/test';
 
-import { E2E_EXPECT_TIMEOUT } from '../../fixtures';
+import { E2E_EXPECT_CI_TIMEOUT } from '../../fixtures';
 import { parse } from 'csv-parse/sync';
 import path from 'path';
 import fs from 'fs';
@@ -116,7 +116,7 @@ export class ReportStep {
   }
 
   async confirmGeneratedReport() {
-    await expect(this.page.getByRole('alert')).toContainText('Help Information', { timeout: E2E_EXPECT_TIMEOUT * 3 });
+    await expect(this.page.getByRole('alert')).toContainText('Help Information', { timeout: E2E_EXPECT_CI_TIMEOUT });
     await expect(this.page.getByRole('alert')).toContainText(
       'The file will expire in 30 minutes, please download it in time.',
     );

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,4 +1,4 @@
-import { E2E_EXPECT_TIMEOUT, VIEWPORT_DEFAULT } from 'e2e/fixtures';
+import { E2E_EXPECT_LOCAL_TIMEOUT, E2E_EXPECT_CI_TIMEOUT, VIEWPORT_DEFAULT } from 'e2e/fixtures';
 import { defineConfig, devices } from '@playwright/test';
 
 /**
@@ -17,7 +17,7 @@ export default defineConfig({
   timeout: 3 * 60 * 1000,
   testDir: './e2e',
   expect: {
-    timeout: E2E_EXPECT_TIMEOUT,
+    timeout: process.env.CI ? E2E_EXPECT_CI_TIMEOUT : E2E_EXPECT_LOCAL_TIMEOUT,
   },
   /* Run tests in files in parallel */
   fullyParallel: true,


### PR DESCRIPTION
## Summary

Since our local api take longer than CI env, entends the local TIMEOUT.

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
