### PR TITLE
rework-bug:[backend] fix: Limited to two decimal places when generate metrics csv

### DIFF
--- a/backend/src/main/java/heartbeat/service/report/CSVFileGenerator.java
+++ b/backend/src/main/java/heartbeat/service/report/CSVFileGenerator.java
@@ -483,7 +483,7 @@ public class CSVFileGenerator {
 		rows.add(new String[] { REWORK_FIELD, "Total rework times", String.valueOf(rework.getTotalReworkTimes()) });
 		rows.add(new String[] { REWORK_FIELD, "Total rework cards", String.valueOf(rework.getTotalReworkCards()) });
 		rows.add(new String[] { REWORK_FIELD, "Rework cards ratio(Total rework cards/Throughput)",
-				String.valueOf(rework.getReworkCardsRatio() * 100) });
+				String.valueOf(DecimalUtil.formatDecimalTwo(rework.getReworkCardsRatio() * 100)) });
 		return rows;
 	}
 

--- a/backend/src/test/java/heartbeat/service/report/CSVFileGeneratorTest.java
+++ b/backend/src/test/java/heartbeat/service/report/CSVFileGeneratorTest.java
@@ -529,7 +529,7 @@ class CSVFileGeneratorTest {
 				"Group","Metrics","Value"
 				"Rework","Total rework times","3"
 				"Rework","Total rework cards","3"
-				"Rework","Rework cards ratio(Total rework cards/Throughput)","99.0"
+				"Rework","Rework cards ratio(Total rework cards/Throughput)","99.00"
 				"Deployment frequency","Heartbeat / Deploy prod / Deployment frequency(Deployments/Day)","0.78"
 				"Lead time for changes","Heartbeat / Deploy prod / PR Lead Time","0"
 				"Lead time for changes","Heartbeat / Deploy prod / Pipeline Lead Time","0.02"


### PR DESCRIPTION

## Summary
Limited to two decimal places when generate metrics csv

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
