### PR TITLE
[frontend] feat/adm 811: Do not clear the configuration settings when returning from the metric page to the configuration page.

### DIFF
--- a/frontend/__tests__/containers/ConfigStep/MetricsTypeCheckbox.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/MetricsTypeCheckbox.test.tsx
@@ -12,8 +12,8 @@ import {
   REWORK_TIMES,
   VELOCITY,
 } from '../../fixtures';
-import { act, fireEvent, render, waitFor, within, screen } from '@testing-library/react';
 import { MetricsTypeCheckbox } from '@src/containers/ConfigStep/MetricsTypeCheckbox';
+import { fireEvent, render, waitFor, within, screen } from '@testing-library/react';
 import { SELECTED_VALUE_SEPARATOR } from '@src/constants/commons';
 import BasicInfo from '@src/containers/ConfigStep/BasicInfo';
 import { setupStore } from '../../utils/setupStoreUtil';
@@ -59,12 +59,8 @@ describe('MetricsTypeCheckbox', () => {
     const { getByRole, getByText } = setup();
     await userEvent.click(screen.getByRole('combobox', { name: REQUIRED_DATA }));
     const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
-    });
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: CYCLE_TIME }));
-    });
+    await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
+    await userEvent.click(listBox.getByRole('option', { name: CYCLE_TIME }));
 
     expect(getByText([VELOCITY, CYCLE_TIME].join(SELECTED_VALUE_SEPARATOR))).toBeInTheDocument();
   });
@@ -72,13 +68,9 @@ describe('MetricsTypeCheckbox', () => {
   it('should show all selections when all option are select', async () => {
     const { getByRole, getByText } = setup();
     const displayedDataList = REQUIRED_DATA_LIST.slice(1);
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
     const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: ALL }));
-    });
+    await userEvent.click(listBox.getByRole('option', { name: ALL }));
 
     expect(within(listBox.getByRole('option', { name: ALL })).getByTestId('CheckBoxIcon')).toBeTruthy();
     expect(getByText(displayedDataList.join(SELECTED_VALUE_SEPARATOR))).toBeInTheDocument();
@@ -88,16 +80,10 @@ describe('MetricsTypeCheckbox', () => {
     const { getByRole, getByText } = setup();
     const displayedDataList = REQUIRED_DATA_LIST.slice(1);
 
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
     const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
-    });
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: ALL }));
-    });
+    await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
+    await userEvent.click(listBox.getByRole('option', { name: ALL }));
 
     expect(within(listBox.getByRole('option', { name: ALL })).getByTestId('CheckBoxIcon')).toBeTruthy();
     expect(getByText(displayedDataList.join(SELECTED_VALUE_SEPARATOR))).toBeInTheDocument();
@@ -105,9 +91,7 @@ describe('MetricsTypeCheckbox', () => {
 
   it('should be checked of All selected option when click any other options', async () => {
     const { getByRole } = setup();
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
 
     const listBox = within(getByRole('listbox'));
     const optionsToClick = [
@@ -129,17 +113,11 @@ describe('MetricsTypeCheckbox', () => {
     const { getByRole, getByText } = setup();
     const displayedDataList = REQUIRED_DATA_LIST.slice(1, REQUIRED_DATA_LIST.length - 1);
 
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
 
     const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: ALL }));
-    });
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: DEV_MEAN_TIME_TO_RECOVERY }));
-    });
+    await userEvent.click(listBox.getByRole('option', { name: ALL }));
+    await userEvent.click(listBox.getByRole('option', { name: DEV_MEAN_TIME_TO_RECOVERY }));
 
     expect(listBox.getByRole('option', { name: DEV_MEAN_TIME_TO_RECOVERY })).toHaveAttribute('aria-selected', 'false');
     expect(within(listBox.getByRole('option', { name: ALL })).getByTestId('CheckBoxOutlineBlankIcon')).toBeTruthy();
@@ -160,51 +138,31 @@ describe('MetricsTypeCheckbox', () => {
   it('should show error message when require data is null', async () => {
     const { getByRole, getByText } = setup();
 
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
     const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
-    });
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
-    });
-    await act(async () => {
-      await userEvent.click(getByRole('listbox', { name: REQUIRED_DATA }));
-    });
+    await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
+    await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
+    await userEvent.click(getByRole('listbox', { name: REQUIRED_DATA }));
 
-    const errorMessage = getByText('Metrics is required');
-    expect(errorMessage).toBeInTheDocument();
+    expect(getByText(/Metrics is required/i)).toBeInTheDocument();
   });
 
   it('should show board component when click MetricsTypeCheckbox selection velocity ', async () => {
-    const { getByRole, getAllByText } = setup();
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
-    const listBox = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
-    });
-
-    expect(getAllByText(CONFIG_TITLE.BOARD)[0]).toBeInTheDocument();
+    setup();
+    await userEvent.click(screen.getByRole('combobox', { name: REQUIRED_DATA }));
+    const listBox = within(screen.getByRole('listbox'));
+    await userEvent.click(listBox.getByRole('option', { name: VELOCITY }));
+    expect(screen.getAllByText(CONFIG_TITLE.BOARD)[0]).toBeInTheDocument();
   });
 
   it('should hidden board component when MetricsTypeCheckbox select is null given MetricsTypeCheckbox select is velocity ', async () => {
-    const { getByRole, queryByText } = setup();
+    setup();
 
-    await act(async () => {
-      await userEvent.click(getByRole('combobox', { name: REQUIRED_DATA }));
-    });
-    const requireDateSelection = within(getByRole('listbox'));
-    await act(async () => {
-      await userEvent.click(requireDateSelection.getByRole('option', { name: VELOCITY }));
-    });
-    await act(async () => {
-      await userEvent.click(requireDateSelection.getByRole('option', { name: VELOCITY }));
-    });
+    await userEvent.click(screen.getByRole('combobox', { name: REQUIRED_DATA }));
+    const requireDateSelection = within(screen.getByRole('listbox'));
+    await userEvent.click(requireDateSelection.getByRole('option', { name: VELOCITY }));
+    await userEvent.click(requireDateSelection.getByRole('option', { name: VELOCITY }));
 
-    expect(queryByText(CONFIG_TITLE.BOARD)).not.toBeInTheDocument();
+    expect(screen.queryByText(CONFIG_TITLE.BOARD)).not.toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/containers/ConfigStep/MetricsTypeCheckbox.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/MetricsTypeCheckbox.test.tsx
@@ -13,7 +13,7 @@ import {
   VELOCITY,
 } from '../../fixtures';
 import { MetricsTypeCheckbox } from '@src/containers/ConfigStep/MetricsTypeCheckbox';
-import { fireEvent, render, waitFor, within, screen } from '@testing-library/react';
+import { render, waitFor, within, screen } from '@testing-library/react';
 import { SELECTED_VALUE_SEPARATOR } from '@src/constants/commons';
 import BasicInfo from '@src/containers/ConfigStep/BasicInfo';
 import { setupStore } from '../../utils/setupStoreUtil';
@@ -104,7 +104,7 @@ describe('MetricsTypeCheckbox', () => {
       listBox.getByRole('option', { name: DEV_CHANGE_FAILURE_RATE }),
       listBox.getByRole('option', { name: DEV_MEAN_TIME_TO_RECOVERY }),
     ];
-    await Promise.all(optionsToClick.map((opt) => fireEvent.click(opt)));
+    await Promise.all(optionsToClick.map((opt) => userEvent.click(opt)));
 
     expect(within(listBox.getByRole('option', { name: ALL })).getByTestId('CheckBoxIcon')).toBeTruthy();
   });

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -55,24 +55,24 @@ describe('PipelineTool', () => {
   });
 
   it('should show pipelineTool title and fields when render pipelineTool component ', () => {
-    const { getByLabelText, getAllByText } = setup();
+    setup();
 
     PIPELINE_TOOL_FIELDS.map((field) => {
-      expect(getByLabelText(`${field} *`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`${field} *`)).toBeInTheDocument();
     });
 
-    expect(getAllByText(CONFIG_TITLE.PIPELINE_TOOL)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(CONFIG_TITLE.PIPELINE_TOOL)[0]).toBeInTheDocument();
   });
 
   it('should show default value buildKite when init pipelineTool component', () => {
-    const { getByText, queryByText } = setup();
-    const pipelineToolType = getByText(PIPELINE_TOOL_TYPES.BUILD_KITE);
+    setup();
+    const pipelineToolType = screen.getByText(PIPELINE_TOOL_TYPES.BUILD_KITE);
 
     expect(pipelineToolType).toBeInTheDocument();
   });
 
   it('should clear all fields information when click reset button', async () => {
-    const { getByText, queryByRole } = setup();
+    setup();
     const tokenInput = within(screen.getByTestId('pipelineToolTextField')).getByLabelText(
       'input Token',
     ) as HTMLInputElement;
@@ -83,45 +83,45 @@ describe('PipelineTool', () => {
     await userEvent.click(screen.getByRole('button', { name: RESET }));
 
     expect(tokenInput.value).toEqual('');
-    expect(getByText(PIPELINE_TOOL_TYPES.BUILD_KITE)).toBeInTheDocument();
-    expect(queryByRole('button', { name: RESET })).not.toBeInTheDocument();
-    expect(queryByRole('button', { name: VERIFY })).toBeDisabled();
+    expect(screen.getByText(PIPELINE_TOOL_TYPES.BUILD_KITE)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: RESET })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: VERIFY })).toBeDisabled();
   });
 
   it('should hidden timeout alert when click reset button', async () => {
-    const { getByTestId, queryByTestId } = setup();
+    setup();
     await fillPipelineToolFieldsInformation();
     pipelineToolClient.verify = jest.fn().mockResolvedValue({ code: AXIOS_REQUEST_ERROR_CODE.TIMEOUT });
 
     await userEvent.click(screen.getByText(VERIFY));
 
-    expect(getByTestId('timeoutAlert')).toBeInTheDocument();
+    expect(screen.getByTestId('timeoutAlert')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: RESET }));
 
-    expect(queryByTestId('timeoutAlert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('timeoutAlert')).not.toBeInTheDocument();
   });
 
   it('should hidden timeout alert when the error type of api call becomes other', async () => {
-    const { getByTestId, queryByTestId } = setup();
+    setup();
     await fillPipelineToolFieldsInformation();
     pipelineToolClient.verify = jest.fn().mockResolvedValue({ code: AXIOS_REQUEST_ERROR_CODE.TIMEOUT });
 
     await userEvent.click(screen.getByText(VERIFY));
 
-    expect(getByTestId('timeoutAlert')).toBeInTheDocument();
+    expect(screen.getByTestId('timeoutAlert')).toBeInTheDocument();
 
     pipelineToolClient.verify = jest.fn().mockResolvedValue({ code: HttpStatusCode.Unauthorized });
 
     await userEvent.click(screen.getByText(REVERIFY));
 
-    expect(queryByTestId('timeoutAlert')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('timeoutAlert')).not.toBeInTheDocument();
   });
 
   it('should show detail options when click pipelineTool fields', async () => {
-    const { getByRole } = setup();
+    setup();
     await userEvent.click(screen.getByRole('combobox', { name: 'Pipeline Tool' }));
-    const listBox = within(getByRole('listbox'));
+    const listBox = within(screen.getByRole('listbox'));
     const options = listBox.getAllByRole('option');
     const optionValue = options.map((li) => li.getAttribute('data-value'));
 
@@ -129,8 +129,8 @@ describe('PipelineTool', () => {
   });
 
   it('should enabled verify button when all fields checked correctly given disable verify button', async () => {
-    const { getByRole } = setup();
-    const verifyButton = getByRole('button', { name: VERIFY });
+    setup();
+    const verifyButton = screen.getByRole('button', { name: VERIFY });
 
     expect(verifyButton).toBeDisabled();
 
@@ -140,7 +140,7 @@ describe('PipelineTool', () => {
   });
 
   it('should show error message and error style when token is empty', async () => {
-    const { getByText } = setup();
+    setup();
     await fillPipelineToolFieldsInformation();
     const mockInfo = 'mockToken';
     const tokenInput = within(screen.getByTestId('pipelineToolTextField')).getByLabelText(
@@ -149,8 +149,8 @@ describe('PipelineTool', () => {
     await userEvent.type(tokenInput, mockInfo);
     await userEvent.clear(tokenInput);
 
-    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toBeVisible();
-    expect(getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeVisible();
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
   });
 
   it('should not show error message when field does not trigger any event given an empty value', () => {
@@ -169,7 +169,7 @@ describe('PipelineTool', () => {
   });
 
   it('should show error message and error style when token is invalid', async () => {
-    const { getByText } = setup();
+    setup();
     const mockInfo = 'mockToken';
     const tokenInput = within(screen.getByTestId('pipelineToolTextField')).getByLabelText(
       'input Token',
@@ -178,34 +178,34 @@ describe('PipelineTool', () => {
 
     expect(tokenInput.value).toEqual(mockInfo);
 
-    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument();
-    expect(getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR);
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[0])).toBeInTheDocument();
+    expect(screen.getByText(TOKEN_ERROR_MESSAGE[0])).toHaveStyle(ERROR_MESSAGE_COLOR);
   });
 
   it('should show reset button and verified button when verify succeed ', async () => {
-    const { getByText } = setup();
+    setup();
     await fillPipelineToolFieldsInformation();
 
     await userEvent.click(screen.getByText(VERIFY));
     expect(screen.getByText(RESET)).toBeVisible();
 
     await waitFor(() => {
-      expect(getByText(VERIFIED)).toBeTruthy();
+      expect(screen.getByText(VERIFIED)).toBeTruthy();
     });
   });
 
   it('should called verifyPipelineTool method once when click verify button', async () => {
-    const { getByText } = setup();
+    setup();
     await fillPipelineToolFieldsInformation();
     await userEvent.click(screen.getByRole('button', { name: VERIFY }));
 
-    expect(getByText('Verified')).toBeInTheDocument();
+    expect(screen.getByText('Verified')).toBeInTheDocument();
   });
 
   it('should check loading animation when click verify button', async () => {
-    const { getByRole, container } = setup();
+    const { container } = setup();
     await fillPipelineToolFieldsInformation();
-    fireEvent.click(getByRole('button', { name: VERIFY }));
+    fireEvent.click(screen.getByRole('button', { name: VERIFY }));
     await waitFor(() => {
       expect(container.getElementsByTagName('span')[0].getAttribute('role')).toEqual('progressbar');
     });

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -11,8 +11,8 @@ import {
   FAKE_PIPELINE_TOKEN,
   REVERIFY,
 } from '../../fixtures';
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { pipelineToolClient } from '@src/clients/pipeline/PipelineToolClient';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import { PipelineTool } from '@src/containers/ConfigStep/PipelineTool';
 import { AXIOS_REQUEST_ERROR_CODE } from '@src/constants/resources';
 import { setupStore } from '../../utils/setupStoreUtil';
@@ -159,10 +159,10 @@ describe('PipelineTool', () => {
     expect(screen.queryByText(TOKEN_ERROR_MESSAGE[1])).not.toBeInTheDocument();
   });
 
-  it('should show error message when focus on field given an empty value', () => {
+  it('should show error message when focus on field given an empty value', async () => {
     setup();
 
-    fireEvent.focus(screen.getByLabelText('input Token'));
+    await userEvent.click(screen.getByLabelText('input Token'));
 
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toBeInTheDocument();
     expect(screen.getByText(TOKEN_ERROR_MESSAGE[1])).toHaveStyle(ERROR_MESSAGE_COLOR);
@@ -203,12 +203,14 @@ describe('PipelineTool', () => {
   });
 
   it('should check loading animation when click verify button', async () => {
+    server.use(
+      rest.post(MOCK_PIPELINE_VERIFY_URL, (_, res, ctx) => res(ctx.delay(300), ctx.status(HttpStatusCode.Ok))),
+    );
     const { container } = setup();
     await fillPipelineToolFieldsInformation();
-    fireEvent.click(screen.getByRole('button', { name: VERIFY }));
-    await waitFor(() => {
-      expect(container.getElementsByTagName('span')[0].getAttribute('role')).toEqual('progressbar');
-    });
+    await userEvent.click(screen.getByRole('button', { name: VERIFY }));
+
+    expect(container.getElementsByTagName('span')[0].getAttribute('role')).toEqual('progressbar');
   });
 
   it('should check error text appear when pipelineTool verify response status is 401', async () => {

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -69,7 +69,6 @@ describe('PipelineTool', () => {
     const pipelineToolType = getByText(PIPELINE_TOOL_TYPES.BUILD_KITE);
 
     expect(pipelineToolType).toBeInTheDocument();
-
   });
 
   it('should clear all fields information when click reset button', async () => {

--- a/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
+++ b/frontend/__tests__/containers/ConfigStep/PipelineTool.test.tsx
@@ -70,26 +70,6 @@ describe('PipelineTool', () => {
 
     expect(pipelineToolType).toBeInTheDocument();
 
-    const option = queryByText(PIPELINE_TOOL_TYPES.GO_CD);
-
-    expect(option).not.toBeInTheDocument();
-  });
-
-  it('should clear other fields information when change pipelineTool Field selection', async () => {
-    const { getByText, getByLabelText } = setup();
-    const tokenInput = within(screen.getByTestId('pipelineToolTextField')).getByLabelText(
-      'input Token',
-    ) as HTMLInputElement;
-
-    await fillPipelineToolFieldsInformation();
-    await userEvent.click(screen.getByRole('combobox', { name: 'Pipeline Tool' }));
-
-    const requireDateSelection = within(getByLabelText('Pipeline Tool type select'));
-    await userEvent.click(requireDateSelection.getByText(PIPELINE_TOOL_TYPES.BUILD_KITE));
-
-    await userEvent.click(getByText(PIPELINE_TOOL_TYPES.GO_CD));
-
-    expect(tokenInput.value).toEqual('');
   });
 
   it('should clear all fields information when click reset button', async () => {

--- a/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
@@ -407,24 +407,4 @@ describe('MetricsStepper', () => {
       expect(exportToJsonFile).toHaveBeenCalledWith(expectedFileName, expectedJson);
     });
   }, 25000);
-
-  it('should clean the config information that is hidden when click next button', async () => {
-    setup();
-
-    await fillConfigPageData();
-    await userEvent.click(screen.getByText(NEXT));
-
-    expect(updateBoard).not.toHaveBeenCalledWith({
-      type: BOARD_TYPES.JIRA,
-      boardId: '',
-      email: '',
-      projectKey: '',
-      site: '',
-      token: '',
-      startTime: 0,
-      endTime: 0,
-    });
-    expect(updateSourceControl).toHaveBeenCalledWith({ type: SOURCE_CONTROL_TYPES.GITHUB, token: '' });
-    expect(updatePipelineTool).toHaveBeenCalledWith({ type: PIPELINE_TOOL_TYPES.BUILD_KITE, token: '' });
-  }, 50000);
 });

--- a/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
@@ -26,7 +26,7 @@ import {
   updatePipelineToolVerifyState,
   updateSourceControlVerifyState,
 } from '@src/context/config/configSlice';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { ASSIGNEE_FILTER_TYPES } from '@src/constants/resources';
 import MetricsStepper from '@src/containers/MetricsStepper';
 import { setupStore } from '../../utils/setupStoreUtil';
@@ -106,9 +106,9 @@ Object.defineProperty(window, 'location', { value: mockLocation });
 let store = setupStore();
 const fillConfigPageData = async () => {
   const projectNameInput = await screen.findByRole('textbox', { name: PROJECT_NAME_LABEL });
-  fireEvent.change(projectNameInput, { target: { value: TEST_PROJECT_NAME } });
+  await userEvent.type(projectNameInput, TEST_PROJECT_NAME);
   const startDateInput = (await screen.findByRole('textbox', { name: START_DATE_LABEL })) as HTMLInputElement;
-  fireEvent.change(startDateInput, { target: { value: INPUT_DATE_VALUE } });
+  await userEvent.type(startDateInput, INPUT_DATE_VALUE);
 
   act(() => {
     store.dispatch(updateMetrics([VELOCITY]));
@@ -241,7 +241,7 @@ describe('MetricsStepper', () => {
     setup();
 
     await fillConfigPageData();
-    fireEvent.click(screen.getByText(NEXT));
+    await userEvent.click(screen.getByText(NEXT));
 
     expect(screen.getByText(METRICS)).toHaveStyle(`color:${stepperColor}`);
   });

--- a/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
+++ b/frontend/__tests__/containers/MetricsStepper/MetricsStepper.test.tsx
@@ -1,11 +1,9 @@
 import {
   BASE_PAGE_ROUTE,
-  BOARD_TYPES,
   CONFIRM_DIALOG_DESCRIPTION,
   DEFAULT_REWORK_SETTINGS,
   MOCK_REPORT_URL,
   NEXT,
-  PIPELINE_TOOL_TYPES,
   PREVIOUS,
   PROJECT_NAME_LABEL,
   SAVE,
@@ -15,15 +13,6 @@ import {
   COMMON_TIME_FORMAT,
 } from '../../fixtures';
 import {
-  updateBoard,
-  updateBoardVerifyState,
-  updateMetrics,
-  updatePipelineTool,
-  updatePipelineToolVerifyState,
-  updateSourceControl,
-  updateSourceControlVerifyState,
-} from '@src/context/config/configSlice';
-import {
   updateCycleTimeSettings,
   saveDoneColumn,
   saveTargetFields,
@@ -31,8 +20,14 @@ import {
   updateDeploymentFrequencySettings,
   updateTreatFlagCardAsBlock,
 } from '@src/context/Metrics/metricsSlice';
-import { ASSIGNEE_FILTER_TYPES, SOURCE_CONTROL_TYPES } from '@src/constants/resources';
+import {
+  updateBoardVerifyState,
+  updateMetrics,
+  updatePipelineToolVerifyState,
+  updateSourceControlVerifyState,
+} from '@src/context/config/configSlice';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ASSIGNEE_FILTER_TYPES } from '@src/constants/resources';
 import MetricsStepper from '@src/containers/MetricsStepper';
 import { setupStore } from '../../utils/setupStoreUtil';
 import userEvent from '@testing-library/user-event';

--- a/frontend/__tests__/fixtures.ts
+++ b/frontend/__tests__/fixtures.ts
@@ -85,7 +85,6 @@ export const BOARD_TYPES = {
 
 export const PIPELINE_TOOL_TYPES = {
   BUILD_KITE: 'BuildKite',
-  GO_CD: 'GoCD',
 };
 
 export enum CONFIG_TITLE {

--- a/frontend/__tests__/utils/Util.test.tsx
+++ b/frontend/__tests__/utils/Util.test.tsx
@@ -143,23 +143,10 @@ describe('findCaseInsensitiveType function', () => {
     expect(value).toBe(PIPELINE_TOOL_TYPES.BUILD_KITE);
   });
 
-  it('Should return "GoCD" when passing a type given case sensitive input GoCD', () => {
-    const selectedValue = 'GoCD';
-    const value = findCaseInsensitiveType(Object.values(PIPELINE_TOOL_TYPES), selectedValue);
-    expect(value).toBe(PIPELINE_TOOL_TYPES.GO_CD);
-  });
-
-  it('Should return "GoCD" when passing a type given case insensitive input Gocd', () => {
-    const selectedValue = 'Gocd';
-    const value = findCaseInsensitiveType(Object.values(PIPELINE_TOOL_TYPES), selectedValue);
-    expect(value).toBe(PIPELINE_TOOL_TYPES.GO_CD);
-  });
-
   it('Should return "_BuildKite" when passing a type given the value mismatches with PIPELINE_TOOL_TYPES', () => {
     const selectedValue = '_BuildKite';
     const value = findCaseInsensitiveType(Object.values(PIPELINE_TOOL_TYPES), selectedValue);
     expect(value).not.toBe(PIPELINE_TOOL_TYPES.BUILD_KITE);
-    expect(value).not.toBe(PIPELINE_TOOL_TYPES.GO_CD);
     expect(value).toBe(selectedValue);
   });
 

--- a/frontend/src/constants/resources.ts
+++ b/frontend/src/constants/resources.ts
@@ -123,7 +123,6 @@ export const BOARD_TYPES = {
 
 export const PIPELINE_TOOL_TYPES = {
   BUILD_KITE: 'BuildKite',
-  GO_CD: 'GoCD',
 };
 
 export enum SOURCE_CONTROL_TYPES {

--- a/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
+++ b/frontend/src/containers/ConfigStep/PipelineTool/index.tsx
@@ -79,15 +79,6 @@ export const PipelineTool = () => {
     );
   };
 
-  const onSelectUpdate = (value: string) => {
-    const newFields = fields.map(({ key }, index) => ({
-      key,
-      value: index === FIELD_KEY.TYPE ? value : EMPTY_STRING,
-      validatedError: '',
-    }));
-    handleUpdate(newFields);
-  };
-
   const getNewFields = (value: string) =>
     fields.map((field, index) =>
       index === FIELD_KEY.TOKEN
@@ -146,7 +137,6 @@ export const PipelineTool = () => {
             labelId='pipelineTool-type-checkbox-label'
             aria-label='Pipeline Tool type select'
             value={fields[FIELD_KEY.TYPE].value}
-            onChange={(e) => onSelectUpdate(e.target.value)}
           >
             {Object.values(PIPELINE_TOOL_TYPES).map((toolType) => (
               <MenuItem key={toolType} value={toolType}>

--- a/frontend/src/containers/MetricsStepper/index.tsx
+++ b/frontend/src/containers/MetricsStepper/index.tsx
@@ -250,11 +250,6 @@ const MetricsStepper = () => {
     if (activeStep === METRICS_STEPS.METRICS) {
       dispatch(updateTimeStamp(new Date().getTime()));
     }
-    if (activeStep === METRICS_STEPS.CONFIG) {
-      cleanBoardState();
-      cleanPipelineToolConfiguration();
-      cleanSourceControlState();
-    }
     dispatch(nextStep());
   };
 
@@ -271,35 +266,6 @@ const MetricsStepper = () => {
 
   const CancelDialog = () => {
     setIsDialogShowing(false);
-  };
-
-  const cleanPipelineToolConfiguration = () => {
-    !isShowPipeline && dispatch(updatePipelineTool({ type: PIPELINE_TOOL_TYPES.BUILD_KITE, token: '' }));
-    isShowPipeline
-      ? dispatch(updatePipelineToolVerifyState(isPipelineToolVerified))
-      : dispatch(updatePipelineToolVerifyState(false));
-  };
-
-  const cleanSourceControlState = () => {
-    !isShowSourceControl && dispatch(updateSourceControl({ type: SOURCE_CONTROL_TYPES.GITHUB, token: '' }));
-    isShowSourceControl
-      ? dispatch(updateSourceControlVerifyState(isSourceControlVerified))
-      : dispatch(updateSourceControlVerifyState(false));
-  };
-
-  const cleanBoardState = () => {
-    !isShowBoard &&
-      dispatch(
-        updateBoard({
-          type: BOARD_TYPES.JIRA,
-          boardId: '',
-          email: '',
-          projectKey: '',
-          site: '',
-          token: '',
-        }),
-      );
-    isShowBoard ? dispatch(updateBoardVerifyState(isBoardVerified)) : dispatch(updateBoardVerifyState(false));
   };
 
   return (

--- a/frontend/src/containers/MetricsStepper/index.tsx
+++ b/frontend/src/containers/MetricsStepper/index.tsx
@@ -1,25 +1,4 @@
 import {
-  selectConfig,
-  selectMetrics,
-  selectPipelineList,
-  updateBoard,
-  updateBoardVerifyState,
-  updatePipelineTool,
-  updatePipelineToolVerifyState,
-  updateSourceControl,
-  updateSourceControlVerifyState,
-} from '@src/context/config/configSlice';
-import {
-  BOARD_TYPES,
-  CYCLE_TIME_SETTINGS_TYPES,
-  DONE,
-  METRICS_CONSTANTS,
-  PIPELINE_TOOL_TYPES,
-  REQUIRED_DATA,
-  SOURCE_CONTROL_TYPES,
-  TIPS,
-} from '@src/constants/resources';
-import {
   BackButton,
   ButtonContainer,
   MetricsStepperContent,
@@ -34,9 +13,11 @@ import {
   selectCycleTimeSettings,
   selectMetricsContent,
 } from '@src/context/Metrics/metricsSlice';
+import { CYCLE_TIME_SETTINGS_TYPES, DONE, METRICS_CONSTANTS, REQUIRED_DATA, TIPS } from '@src/constants/resources';
 import { backStep, nextStep, selectStepNumber, updateTimeStamp } from '@src/context/stepper/StepperSlice';
 import { useMetricsStepValidationCheckContext } from '@src/hooks/useMetricsStepValidationCheckContext';
 import { convertCycleTimeSettings, exportToJsonFile, onlyEmptyAndDoneState } from '@src/utils/util';
+import { selectConfig, selectMetrics, selectPipelineList } from '@src/context/config/configSlice';
 import { COMMON_BUTTONS, METRICS_STEPS, STEPS } from '@src/constants/commons';
 import { ConfirmDialog } from '@src/containers/MetricsStepper/ConfirmDialog';
 import { useAppDispatch, useAppSelector } from '@src/hooks/useAppDispatch';


### PR DESCRIPTION
## Summary
Do not clear the configuration settings when returning from the metric page to the configuration page.


...

## Before
Auto clear board, pipeline and source control config when back to config page from metric page


## After
1. do not auto clear config 
2. remove pipeline tools type GoCD
3. refactor unit test style
4. remove unit tests that are no longer needed. 

## Note


