### PR TITLE
ADM-963 [frontend]: fix bug of multiple pipeline

### DIFF
--- a/frontend/__tests__/containers/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportStep.test.tsx
@@ -840,9 +840,16 @@ describe('Report Step', () => {
       const switchDORATab = screen.getByText(CHART_TYPE.DORA);
       await userEvent.click(switchDORATab);
 
-      // expect(async () => {
-      //   await userEvent.click(switchDORATab);
-      // }).rejects.toThrowError();
+      const exportDORAButton = screen.getByText(EXPORT_PIPELINE_DATA);
+      await userEvent.click(exportDORAButton);
+      expect(exportDORAButton).toBeInTheDocument();
+
+      const switchBoardTab = screen.getByText(CHART_TYPE.BOARD);
+      await userEvent.click(switchBoardTab);
+
+      const exportBoardButton = screen.getByText(EXPORT_BOARD_DATA);
+      await userEvent.click(exportBoardButton);
+      expect(exportBoardButton).toBeInTheDocument();
     });
   });
 });

--- a/frontend/__tests__/containers/ReportStep/ReportStep.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportStep.test.tsx
@@ -12,6 +12,7 @@ import {
   LEAD_TIME_FOR_CHANGES,
   MOCK_JIRA_VERIFY_RESPONSE,
   MOCK_REPORT_RESPONSE,
+  MOCK_REPORT_RESPONSE_WITH_AVERAGE_EXCEPTION,
   PREVIOUS,
   REQUIRED_DATA_LIST,
   RETRY,
@@ -825,6 +826,23 @@ describe('Report Step', () => {
       const exportBoardButton = screen.getByText(EXPORT_BOARD_DATA);
       await userEvent.click(exportBoardButton);
       expect(exportBoardButton).toBeInTheDocument();
+    });
+
+    it('should export error when click DORA Chart and lead time for change dont have average', async () => {
+      setup(REQUIRED_DATA_LIST, [fullValueDateRange, emptyValueDateRange]);
+
+      reportHook.current.reportInfos[0].reportData = { ...MOCK_REPORT_RESPONSE_WITH_AVERAGE_EXCEPTION };
+      reportHook.current.reportInfos[1].reportData = { ...MOCK_REPORT_RESPONSE };
+
+      const switchChartButton = screen.getByText(DISPLAY_TYPE.CHART);
+      await userEvent.click(switchChartButton);
+
+      const switchDORATab = screen.getByText(CHART_TYPE.DORA);
+      await userEvent.click(switchDORATab);
+
+      // expect(async () => {
+      //   await userEvent.click(switchDORATab);
+      // }).rejects.toThrowError();
     });
   });
 });

--- a/frontend/__tests__/fixtures.ts
+++ b/frontend/__tests__/fixtures.ts
@@ -425,6 +425,140 @@ const reportMetricsError = {
   sourceControlMetricsError: null,
 };
 
+export const MOCK_REPORT_RESPONSE_WITH_AVERAGE_EXCEPTION: ReportResponseDTO = {
+  velocity: {
+    velocityForSP: 20,
+    velocityForCards: 14,
+  },
+  cycleTime: {
+    averageCycleTimePerCard: 30.26,
+    averageCycleTimePerSP: 21.18,
+    totalTimeForCards: 423.59,
+    swimlaneList: [
+      {
+        optionalItemName: 'Analysis',
+        averageTimeForSP: 8.36,
+        averageTimeForCards: 11.95,
+        totalTime: 167.27,
+      },
+      {
+        optionalItemName: 'In Dev',
+        averageTimeForSP: 12.13,
+        averageTimeForCards: 17.32,
+        totalTime: 242.51,
+      },
+    ],
+  },
+  deploymentFrequency: {
+    avgDeploymentFrequency: {
+      name: 'Average',
+      deploymentFrequency: NaN,
+    },
+    deploymentFrequencyOfPipelines: [
+      {
+        name: 'fs-platform-onboarding',
+        step: ' :shipit: deploy to PROD',
+        deploymentFrequency: 0.3,
+        dailyDeploymentCounts: [
+          {
+            date: '9/9/2022',
+            count: 1,
+          },
+        ],
+      },
+    ],
+  },
+  devMeanTimeToRecovery: {
+    avgDevMeanTimeToRecovery: {
+      name: 'Average',
+      timeToRecovery: NaN,
+    },
+    devMeanTimeToRecoveryOfPipelines: [
+      {
+        name: 'Heartbeat',
+        step: ':react: Build Frontend',
+        timeToRecovery: 15560177,
+      },
+      {
+        name: 'Heartbeat',
+        step: ':cloudformation: Deploy infra',
+        timeToRecovery: 0,
+      },
+      {
+        name: 'Heartbeat',
+        step: ':rocket: Run e2e',
+        timeToRecovery: 27628149.333333332,
+      },
+    ],
+  },
+  rework: {
+    totalReworkTimes: 111,
+    reworkState: 'In Dev',
+    fromAnalysis: null,
+    fromInDev: null,
+    fromBlock: 111,
+    fromReview: 111,
+    fromWaitingForTesting: 111,
+    fromTesting: null,
+    fromDone: 111,
+    totalReworkCards: 111,
+    reworkCardsRatio: 0.8888,
+    throughput: 1110,
+  },
+  leadTimeForChanges: {
+    leadTimeForChangesOfPipelines: [
+      {
+        name: 'fs-platform-payment-selector',
+        step: 'RECORD RELEASE TO PROD',
+        prLeadTime: 2702.53,
+        pipelineLeadTime: 2587.42,
+        totalDelayTime: 5289.95,
+      },
+    ],
+    avgLeadTimeForChanges: {
+      name: 'other',
+      prLeadTime: 3647.51,
+      pipelineLeadTime: 2341.72,
+      totalDelayTime: 5989.22,
+    },
+  },
+  devChangeFailureRate: {
+    avgDevChangeFailureRate: {
+      name: 'Average',
+      totalTimes: 6,
+      totalFailedTimes: 0,
+      failureRate: 0.0,
+    },
+    devChangeFailureRateOfPipelines: [
+      {
+        name: 'fs-platform-onboarding',
+        step: ' :shipit: deploy to PROD',
+        failedTimesOfPipeline: 0,
+        totalTimesOfPipeline: 2,
+        failureRate: 0.0,
+      },
+    ],
+  },
+  classificationList: [
+    {
+      fieldName: 'FS Work Type',
+      pairList: [
+        {
+          name: 'Feature Work - Planned',
+          value: 0.5714,
+        },
+      ],
+    },
+  ],
+  exportValidityTime: 1800000,
+  boardMetricsCompleted: true,
+  doraMetricsCompleted: true,
+  overallMetricsCompleted: true,
+  allMetricsCompleted: true,
+  isSuccessfulCreateCsvFile: true,
+  reportMetricsError,
+};
+
 export const MOCK_REPORT_RESPONSE: ReportResponseDTO = {
   velocity: {
     velocityForSP: 20,

--- a/frontend/__tests__/hooks/reportMapper/changeFailureRate.test.tsx
+++ b/frontend/__tests__/hooks/reportMapper/changeFailureRate.test.tsx
@@ -29,6 +29,15 @@ describe('dev change failure rate data mapper', () => {
           },
         ],
       },
+      {
+        id: 1,
+        name: 'Average',
+        valueList: [
+          {
+            value: '0.00',
+          },
+        ],
+      },
     ];
     const mappedDevChangeFailureRate = devChangeFailureRateMapper(mockDevChangeFailureRateRes);
 

--- a/frontend/__tests__/hooks/reportMapper/deploymentFrequency.test.tsx
+++ b/frontend/__tests__/hooks/reportMapper/deploymentFrequency.test.tsx
@@ -39,6 +39,15 @@ describe('deployment frequency data mapper', () => {
           },
         ],
       },
+      {
+        id: 1,
+        name: 'Average',
+        valueList: [
+          {
+            value: '0.40',
+          },
+        ],
+      },
     ];
     const mappedDeploymentFrequency = deploymentFrequencyMapper(mockDeploymentFrequencyRes);
 

--- a/frontend/__tests__/hooks/reportMapper/meanTimeToRecovery.test.tsx
+++ b/frontend/__tests__/hooks/reportMapper/meanTimeToRecovery.test.tsx
@@ -25,6 +25,15 @@ describe('dev mean time to recovery data mapper', () => {
           },
         ],
       },
+      {
+        id: 1,
+        name: 'Average',
+        valueList: [
+          {
+            value: '45.03',
+          },
+        ],
+      },
     ];
     const mappedDevMeanTimeToRecovery = devMeanTimeToRecoveryMapper(mockDevMeanTimeToRecovery);
 
@@ -55,6 +64,15 @@ describe('dev mean time to recovery data mapper', () => {
           },
         ],
       },
+      {
+        id: 1,
+        name: 'Average',
+        valueList: [
+          {
+            value: '0.00',
+          },
+        ],
+      },
     ];
     const mappedDevMeanTimeToRecovery = devMeanTimeToRecoveryMapper(mockDevMeanTimeToRecovery);
 
@@ -79,6 +97,15 @@ describe('dev mean time to recovery data mapper', () => {
       {
         id: 0,
         name: 'fs-platform-onboarding/ :shipit: deploy to PROD',
+        valueList: [
+          {
+            value: '0.00',
+          },
+        ],
+      },
+      {
+        id: 1,
+        name: 'Average',
         valueList: [
           {
             value: '0.00',

--- a/frontend/__tests__/hooks/reportMapper/report.test.tsx
+++ b/frontend/__tests__/hooks/reportMapper/report.test.tsx
@@ -81,6 +81,15 @@ export const EXPECTED_REPORT_VALUES = {
         },
       ],
     },
+    {
+      id: 1,
+      name: 'Average',
+      valueList: [
+        {
+          value: '0.40',
+        },
+      ],
+    },
   ],
   devMeanTimeToRecoveryList: [
     {
@@ -107,6 +116,15 @@ export const EXPECTED_REPORT_VALUES = {
       valueList: [
         {
           value: '7.67',
+        },
+      ],
+    },
+    {
+      id: 3,
+      name: 'Average',
+      valueList: [
+        {
+          value: '4.00',
         },
       ],
     },
@@ -138,6 +156,15 @@ export const EXPECTED_REPORT_VALUES = {
       valueList: [
         {
           value: '0.00%(0/2)',
+        },
+      ],
+    },
+    {
+      id: 1,
+      name: 'Average',
+      valueList: [
+        {
+          value: '0.00',
         },
       ],
     },

--- a/frontend/src/containers/ReportStep/DoraMetricsChart/ChartOption.ts
+++ b/frontend/src/containers/ReportStep/DoraMetricsChart/ChartOption.ts
@@ -1,4 +1,5 @@
 import { percentageFormatter, xAxisLabelDateFormatter } from '@src/utils/util';
+import { TooltipComponentOption } from 'echarts';
 import { theme } from '@src/theme';
 
 export interface BarOptionProps {
@@ -21,6 +22,7 @@ export interface Series {
   name: string;
   type: string;
   data: number[];
+  tooltip?: TooltipComponentOption;
 }
 export interface yAxis {
   name: string;
@@ -102,6 +104,7 @@ export const oneLineOptionMapper = (props: LineOptionProps) => {
       areaStyle: {
         opacity: 0.3,
       },
+      tooltip: props.series.tooltip,
     },
   };
 };

--- a/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
@@ -14,9 +14,9 @@ import {
 } from '@src/constants/resources';
 import { ReportResponse, ReportResponseDTO } from '@src/clients/report/dto/response';
 import ChartAndTitleWrapper from '@src/containers/ReportStep/ChartAndTitleWrapper';
+import { calculateTrendInfo, percentageFormatter } from '@src/utils/util';
 import { ChartContainer } from '@src/containers/MetricsStep/style';
 import { reportMapper } from '@src/hooks/reportMapper/report';
-import { calculateTrendInfo } from '@src/utils/util';
 import { theme } from '@src/theme';
 
 interface DoraMetricsChartProps {
@@ -113,6 +113,9 @@ function extractedChangeFailureRateData(allDateRanges: string[], mappedData: Rep
       name: RequiredData.DevChangeFailureRate,
       type: 'line',
       data: value!,
+      tooltip: {
+        valueFormatter: percentageFormatter(!!value),
+      },
     },
     color: theme.main.doraChart.devChangeFailureRateColor,
     trendInfo,

--- a/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
@@ -34,7 +34,7 @@ function extractedStackedBarData(allDateRanges: string[], mappedData: ReportResp
     .slice(0, 2);
   const extractedValues = mappedData?.map((data) => {
     const averageItem = data.leadTimeForChangesList?.find((leadTimeForChange) => leadTimeForChange.name === AVERAGE);
-    if (!averageItem) return;
+    if (!averageItem) return [];
 
     return averageItem.valuesList.map((item) => Number(item.value));
   });

--- a/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/DoraMetricsChart/index.tsx
@@ -26,16 +26,19 @@ interface DoraMetricsChartProps {
 
 const NO_LABEL = '';
 const LABEL_PERCENT = '%';
+const AVERAGE = 'Average';
 
 function extractedStackedBarData(allDateRanges: string[], mappedData: ReportResponse[] | undefined) {
   const extractedName = mappedData?.[0].leadTimeForChangesList?.[0].valuesList
     .map((item) => LEAD_TIME_CHARTS_MAPPING[item.name])
     .slice(0, 2);
-  const extractedValues = mappedData?.map((data) =>
-    data.leadTimeForChangesList?.[0].valuesList.map((item) => {
-      return Number(item.value);
-    }),
-  );
+  const extractedValues = mappedData?.map((data) => {
+    const averageItem = data.leadTimeForChangesList?.find((leadTimeForChange) => leadTimeForChange.name === AVERAGE);
+    if (!averageItem) return;
+
+    return averageItem.valuesList.map((item) => Number(item.value));
+  });
+
   const prLeadTimeValues = extractedValues?.map((value) => value![0]);
   const trendInfo = calculateTrendInfo(prLeadTimeValues, allDateRanges, ChartType.LeadTimeForChanges);
 
@@ -66,8 +69,10 @@ function extractedStackedBarData(allDateRanges: string[], mappedData: ReportResp
 
 function extractedDeploymentFrequencyData(allDateRanges: string[], mappedData: ReportResponse[] | undefined) {
   const data = mappedData?.map((item) => item.deploymentFrequencyList);
-  const value = data?.map((item) => {
-    return Number(item?.[0].valueList[0].value) || 0;
+  const value = data?.map((items) => {
+    const averageItem = items?.find((item) => item.name === AVERAGE);
+    if (!averageItem) return 0;
+    return Number(averageItem.valueList[0].value) || 0;
   });
   const trendInfo = calculateTrendInfo(value, allDateRanges, ChartType.DeploymentFrequency);
   return {
@@ -90,10 +95,11 @@ function extractedDeploymentFrequencyData(allDateRanges: string[], mappedData: R
 
 function extractedChangeFailureRateData(allDateRanges: string[], mappedData: ReportResponse[] | undefined) {
   const data = mappedData?.map((item) => item.devChangeFailureRateList);
-  const valueStr = data?.map((item) => {
-    return item?.[0].valueList[0].value as string;
+  const value = data?.map((items) => {
+    const averageItem = items?.find((item) => item.name === AVERAGE);
+    if (!averageItem) return 0;
+    return Number(averageItem.valueList[0].value) || 0;
   });
-  const value = valueStr?.map((item) => Number(item?.split('%', 1)[0]));
   const trendInfo = calculateTrendInfo(value, allDateRanges, ChartType.DevChangeFailureRate);
   return {
     legend: RequiredData.DevChangeFailureRate,
@@ -115,8 +121,10 @@ function extractedChangeFailureRateData(allDateRanges: string[], mappedData: Rep
 
 function extractedMeanTimeToRecoveryDataData(allDateRanges: string[], mappedData: ReportResponse[] | undefined) {
   const data = mappedData?.map((item) => item.devMeanTimeToRecoveryList);
-  const value = data?.map((item) => {
-    return Number(item?.[0].valueList[0].value) || 0;
+  const value = data?.map((items) => {
+    const averageItem = items?.find((item) => item.name === AVERAGE);
+    if (!averageItem) return 0;
+    return Number(averageItem.valueList[0].value) || 0;
   });
   const trendInfo = calculateTrendInfo(value, allDateRanges, ChartType.DevMeanTimeToRecovery);
   return {

--- a/frontend/src/hooks/reportMapper/deploymentFrequency.ts
+++ b/frontend/src/hooks/reportMapper/deploymentFrequency.ts
@@ -1,7 +1,10 @@
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import { DeploymentFrequencyResponse } from '@src/clients/report/dto/response';
 
-export const deploymentFrequencyMapper = ({ deploymentFrequencyOfPipelines }: DeploymentFrequencyResponse) => {
+export const deploymentFrequencyMapper = ({
+  deploymentFrequencyOfPipelines,
+  avgDeploymentFrequency,
+}: DeploymentFrequencyResponse) => {
   const mappedDeploymentFrequencyValue: ReportDataWithTwoColumns[] = [];
 
   deploymentFrequencyOfPipelines.map((item, index) => {
@@ -11,6 +14,16 @@ export const deploymentFrequencyMapper = ({ deploymentFrequencyOfPipelines }: De
       valueList: [{ value: `${item.deploymentFrequency.toFixed(2)}` }],
     };
     mappedDeploymentFrequencyValue.push(deploymentFrequencyValue);
+  });
+
+  mappedDeploymentFrequencyValue.push({
+    id: mappedDeploymentFrequencyValue.length,
+    name: avgDeploymentFrequency.name,
+    valueList: [
+      {
+        value: `${avgDeploymentFrequency.deploymentFrequency.toFixed(2)}`,
+      },
+    ],
   });
 
   return mappedDeploymentFrequencyValue;

--- a/frontend/src/hooks/reportMapper/devChangeFailureRate.ts
+++ b/frontend/src/hooks/reportMapper/devChangeFailureRate.ts
@@ -1,7 +1,10 @@
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import { DevChangeFailureRateResponse } from '@src/clients/report/dto/response';
 
-export const devChangeFailureRateMapper = ({ devChangeFailureRateOfPipelines }: DevChangeFailureRateResponse) => {
+export const devChangeFailureRateMapper = ({
+  devChangeFailureRateOfPipelines,
+  avgDevChangeFailureRate,
+}: DevChangeFailureRateResponse) => {
   const mappedDevChangeFailureRateValue: ReportDataWithTwoColumns[] = [];
 
   devChangeFailureRateOfPipelines.map((item, index) => {
@@ -16,5 +19,16 @@ export const devChangeFailureRateMapper = ({ devChangeFailureRateOfPipelines }: 
     };
     mappedDevChangeFailureRateValue.push(devChangeFailureRateValue);
   });
+
+  mappedDevChangeFailureRateValue.push({
+    id: mappedDevChangeFailureRateValue.length,
+    name: avgDevChangeFailureRate.name,
+    valueList: [
+      {
+        value: `${(avgDevChangeFailureRate.failureRate * 100).toFixed(2)}`,
+      },
+    ],
+  });
+
   return mappedDevChangeFailureRateValue;
 };

--- a/frontend/src/hooks/reportMapper/devMeanTimeToRecovery.ts
+++ b/frontend/src/hooks/reportMapper/devMeanTimeToRecovery.ts
@@ -1,7 +1,10 @@
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import { DevMeanTimeToRecoveryResponse } from '@src/clients/report/dto/response';
 
-export const devMeanTimeToRecoveryMapper = ({ devMeanTimeToRecoveryOfPipelines }: DevMeanTimeToRecoveryResponse) => {
+export const devMeanTimeToRecoveryMapper = ({
+  devMeanTimeToRecoveryOfPipelines,
+  avgDevMeanTimeToRecovery,
+}: DevMeanTimeToRecoveryResponse) => {
   const minutesPerHour = 60;
   const milliscondMinute = 60000;
   const formatDuration = (duration: number) => {
@@ -22,6 +25,16 @@ export const devMeanTimeToRecoveryMapper = ({ devMeanTimeToRecoveryOfPipelines }
       ],
     };
     mappedDevMeanTimeToRecoveryValue.push(devMeanTimeToRecoveryValue);
+  });
+
+  mappedDevMeanTimeToRecoveryValue.push({
+    id: mappedDevMeanTimeToRecoveryValue.length,
+    name: avgDevMeanTimeToRecovery.name,
+    valueList: [
+      {
+        value: `${formatDuration(avgDevMeanTimeToRecovery.timeToRecovery)}`,
+      },
+    ],
   });
 
   return mappedDevMeanTimeToRecoveryValue;

--- a/frontend/src/utils/util.ts
+++ b/frontend/src/utils/util.ts
@@ -267,7 +267,7 @@ export const convertNumberToPercent = (num: number): string => {
 };
 
 export const percentageFormatter = (showPercentage = true) => {
-  return (value: number) => value + (showPercentage ? '%' : '');
+  return (value: unknown) => value + (showPercentage ? '%' : '');
 };
 export const valueFormatter = (value: number) => {
   if (isNaN(value)) {


### PR DESCRIPTION
## Summary

fix the bug when selecting multiple pipeline the doar chart show error.

## Before

such as `pr lead time`

In the list, the average is the below picture:

<img width="1707" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/61cfa15b-9c44-4fcd-a204-3f33483996f2">

but the chart is the below picture:

<img width="649" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/0a5d8353-4b56-44d4-b0a1-03be4a1592b0">

## After

In the list, the average is the below picture:

<img width="1712" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/2cc3a57b-8e98-4a74-8772-eda93ede5a21">

the chart is the below picture:

<img width="642" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/6996616a-9709-4ff1-99c5-a055241415b8">

## Note

_Null_
