### PR TITLE
ADM-986 [frontend]: fix the bug that in the board details in the share page we don't find the classification data

### DIFF
--- a/frontend/__tests__/containers/ReportStep/ReportDetail/board.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportDetail/board.test.tsx
@@ -27,7 +27,7 @@ describe('board', () => {
 
     render(
       <Provider store={setupStore()}>
-        <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+        <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
       </Provider>,
     );
 
@@ -46,7 +46,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -63,7 +63,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -83,7 +83,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -100,7 +100,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -123,7 +123,7 @@ describe('board', () => {
 
       render(
         <Provider store={store}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Classification', 'Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -140,7 +140,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -151,12 +151,15 @@ describe('board', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         classification: null,
       });
-      const store = setupStore();
-      store.dispatch(updateMetrics([REQUIRED_DATA_LIST[3]]));
 
       render(
-        <Provider store={store}>
-          <BoardDetail data={data} onBack={() => 'back'} errorMessage={'Data loading failed'} />
+        <Provider store={setupStore()}>
+          <BoardDetail
+            metrics={['Classification']}
+            data={data}
+            onBack={() => 'back'}
+            errorMessage={'Data loading failed'}
+          />
         </Provider>,
       );
 
@@ -181,12 +184,15 @@ describe('board', () => {
         { id: 2, name: 'name3', valuesList: [{ name: 'test3', value: 3 }] },
       ],
     });
-    const store = setupStore();
-    store.dispatch(updateMetrics(REQUIRED_DATA_LIST));
 
     render(
-      <Provider store={store}>
-        <BoardDetail data={data} onBack={() => 'back'} errorMessage={''} />
+      <Provider store={setupStore()}>
+        <BoardDetail
+          metrics={['Velocity', 'Classification', 'Cycle Time', 'Rework times']}
+          data={data}
+          onBack={() => 'back'}
+          errorMessage={''}
+        />
       </Provider>,
     );
 

--- a/frontend/__tests__/containers/ReportStep/ReportDetail/board.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportDetail/board.test.tsx
@@ -27,7 +27,7 @@ describe('board', () => {
 
     render(
       <Provider store={setupStore()}>
-        <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
+        <BoardDetail isShowBack={true} metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
       </Provider>,
     );
 
@@ -46,7 +46,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail isShowBack={true} metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -63,7 +63,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail isShowBack={true} metrics={['Velocity']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -83,7 +83,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail isShowBack={true} metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -100,7 +100,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail isShowBack={true} metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
         </Provider>,
       );
 
@@ -123,7 +123,13 @@ describe('board', () => {
 
       render(
         <Provider store={store}>
-          <BoardDetail metrics={['Classification', 'Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail
+            isShowBack={true}
+            metrics={['Classification', 'Cycle Time']}
+            data={data}
+            onBack={() => 'back'}
+            errorMessage={''}
+          />
         </Provider>,
       );
 
@@ -140,7 +146,7 @@ describe('board', () => {
 
       render(
         <Provider store={setupStore()}>
-          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} />
+          <BoardDetail metrics={['Cycle Time']} data={data} onBack={() => 'back'} errorMessage={''} isShowBack={true} />
         </Provider>,
       );
 
@@ -159,6 +165,7 @@ describe('board', () => {
             data={data}
             onBack={() => 'back'}
             errorMessage={'Data loading failed'}
+            isShowBack={false}
           />
         </Provider>,
       );
@@ -191,6 +198,7 @@ describe('board', () => {
           metrics={['Velocity', 'Classification', 'Cycle Time', 'Rework times']}
           data={data}
           onBack={() => 'back'}
+          isShowBack={true}
           errorMessage={''}
         />
       </Provider>,

--- a/frontend/__tests__/containers/ReportStep/ReportDetail/dora.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportDetail/dora.test.tsx
@@ -12,7 +12,7 @@ describe('DoraDetail', () => {
 
   it('should render a back link', () => {
     (reportMapper as jest.Mock).mockReturnValue({});
-    render(<DoraDetail data={data} onBack={jest.fn()} />);
+    render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
     expect(screen.getByTestId('ArrowBackIcon')).toBeInTheDocument();
     expect(screen.getByText('Back')).toBeInTheDocument();
   });
@@ -22,7 +22,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         deploymentFrequencyList: [{ id: 0, name: 'name1', valueList: [{ value: 1 }] }],
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       const deploymentFrequencyTable = screen.getByLabelText('Deployment Frequency');
       expect(screen.getByText('Deployment Frequency')).toBeInTheDocument();
       expect(deploymentFrequencyTable).toBeInTheDocument();
@@ -33,7 +33,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         deploymentFrequencyList: null,
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       expect(screen.queryAllByText('Deployment Frequency').length).toEqual(0);
     });
   });
@@ -43,7 +43,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         leadTimeForChangesList: [{ id: 0, name: 'name1', valuesList: [{ name: 'test1', value: 1 }] }],
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       const leadTimeForChangesTable = screen.getByTestId('Lead Time For Changes');
       expect(screen.getByText('Lead Time For Changes')).toBeInTheDocument();
       expect(leadTimeForChangesTable).toBeInTheDocument();
@@ -54,7 +54,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         leadTimeForChangesList: null,
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       expect(screen.queryAllByText('Lead Time For Changes').length).toEqual(0);
     });
   });
@@ -64,7 +64,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         devChangeFailureRateList: [{ id: 0, name: 'name1', valueList: [{ value: 1 }] }],
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       const devChangeFailureRateTable = screen.getByTestId('Dev Change Failure Rate');
       expect(screen.getByText('Dev Change Failure Rate')).toBeInTheDocument();
       expect(devChangeFailureRateTable).toBeInTheDocument();
@@ -75,7 +75,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         devChangeFailureRateList: null,
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       expect(screen.queryAllByText('Dev Change Failure Rate').length).toEqual(0);
     });
   });
@@ -85,7 +85,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         devMeanTimeToRecoveryList: [{ id: 0, name: 'name1', valueList: [{ value: 1 }] }],
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       const devMeanTimeToRecoveryTable = screen.getByTestId('Dev Mean Time To Recovery');
       expect(screen.getByText('Dev Mean Time To Recovery')).toBeInTheDocument();
       expect(devMeanTimeToRecoveryTable).toBeInTheDocument();
@@ -96,7 +96,7 @@ describe('DoraDetail', () => {
       (reportMapper as jest.Mock).mockReturnValue({
         devMeanTimeToRecoveryList: null,
       });
-      render(<DoraDetail data={data} onBack={jest.fn()} />);
+      render(<DoraDetail data={data} onBack={jest.fn()} isShowBack={true} />);
       expect(screen.queryAllByText('Dev Mean Time To Recovery').length).toEqual(0);
     });
   });

--- a/frontend/__tests__/containers/ReportStep/ReportDetail/withBack.test.tsx
+++ b/frontend/__tests__/containers/ReportStep/ReportDetail/withBack.test.tsx
@@ -9,19 +9,19 @@ describe('withGoBack', () => {
 
   it('should render a link with back', () => {
     const Component = withGoBack(() => <div>{'test1'}</div>);
-    render(<Component onBack={onBack} />);
+    render(<Component onBack={onBack} isShowBack={true} />);
     expect(screen.getByText('Back')).toBeInTheDocument();
   });
 
   it('should render the icon', () => {
     const Component = withGoBack(() => <div>{'test2'}</div>);
-    render(<Component onBack={onBack} />);
+    render(<Component onBack={onBack} isShowBack={true} />);
     expect(screen.getByTestId('ArrowBackIcon')).toBeInTheDocument();
   });
 
   it('should call onBack when the back is clicked', () => {
     const Component = withGoBack(() => <div>{'test3'}</div>);
-    render(<Component onBack={onBack} />);
+    render(<Component onBack={onBack} isShowBack={true} />);
     fireEvent.click(screen.getByText('Back'));
     expect(onBack).toBeCalled();
   });

--- a/frontend/src/containers/ReportStep/ReportContent/index.tsx
+++ b/frontend/src/containers/ReportStep/ReportContent/index.tsx
@@ -346,7 +346,7 @@ const ReportContent = (props: ReportContentProps) => {
   );
 
   const showBoardDetail = (data?: ReportResponseDTO) => (
-    <BoardDetail onBack={() => handleBack()} data={data} errorMessage={getErrorMessage4Board()} />
+    <BoardDetail metrics={metrics} onBack={() => handleBack()} data={data} errorMessage={getErrorMessage4Board()} />
   );
   const showDoraDetail = (data: ReportResponseDTO) => <DoraDetail onBack={() => backToSummaryPage()} data={data} />;
 

--- a/frontend/src/containers/ReportStep/ReportContent/index.tsx
+++ b/frontend/src/containers/ReportStep/ReportContent/index.tsx
@@ -60,6 +60,7 @@ export interface ReportContentProps {
   handleSave?: () => void;
   reportId?: number;
   hideButtons?: boolean;
+  isSharePage: boolean;
 }
 
 const timeoutNotificationMessages = {
@@ -84,6 +85,7 @@ const ReportContent = (props: ReportContentProps) => {
     handleSave,
     reportId,
     hideButtons = false,
+    isSharePage,
   } = props;
 
   const dispatch = useAppDispatch();
@@ -345,10 +347,22 @@ const ReportContent = (props: ReportContentProps) => {
     <BoardMetricsChart data={data} dateRanges={allDateRanges} metrics={metrics} />
   );
 
-  const showBoardDetail = (data?: ReportResponseDTO) => (
-    <BoardDetail metrics={metrics} onBack={() => handleBack()} data={data} errorMessage={getErrorMessage4Board()} />
+  const showBoardDetail = (data?: ReportResponseDTO) => {
+    const onlySelectClassification = metrics.length === 1 && metrics[0] === RequiredData.Classification;
+
+    return (
+      <BoardDetail
+        isShowBack={!onlySelectClassification || !isSharePage}
+        metrics={metrics}
+        onBack={() => handleBack()}
+        data={data}
+        errorMessage={getErrorMessage4Board()}
+      />
+    );
+  };
+  const showDoraDetail = (data: ReportResponseDTO) => (
+    <DoraDetail isShowBack={true} onBack={() => backToSummaryPage()} data={data} />
   );
-  const showDoraDetail = (data: ReportResponseDTO) => <DoraDetail onBack={() => backToSummaryPage()} data={data} />;
 
   const handleBack = () => {
     setDisplayType(DISPLAY_TYPE.LIST);

--- a/frontend/src/containers/ReportStep/ReportDetail/board.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/board.tsx
@@ -1,5 +1,6 @@
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import ReportForThreeColumns from '@src/components/Common/ReportForThreeColumns';
+import { DetailContainer } from '@src/containers/ReportStep/ReportDetail/style';
 import { MESSAGE, MetricsTitle, RequiredData } from '@src/constants/resources';
 import { addNotification } from '@src/context/notification/NotificationSlice';
 import ReportForTwoColumns from '@src/components/Common/ReportForTwoColumns';
@@ -38,7 +39,7 @@ export const BoardDetail = withGoBack(({ data, errorMessage, metrics }: Property
   }, [dispatch, onlySelectClassification, errorMessage]);
 
   return (
-    <div style={{ margin: '2.25rem 0 0 0' }}>
+    <DetailContainer>
       {showSectionWith2Columns(MetricsTitle.Velocity, mappedData?.velocityList)}
       {showSectionWith2Columns(MetricsTitle.CycleTime, mappedData?.cycleTimeList)}
       {metrics.includes(RequiredData.Classification) && (
@@ -51,6 +52,6 @@ export const BoardDetail = withGoBack(({ data, errorMessage, metrics }: Property
         />
       )}
       {showSectionWith2Columns(MetricsTitle.Rework, mappedData?.reworkList)}
-    </div>
+    </DetailContainer>
   );
 });

--- a/frontend/src/containers/ReportStep/ReportDetail/board.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/board.tsx
@@ -15,6 +15,7 @@ interface Property {
   onBack: () => void;
   errorMessage: string;
   metrics: string[];
+  isShowBack: boolean;
 }
 
 const showSectionWith2Columns = (title: string, value: Optional<ReportDataWithTwoColumns[]>) =>
@@ -37,7 +38,7 @@ export const BoardDetail = withGoBack(({ data, errorMessage, metrics }: Property
   }, [dispatch, onlySelectClassification, errorMessage]);
 
   return (
-    <>
+    <div style={{ margin: '2.25rem 0 0 0' }}>
       {showSectionWith2Columns(MetricsTitle.Velocity, mappedData?.velocityList)}
       {showSectionWith2Columns(MetricsTitle.CycleTime, mappedData?.cycleTimeList)}
       {metrics.includes(RequiredData.Classification) && (
@@ -50,6 +51,6 @@ export const BoardDetail = withGoBack(({ data, errorMessage, metrics }: Property
         />
       )}
       {showSectionWith2Columns(MetricsTitle.Rework, mappedData?.reworkList)}
-    </>
+    </div>
   );
 });

--- a/frontend/src/containers/ReportStep/ReportDetail/board.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/board.tsx
@@ -1,4 +1,3 @@
-import { isOnlySelectClassification, selectMetrics } from '@src/context/config/configSlice';
 import { ReportDataWithTwoColumns } from '@src/hooks/reportMapper/reportUIDataStructure';
 import ReportForThreeColumns from '@src/components/Common/ReportForThreeColumns';
 import { MESSAGE, MetricsTitle, RequiredData } from '@src/constants/resources';
@@ -8,7 +7,6 @@ import { ReportResponseDTO } from '@src/clients/report/dto/response';
 import { reportMapper } from '@src/hooks/reportMapper/report';
 import { useAppDispatch } from '@src/hooks/useAppDispatch';
 import { Optional } from '@src/utils/types';
-import { useAppSelector } from '@src/hooks';
 import React, { useEffect } from 'react';
 import { withGoBack } from './withBack';
 
@@ -16,15 +14,15 @@ interface Property {
   data: ReportResponseDTO | undefined;
   onBack: () => void;
   errorMessage: string;
+  metrics: string[];
 }
 
 const showSectionWith2Columns = (title: string, value: Optional<ReportDataWithTwoColumns[]>) =>
   value && <ReportForTwoColumns title={title} data={value} />;
 
-export const BoardDetail = withGoBack(({ data, errorMessage }: Property) => {
+export const BoardDetail = withGoBack(({ data, errorMessage, metrics }: Property) => {
   const dispatch = useAppDispatch();
-  const metrics = useAppSelector(selectMetrics);
-  const onlySelectClassification = useAppSelector(isOnlySelectClassification);
+  const onlySelectClassification = metrics.length === 1 && metrics[0] === RequiredData.Classification;
   const mappedData = data && reportMapper(data);
 
   useEffect(() => {

--- a/frontend/src/containers/ReportStep/ReportDetail/dora.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/dora.tsx
@@ -2,6 +2,7 @@ import { ReportDataWithThreeColumns, ReportDataWithTwoColumns } from '@src/hooks
 import { MetricsTitle, PIPELINE_STEP, ReportSuffixUnits, SUBTITLE } from '@src/constants/resources';
 import ReportForDeploymentFrequency from '@src/components/Common/ReportForDeploymentFrequency';
 import ReportForThreeColumns from '@src/components/Common/ReportForThreeColumns';
+import { DetailContainer } from '@src/containers/ReportStep/ReportDetail/style';
 import ReportForTwoColumns from '@src/components/Common/ReportForTwoColumns';
 import { ReportResponseDTO } from '@src/clients/report/dto/response';
 import { reportMapper } from '@src/hooks/reportMapper/report';
@@ -28,7 +29,7 @@ export const DoraDetail = withGoBack(({ data }: Property) => {
   const mappedData = reportMapper(data);
 
   return (
-    <div style={{ margin: '2.25rem 0 0 0' }}>
+    <DetailContainer>
       {showDeploymentSection(
         MetricsTitle.DeploymentFrequency,
         [ReportSuffixUnits.DeploymentsPerDay, ReportSuffixUnits.DeploymentsTimes],
@@ -37,6 +38,6 @@ export const DoraDetail = withGoBack(({ data }: Property) => {
       {showThreeColumnSection(MetricsTitle.LeadTimeForChanges, mappedData.leadTimeForChangesList)}
       {showTwoColumnSection(MetricsTitle.DevChangeFailureRate, mappedData.devChangeFailureRateList)}
       {showTwoColumnSection(MetricsTitle.DevMeanTimeToRecovery, mappedData.devMeanTimeToRecoveryList)}
-    </div>
+    </DetailContainer>
   );
 });

--- a/frontend/src/containers/ReportStep/ReportDetail/dora.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/dora.tsx
@@ -12,6 +12,7 @@ import React from 'react';
 interface Property {
   data: ReportResponseDTO;
   onBack: () => void;
+  isShowBack: boolean;
 }
 
 const showTwoColumnSection = (title: string, value: Optional<ReportDataWithTwoColumns[]>) =>
@@ -27,7 +28,7 @@ export const DoraDetail = withGoBack(({ data }: Property) => {
   const mappedData = reportMapper(data);
 
   return (
-    <>
+    <div style={{ margin: '2.25rem 0 0 0' }}>
       {showDeploymentSection(
         MetricsTitle.DeploymentFrequency,
         [ReportSuffixUnits.DeploymentsPerDay, ReportSuffixUnits.DeploymentsTimes],
@@ -36,6 +37,6 @@ export const DoraDetail = withGoBack(({ data }: Property) => {
       {showThreeColumnSection(MetricsTitle.LeadTimeForChanges, mappedData.leadTimeForChangesList)}
       {showTwoColumnSection(MetricsTitle.DevChangeFailureRate, mappedData.devChangeFailureRateList)}
       {showTwoColumnSection(MetricsTitle.DevMeanTimeToRecovery, mappedData.devMeanTimeToRecoveryList)}
-    </>
+    </div>
   );
 });

--- a/frontend/src/containers/ReportStep/ReportDetail/style.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/style.tsx
@@ -1,0 +1,5 @@
+import { styled } from '@mui/material/styles';
+
+export const DetailContainer = styled('div')({
+  margin: '2.25rem 0 0 0',
+});

--- a/frontend/src/containers/ReportStep/ReportDetail/withBack.tsx
+++ b/frontend/src/containers/ReportStep/ReportDetail/withBack.tsx
@@ -5,6 +5,7 @@ import { theme } from '@src/theme';
 import React from 'react';
 interface Property {
   onBack: () => void;
+  isShowBack: boolean;
 }
 
 const StyledDiv = styled('div')`
@@ -12,7 +13,7 @@ const StyledDiv = styled('div')`
   align-items: center;
   width: max-content;
   z-index: 2;
-  margin: 2.25rem 0;
+  margin: 2.25rem 0 0 0;
   color: ${theme.main.secondColor};
   opacity: 0.65;
   cursor: pointer;
@@ -28,7 +29,7 @@ export const withGoBack =
   <P extends Property>(Child: React.ComponentType<P>) =>
   (prop: P) => (
     <>
-      <StyledDiv onClick={prop.onBack}>
+      <StyledDiv onClick={prop.onBack} style={{ display: prop.isShowBack ? 'inherit' : 'none' }}>
         <StyledArrowBack />
         {BACK}
       </StyledDiv>

--- a/frontend/src/containers/ReportStep/index.tsx
+++ b/frontend/src/containers/ReportStep/index.tsx
@@ -230,6 +230,7 @@ const ReportStep = ({ handleSave }: ReportStepProps) => {
 
   return (
     <ReportContent
+      isSharePage={false}
       metrics={metrics}
       allPipelines={deploymentFrequencySettings.map((it) => `${it.pipelineName}/${it.step}`)}
       dateRanges={dateRanges}

--- a/frontend/src/containers/ShareReport/index.tsx
+++ b/frontend/src/containers/ShareReport/index.tsx
@@ -25,6 +25,7 @@ const ShareReport = () => {
     return (
       <StyledPageContentWrapper>
         <ReportContent
+          isSharePage={true}
           metrics={metrics}
           allPipelines={allPipelines}
           dateRanges={dateRanges}

--- a/frontend/src/context/config/configSlice.ts
+++ b/frontend/src/context/config/configSlice.ts
@@ -236,8 +236,6 @@ export const isSelectBoardMetrics = (state: RootState) =>
   state.config.basic.metrics.some((metric) => BOARD_METRICS.includes(metric));
 export const isSelectDoraMetrics = (state: RootState) =>
   state.config.basic.metrics.some((metric) => DORA_METRICS.includes(metric));
-export const isOnlySelectClassification = (state: RootState) =>
-  state.config.basic.metrics.length === 1 && state.config.basic.metrics[0] === RequiredData.Classification;
 export const selectBoard = (state: RootState) => state.config.board.config;
 export const selectPipelineTool = (state: RootState) => state.config.pipelineTool.config;
 export const selectSourceControl = (state: RootState) => state.config.sourceControl.config;


### PR DESCRIPTION
## Summary

...

## Before

_Description_

<img width="1612" alt="image" src="https://github.com/user-attachments/assets/a9514df1-b25e-41b0-b44c-bee8f953f5bd">

<img width="1695" alt="image" src="https://github.com/user-attachments/assets/7c295359-d0cb-41b7-a4ca-0771622db0d0">

## After

_Description_

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/5dbd8413-e820-4ca1-9217-bc1f818edd53">

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/609cff5e-92a1-42a7-86b3-d4b83bff0679">
## Note

_Null_
