### PR TITLE
ADM-960 [frontend]: fix the rework loading bug

### DIFF
--- a/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
@@ -277,9 +277,9 @@ export const BoardMetricsChart = ({ data, dateRanges, metrics }: BoardMetricsCha
     reworkList?.length === dateRanges.length &&
     reworkList?.every(
       (values) =>
-        Number.isFinite(values?.totalReworkTimes) &&
-        Number.isFinite(values?.totalReworkCards) &&
-        Number.isFinite(values?.reworkCardsRatio),
+        Number.isNaN(values?.totalReworkTimes) &&
+        Number.isNaN(values?.totalReworkCards) &&
+        Number.isNaN(values?.reworkCardsRatio),
     );
 
   useEffect(() => {

--- a/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
@@ -277,9 +277,9 @@ export const BoardMetricsChart = ({ data, dateRanges, metrics }: BoardMetricsCha
     reworkList?.length === dateRanges.length &&
     reworkList?.every(
       (values) =>
-        Number.isNaN(values?.totalReworkTimes) &&
-        Number.isNaN(values?.totalReworkCards) &&
-        Number.isNaN(values?.reworkCardsRatio),
+        !Number.isNaN(values?.totalReworkTimes) &&
+        !Number.isNaN(values?.totalReworkCards) &&
+        !Number.isNaN(values?.reworkCardsRatio),
     );
 
   useEffect(() => {

--- a/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
+++ b/frontend/src/containers/ReportStep/BoardMetricsChart/index.tsx
@@ -275,7 +275,12 @@ export const BoardMetricsChart = ({ data, dateRanges, metrics }: BoardMetricsCha
   const reworkList = mappedData?.map((values) => values.rework).filter((value) => value);
   const isReworkFinished =
     reworkList?.length === dateRanges.length &&
-    reworkList?.every((values) => values?.totalReworkTimes && values.totalReworkCards && values.reworkCardsRatio);
+    reworkList?.every(
+      (values) =>
+        Number.isFinite(values?.totalReworkTimes) &&
+        Number.isFinite(values?.totalReworkCards) &&
+        Number.isFinite(values?.reworkCardsRatio),
+    );
 
   useEffect(() => {
     showChart(velocity.current, isVelocityFinished, velocityDataOption);

--- a/frontend/src/containers/ReportStep/ChartAndTitleWrapper/index.tsx
+++ b/frontend/src/containers/ReportStep/ChartAndTitleWrapper/index.tsx
@@ -78,7 +78,7 @@ const ChartAndTitleWrapper = forwardRef(
         )}
         <ChartTitle>
           {trendInfo.type}
-          {trendInfo.trendNumber !== undefined && (
+          {trendInfo.trendNumber !== undefined && !isLoading && (
             <Tooltip title={tipContent} arrow>
               <TrendContainer
                 color={TREND_COLOR_MAP[trendInfo.trendType!]}


### PR DESCRIPTION
## Summary

fix the rework loading bug, and hide the trend icon when data don't load completely.

## Before

<img width="831" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/5962cfb5-fba9-4e94-8bc2-51ec09ee7d32">

## After

<img width="1241" alt="image" src="https://github.com/thoughtworks/HeartBeat/assets/147299494/da0562f1-82a0-45f0-be9e-33a641ebeecc">

## Note

_Null_
