### PR TITLE
fix/ADM-937 [backend]: fix the error that performance is different when pipeline crews is all and pipeline crews is empty

### DIFF
--- a/frontend/scripts/generate-config-files.sh
+++ b/frontend/scripts/generate-config-files.sh
@@ -33,7 +33,7 @@ import_file_name='./e2e/fixtures/input-files/pipeline-no-org-config-file.json'
 echo "Start to generate ${import_file_name}"
 cat ./e2e/fixtures/input-files/pipeline-no-org-config-file.template.json > "${import_file_name}"
 sed -i -e "s/<E2E_TOKEN_JIRA>/${E2E_TOKEN_JIRA}/g" "${import_file_name}"
-#sed -i -e "s/<E2E_TOKEN_PIPELINE_NO_ORG_CONFIG_BUILDKITE>/${E2E_TOKEN_PIPELINE_NO_ORG_CONFIG_BUILDKITE}/g" "${import_file_name}"
+sed -i -e "s/<E2E_TOKEN_PIPELINE_NO_ORG_CONFIG_BUILDKITE>/${E2E_TOKEN_PIPELINE_NO_ORG_CONFIG_BUILDKITE}/g" "${import_file_name}"
 sed -i -e "s/<E2E_TOKEN_GITHUB>/${E2E_TOKEN_GITHUB}/g" "${import_file_name}"
 echo "Successfully generate ${import_file_name}"
 


### PR DESCRIPTION
## Summary

fix the error that performance is different when pipeline crews are all and pipeline crews are empty.
## Before

When we select empty pipeline crews and download pipeline data, we will find the empty `Code Committer` in csv file. This is an error, because maybe the empty `Code Committer` contains two situations of `Unknown` and `username=null`.


<img width="361" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/147299494/af34ffbd-a2ac-46d5-9617-58fd9bc72afe">

## After

When we select  empty pipeline crews and download pipeline data, we will not find the empty `Code Committer` in csv file.

<img width="280" alt="image" src="https://github.com/au-heartbeat/Heartbeat/assets/147299494/ff7150cb-93f3-46d9-93ba-0218419ad9c5">
