### PR TITLE
[ADM-877][frontend]: feat: remove the limit of start-date & end-date selection.

### DIFF
--- a/frontend/src/containers/ConfigStep/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/containers/ConfigStep/DateRangePicker/DateRangePicker.tsx
@@ -16,11 +16,7 @@ import {
   updateShouldGetBoardConfig,
   updateShouldGetPipelineConfig,
 } from '@src/context/Metrics/metricsSlice';
-import {
-  isStartDateDisabled,
-  isEndDateDisabled,
-  calculateLastAvailableDate,
-} from '@src/containers/ConfigStep/DateRangePicker/validation';
+import { isDateDisabled, calculateLastAvailableDate } from '@src/containers/ConfigStep/DateRangePicker/validation';
 import { IRangePickerProps } from '@src/containers/ConfigStep/DateRangePicker/types';
 import { selectDateRange, updateDateRange } from '@src/context/config/configSlice';
 import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';
@@ -45,8 +41,8 @@ export const DateRangePicker = ({ startDate, endDate, index }: IRangePickerProps
   const dateRangeGroup = useAppSelector(selectDateRange);
   const isShowRemoveButton = dateRangeGroup.length > 1;
   const dateRangeGroupExcludeSelf = dateRangeGroup.filter((_, idx) => idx !== index);
-  const shouldStartDateDisableDate = isStartDateDisabled.bind(null, dateRangeGroupExcludeSelf);
-  const shouldEndDateDisableDate = isEndDateDisabled.bind(null, dateRangeGroupExcludeSelf);
+  const shouldStartDateDisableDate = isDateDisabled.bind(null, dateRangeGroupExcludeSelf);
+  const shouldEndDateDisableDate = isDateDisabled.bind(null, dateRangeGroupExcludeSelf);
 
   const dispatchUpdateConfig = () => {
     dispatch(updateShouldGetBoardConfig(true));

--- a/frontend/src/containers/ConfigStep/DateRangePicker/DateRangePicker.tsx
+++ b/frontend/src/containers/ConfigStep/DateRangePicker/DateRangePicker.tsx
@@ -45,8 +45,8 @@ export const DateRangePicker = ({ startDate, endDate, index }: IRangePickerProps
   const dateRangeGroup = useAppSelector(selectDateRange);
   const isShowRemoveButton = dateRangeGroup.length > 1;
   const dateRangeGroupExcludeSelf = dateRangeGroup.filter((_, idx) => idx !== index);
-  const shouldStartDateDisableDate = isStartDateDisabled.bind(null, dayjs(endDate), dateRangeGroupExcludeSelf);
-  const shouldEndDateDisableDate = isEndDateDisabled.bind(null, dayjs(startDate), dateRangeGroupExcludeSelf);
+  const shouldStartDateDisableDate = isStartDateDisabled.bind(null, dateRangeGroupExcludeSelf);
+  const shouldEndDateDisableDate = isEndDateDisabled.bind(null, dateRangeGroupExcludeSelf);
 
   const dispatchUpdateConfig = () => {
     dispatch(updateShouldGetBoardConfig(true));

--- a/frontend/src/containers/ConfigStep/DateRangePicker/validation.ts
+++ b/frontend/src/containers/ConfigStep/DateRangePicker/validation.ts
@@ -24,12 +24,7 @@ export const calculateLastAvailableDate = (date: Dayjs, coveredRange: TDateRange
   return lastAvailableDate;
 };
 
-export const isStartDateDisabled = (coveredRange: TDateRange, date: Dayjs) =>
-  coveredRange.some(
-    ({ startDate, endDate }) => date.isSameOrAfter(startDate, 'date') && date.isSameOrBefore(endDate, 'date'),
-  );
-
-export const isEndDateDisabled = (coveredRange: TDateRange, date: Dayjs) =>
+export const isDateDisabled = (coveredRange: TDateRange, date: Dayjs) =>
   coveredRange.some(
     ({ startDate, endDate }) => date.isSameOrAfter(startDate, 'date') && date.isSameOrBefore(endDate, 'date'),
   );

--- a/frontend/src/containers/ConfigStep/DateRangePicker/validation.ts
+++ b/frontend/src/containers/ConfigStep/DateRangePicker/validation.ts
@@ -24,16 +24,12 @@ export const calculateLastAvailableDate = (date: Dayjs, coveredRange: TDateRange
   return lastAvailableDate;
 };
 
-export const isStartDateDisabled = (selfEndDate: Dayjs, coveredRange: TDateRange, date: Dayjs) => {
-  const isDateInCovredRange = coveredRange.some(
+export const isStartDateDisabled = (coveredRange: TDateRange, date: Dayjs) =>
+  coveredRange.some(
     ({ startDate, endDate }) => date.isSameOrAfter(startDate, 'date') && date.isSameOrBefore(endDate, 'date'),
   );
-  return isDateInCovredRange || date.isAfter(selfEndDate);
-};
 
-export const isEndDateDisabled = (selfStartDate: Dayjs, coveredRange: TDateRange, date: Dayjs) => {
-  const isDateInCovredRange = coveredRange.some(
+export const isEndDateDisabled = (coveredRange: TDateRange, date: Dayjs) =>
+  coveredRange.some(
     ({ startDate, endDate }) => date.isSameOrAfter(startDate, 'date') && date.isSameOrBefore(endDate, 'date'),
   );
-  return isDateInCovredRange || date.isBefore(selfStartDate);
-};


### PR DESCRIPTION
## Summary

When select `startDate` or `endDate`, it is no longer limited by its corresponding `endDate` or `startDate`.

## Before

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## After

_Description_

**Screenshots**
If applicable, add screenshots to help explain behavior of your code.

## Note

_Null_
